### PR TITLE
v3.0.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0",
+  "version": "3.0.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-30
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.
+
 ## [3.0.0] - 2026-04-30
 
 ### Changed

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-30
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.
+
 ## [3.0.0] - 2026-04-30
 
 Initial release. Companion library to [`@turing-machine-js/library-binary-numbers`](../library-binary-numbers) with the same operations on a 3-symbol alphabet (no `^`/`$` markers, single number per tape, much smaller state graphs).

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-30
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.
+
 ## [3.0.0] - 2026-04-30
 
 ### Added

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-30
+
+### Fixed
+
+- **`graphFormats.ts` — polynomial-time regex (CodeQL `js/polynomial-redos`).** `alphabetsRegex` was `/^%%\s*alphabets:\s*(.+)$/`, where the `\s*` and `(.+)` both match whitespace, letting the engine try N+1 split points on inputs like `"%%alphabets:"` followed by many trailing spaces. Anchored the first captured char as `\S` to remove the ambiguity.
+
+### Added
+
+- **`MachineState` re-export** from `index.ts`. The type was always `export type MachineState = ...` in `classes/TuringMachine.ts`, but the package barrel didn't surface it. Consumers (notably `@post-machine-js/machine`'s `PostMachine` overrides of `run` / `runStepByStep`) can now `import { type MachineState } from '@turing-machine-js/machine'` directly, dropping any local `Generator<infer T>` workaround.
+
+### Changed (internal)
+
+- Removed the unreachable `if (hasCycles) return` guard at the top of `summarizeGraph`'s `visit()` cycle-detection. The recursive call pattern (outer for-loop checks before calling, inner loop checks after each recursive call) ensures `visit()` is never invoked when `hasCycles` is already true. Static analysis confirmed the guard was dead code.
+- Tightened test coverage on `State.ts` and the v3 utilities — overall coverage rose from 95.64% / 88.39% / 95.5% (statements/branches/lines) to 98.39% / 94.01% / 98.34%. New tests cover invalid-input paths in the `State` constructor (string-keyed definitions, non-`State`/`Reference` `nextState`, empty-array commands), the `getSymbol` fallback to `ifOtherSymbol`, the `toGraph` skip of unbound `Reference` transitions, the `fromGraph` cyclic-override-halt error, and the previously-unexercised branches in `splitUnescaped`, `parsePatternString`, `parseMovementLabel`, and `fromMermaid`'s ensureNode update / error paths.
+
 ## [3.0.0] - 2026-04-30
 
 ### Added

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/State.spec.ts
+++ b/packages/machine/src/classes/State.spec.ts
@@ -201,3 +201,92 @@ describe('methods', () => {
     expect(state2.name).toBe(`${state.name}>${haltState.name}`);
   });
 });
+
+describe('State constructor — invalid inputs', () => {
+  const alphabet = new Alphabet(' 01'.split(''));
+  const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+  const {symbol} = tapeBlock;
+
+  test('throws when stateDefinition has string-keyed properties (only symbol keys allowed)', () => {
+    expect(() => new State({foo: {nextState: haltState}} as never))
+      .toThrow(/^invalid state definition/);
+  });
+
+  test('throws when nextState is neither State nor Reference', () => {
+    expect(() => new State({
+      [symbol(['0'])]: {nextState: 'not a state' as never},
+    })).toThrow('invalid nextState');
+  });
+
+  test('throws "invalid command" when Command construction fails (empty array)', () => {
+    // command: [] is an Array, so the constructor takes the `try { new Command([]) }`
+    // branch. Command rejects empty input with "invalid parameter"; the catch
+    // swallows it (exercises the `void error` line), commandLocal remains
+    // the plain [], fails the `instanceof Command` check, and throws.
+    expect(() => new State({
+      [symbol(['0'])]: {command: [] as never, nextState: haltState},
+    })).toThrow('invalid command');
+  });
+});
+
+describe('State.getSymbol — fallback', () => {
+  const alphabet = new Alphabet(' 01'.split(''));
+  const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+  const {symbol} = tapeBlock;
+
+  test('returns ifOtherSymbol when no specific transition matches the head', () => {
+    // State has only a transition for '1'. Tape head is on the blank ' '.
+    // No specific symbol in the map matches → fallback to ifOtherSymbol.
+    const state = new State({
+      [symbol(['1'])]: {nextState: haltState},
+    });
+
+    // Tape default position 0, default symbols → blank ' '. The state's only
+    // key is the symbol(['1']) pattern which does NOT match a blank head.
+    expect(state.getSymbol(tapeBlock)).toBe(ifOtherSymbol);
+  });
+});
+
+describe('State.toGraph — unbound Reference', () => {
+  const alphabet = new Alphabet(' 01'.split(''));
+  const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+  const {symbol} = tapeBlock;
+
+  test('skips a transition whose nextState is an unbound Reference', () => {
+    // An unbound Reference throws when its `.ref` getter is read. State.toGraph
+    // catches that and skips the transition rather than failing the whole walk.
+    const unboundRef = new Reference();
+    const state = new State({
+      [symbol(['0'])]: {nextState: unboundRef},
+      [symbol(['1'])]: {nextState: haltState},
+    });
+
+    const graph = State.toGraph(state, tapeBlock);
+
+    // Only the haltState-bound transition survives; the unbound one is dropped.
+    expect(graph.nodes[state.id].transitions).toHaveLength(1);
+  });
+});
+
+describe('State.fromGraph — cyclic override-halt chain', () => {
+  test('throws when the override-halt graph has a cycle', () => {
+    // Graphs constructed by State.toGraph always have acyclic override chains
+    // (cycles throw at State construction). To exercise the defensive cycle
+    // detection in fromGraph, hand-build a Graph with overrodeHaltStateId
+    // pointing in a loop.
+    // Nodes need at least one transition each — State construction at pass 2
+    // rejects empty stateDefinitions before pass 3's cycle check would run.
+    const dummyTransition = {pattern: '*', command: [{symbol: '·', movement: 'S'}], nextStateId: 0};
+    const graph = {
+      initialId: 1,
+      alphabets: [[' ', '0', '1']],
+      nodes: {
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overrodeHaltStateId: null},
+        1: {id: 1, name: 'a', isHalt: false, transitions: [dummyTransition], overrodeHaltStateId: 2},
+        2: {id: 2, name: 'b', isHalt: false, transitions: [dummyTransition], overrodeHaltStateId: 1},
+      },
+    };
+
+    expect(() => State.fromGraph(graph)).toThrow(/^override-halt cycle at state #/);
+  });
+});

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -5,7 +5,7 @@ export { default as State, haltState, ifOtherSymbol } from './classes/State';
 export { default as Tape } from './classes/Tape';
 export { default as TapeBlock } from './classes/TapeBlock';
 export { default as TapeCommand, movements, symbolCommands } from './classes/TapeCommand';
-export { default as TuringMachine } from './classes/TuringMachine';
+export { default as TuringMachine, type MachineState } from './classes/TuringMachine';
 export { type Graph, type GraphNode, type GraphTransition, type GraphCommand } from './utilities/graph';
 export { toMermaid, fromMermaid } from './utilities/graphFormats';
 export { summarize, summarizeGraph, type GraphSummary } from './utilities/introspection';

--- a/packages/machine/src/utilities/introspection.ts
+++ b/packages/machine/src/utilities/introspection.ts
@@ -95,10 +95,10 @@ export function summarizeGraph(graph: Graph): GraphSummary {
   let hasCycles = false;
 
   const visit = (id: number): void => {
-    if (hasCycles) {
-      return;
-    }
-
+    // No `if (hasCycles) return` guard at function entry: the recursive call
+    // pattern (outer for-loop checks before calling, inner loop checks after
+    // each recursive call) ensures visit() is never invoked when hasCycles
+    // is already true. Static analysis confirmed the guard was unreachable.
     if (color.get(id) === GREY) {
       hasCycles = true;
       return;


### PR DESCRIPTION
Patch release. No new public API.

## Fixed
- **\`graphFormats.ts\` — polynomial-time regex (CodeQL \`js/polynomial-redos\`).** \`alphabetsRegex\` was \`/^%%\s*alphabets:\s*(.+)\$/\`, where \`\s*\` and \`(.+)\` both match whitespace, letting the engine try N+1 split points on inputs like \`"%%alphabets:"\` followed by many trailing spaces. Anchored the first captured char as \`\S\` to remove the ambiguity. Already on master via the v3.0.0 merge PR — this is the first time it ships to npm.

## Added
- **\`MachineState\` re-export** from \`packages/machine/src/index.ts\`. The type was always \`export type MachineState = ...\` in \`classes/TuringMachine.ts\` but the package barrel didn't surface it. Consumers (notably \`@post-machine-js/machine\`'s \`PostMachine\` overrides of \`run\` / \`runStepByStep\`) can now \`import { type MachineState } from '@turing-machine-js/machine'\` directly, dropping any local \`Generator<infer T>\` workaround.

## Changed (internal)
- \`summarizeGraph\` \`visit()\`: removed the unreachable \`if (hasCycles) return\` guard at function entry. Recursive call pattern guarantees \`visit()\` is never invoked with \`hasCycles\` already true.
- New tests covering invalid \`State\` inputs (string-keyed definitions, non-\`State\`/\`Reference\` \`nextState\`, empty-array commands), \`getSymbol\` fallback, \`toGraph\` unbound-\`Reference\` skip, \`fromGraph\` cyclic-override-halt error, and previously-uncovered branches in \`splitUnescaped\`, \`parsePatternString\`, \`parseMovementLabel\`, \`fromMermaid\` ensureNode update / error paths. Coverage rose 95.64/88.39/95.5 → 98.39/94.01/98.34 (stmts/branches/lines).

## Lockstep
\`builder\`, \`library-binary-numbers\`, and \`library-binary-numbers-bare\` bumped to 3.0.1 alongside; no source or behavior changes in those packages.

## Test plan
- [x] \`npm run build\` clean (after \`npm ci\` to refresh local deps)
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 36 suites / 499 tests pass
- [x] \`npm run test:coverage\` — 98.39% statements / 94.01% branches / 98.34% lines
- [ ] CI re-runs all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)