### PR TITLE
v3.0.2 — Tape constructor normalises viewportWidth (#95)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.1",
+  "version": "3.0.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14020,7 +14020,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -14031,7 +14031,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -14042,7 +14042,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -14053,7 +14053,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-05-04
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.2. No source or behavior changes in this package.
+
 ## [3.0.1] - 2026-04-30
 
 Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-05-04
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.2. No source or behavior changes in this package.
+
 ## [3.0.1] - 2026-04-30
 
 Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-05-04
+
+Released in lockstep with `@turing-machine-js/machine` 3.0.2. No source or behavior changes in this package.
+
 ## [3.0.1] - 2026-04-30
 
 Released in lockstep with `@turing-machine-js/machine` 3.0.1. No source or behavior changes in this package.

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-05-04
+
+### Fixed
+
+- **`Tape` constructor now normalises and validates `viewportWidth`** ([#95](https://github.com/mellonis/turing-machine-js/issues/95)). The constructor stored `viewportWidth` raw — the setter padded `#symbols` via `normalise()` and validated `>= 1` / bumped even values to odd, but the constructor did neither. As a result, `new Tape({ alphabet, symbols: ['a','b','a','b'], viewportWidth: 23 }).viewport.length` was `4` instead of `23`, and `viewportWidth: 0` or `viewportWidth: 4` silently produced an invalid tape. The constructor now defers to the setter, so a single source of truth handles validation + normalisation.
+
+### Changed (observable)
+
+- A constructor call with an out-of-range `position` (e.g. `position: 5` with `symbols: ['x']`) now normalises at construction — the symbol array is padded with blanks so `position` lands inside the viewport. Previously the tape was left in a malformed state until the first head movement triggered `normalise()`. Strictly a fix, but observable if user code inspected `.symbols.length` immediately after construction.
+
 ## [3.0.1] - 2026-04-30
 
 ### Fixed

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/Tape.spec.ts
+++ b/packages/machine/src/classes/Tape.spec.ts
@@ -49,6 +49,44 @@ describe('Tape constructor', () => {
     })
       .toThrow('symbolList contains invalid symbol');
   });
+
+  test('viewportWidth normalises and pads symbols (issue #95)', () => {
+    const alphabet = new Alphabet(['␣', 'a', 'b']);
+    const tape = new Tape({
+      alphabet,
+      symbols: ['a', 'b', 'a', 'b'],
+      position: 0,
+      viewportWidth: 23,
+    });
+
+    expect(tape.viewportWidth).toBe(23);
+    expect(tape.viewport.length).toBe(23);
+  });
+
+  test('viewportWidth default leaves a single-cell viewport', () => {
+    const alphabet = new Alphabet(['0', '1']);
+    const tape = new Tape({ alphabet });
+
+    expect(tape.viewportWidth).toBe(1);
+    expect(tape.viewport.length).toBe(1);
+  });
+
+  test('even viewportWidth is bumped to the next odd value', () => {
+    const alphabet = new Alphabet(['0', '1']);
+    const tape = new Tape({ alphabet, viewportWidth: 4 });
+
+    expect(tape.viewportWidth).toBe(5);
+    expect(tape.viewport.length).toBe(5);
+  });
+
+  test('viewportWidth < 1 throws from the constructor', () => {
+    const alphabet = new Alphabet(['0', '1']);
+
+    expect(() => new Tape({ alphabet, viewportWidth: 0 }))
+      .toThrow('Invalid viewportWidth');
+    expect(() => new Tape({ alphabet, viewportWidth: -1 }))
+      .toThrow('Invalid viewportWidth');
+  });
 });
 
 describe('Tape properties', () => {

--- a/packages/machine/src/classes/Tape.ts
+++ b/packages/machine/src/classes/Tape.ts
@@ -20,7 +20,7 @@ export default class Tape {
 
     this.#alphabet = new Alphabet(alphabet);
     this.#position = position;
-    this.#viewportWidth = viewportWidth;
+    this.#viewportWidth = 1;
 
     const symbolsCopy = Array.from(symbols);
 
@@ -29,6 +29,8 @@ export default class Tape {
     }
 
     this.#symbols = symbolsCopy.map((symbol) => this.#alphabet.index(symbol));
+
+    this.viewportWidth = viewportWidth;
   }
 
   get alphabet() {


### PR DESCRIPTION
## Summary

- Fix [#95](https://github.com/mellonis/turing-machine-js/issues/95): `Tape` constructor now defers to the `viewportWidth` setter, so a fresh tape gets the same validation (`>= 1`, even-bump-to-odd) and `normalise()` padding as one whose `viewportWidth` is set after construction.
- Lockstep 3.0.1 → 3.0.2 across all four packages, matching the v3.0.1 release shape.

## Why

Pre-fix, `new Tape({ alphabet, symbols: ['a','b','a','b'], viewportWidth: 23 }).viewport.length` returned **4** instead of 23 — `#symbols` was never padded — and `viewportWidth: 0` / `viewportWidth: 4` silently produced an invalid tape because the constructor skipped the setter's input validation. `machines-demo`'s `_buildMirrorMachine` carried a workaround (set via the setter post-construction); that workaround can be removed once this lands.

## Observable behaviour change

A constructor call with an out-of-range `position` (e.g. `position: 5` with `symbols: ['x']`) now normalises at construction — `#symbols` is padded with blanks so `position` sits inside the viewport. Previously the tape was malformed until the first head movement triggered `normalise()`. Strictly a fix, but observable if user code inspected `.symbols.length` immediately after construction.

## Test plan

- [x] `npx jest packages/machine/src/classes/Tape.spec.ts` — passes (4 new tests covering the issue repro + validation paths)
- [x] `npm test` — 507 passed (full monorepo)
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)