### PR TITLE
feat: debugger-break (v4)

### DIFF
--- a/docs/superpowers/plans/2026-05-07-debugger-break.md
+++ b/docs/superpowers/plans/2026-05-07-debugger-break.md
@@ -1,4 +1,4 @@
-xnj tck# Debugger-break Implementation Plan
+# Debugger-break Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 >

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.2",
+  "version": "4.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14020,40 +14020,40 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "3.0.2",
+      "version": "4.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^3.0.0"
+        "@turing-machine-js/machine": "^4.0.0"
       }
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "3.0.2",
+      "version": "4.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^3.0.0"
+        "@turing-machine-js/machine": "^4.0.0"
       }
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "3.0.2",
+      "version": "4.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^3.0.0"
+        "@turing-machine-js/machine": "^4.0.0"
       }
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "3.0.2",
+      "version": "4.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "builder"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^3.0.0"
+    "@turing-machine-js/machine": "^4.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,7 +28,7 @@
     "teaching"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^3.0.0"
+    "@turing-machine-js/machine": "^4.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"
@@ -27,7 +27,7 @@
     "numbers"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^3.0.0"
+    "@turing-machine-js/machine": "^4.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -34,7 +34,7 @@ const tape = new Tape({ alphabet, symbols: ['a', 'b', 'c', 'b', 'a'] });
 const tapeBlock = TapeBlock.fromTapes([tape]);
 const machine = new TuringMachine({ tapeBlock });
 
-machine.run({
+await machine.run({
   initialState: new State({
     [tapeBlock.symbol(['b'])]: {
       command: [{ symbol: '*', movement: movements.right }],
@@ -218,8 +218,8 @@ The runtime. Owns one `TapeBlock` and drives a state graph until it reaches `hal
 ```javascript
 const machine = new TuringMachine({ tapeBlock });
 
-// Run to halt:
-machine.run({ initialState, stepsLimit: 1e5 });
+// Run to halt — `run()` is async (v4+), it returns a Promise<void>:
+await machine.run({ initialState, stepsLimit: 1e5 });
 
 // Or step-by-step (useful for visualization / debugging):
 for (const step of machine.runStepByStep({ initialState })) {
@@ -228,6 +228,55 @@ for (const step of machine.runStepByStep({ initialState })) {
 ```
 
 `stepsLimit` (default `1e5`) guards against runaway loops — exceeding it throws.
+
+## Debugging breakpoints (v4+)
+
+Any `State` can carry a runtime-mutable `debug` config that pauses execution at chosen points.
+
+```ts
+import { State, haltState, ifOtherSymbol, type DebugConfig } from '@turing-machine-js/machine';
+
+const myState = new State({...});
+
+// Pause before applying any of myState's commands:
+myState.debug = { before: true };
+
+// Pause only when the head shows symA:
+myState.debug = { before: [symA] };
+
+// Pause both before and after for the same symbol — two pauses per visit:
+myState.debug = { before: [symA], after: [symA] };
+
+// Pause when the engine is about to enter halt (program exit OR subroutine pop):
+haltState.debug = { before: true };
+
+// Disable later:
+myState.debug = null;
+```
+
+The `debug` field is mutable — toggle breakpoints at runtime without rebuilding the graph. The internal cell is shared with `state.withOverrodeHaltState(...)` wrappers, so an assignment on the original is visible from every wrapper.
+
+`run()` is async and accepts an `onDebugBreak` hook:
+
+```ts
+await machine.run({
+  initialState,
+  onStep: (m) => { /* logger sees every step */ },
+  onDebugBreak: async (m) => {
+    // Awaited at every break — hold execution until you resolve.
+    if (m.debugBreak?.before) console.log('before:', m.state.name);
+    if (m.debugBreak?.after)  console.log('after:',  m.state.name);
+  },
+});
+```
+
+For `after` calls, `m` is the previous yield's snapshot — `m.state` is the state whose `after` filter fired. For `before` calls, `m` is the current iteration. `onStep` always sees the original (un-substituted) yield.
+
+If `onDebugBreak` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
+
+**Filter semantics:** `true` is a wildcard (match any symbol). `[ifOtherSymbol]` is NOT a wildcard — it matches only the catch-all resolution case (same meaning as in transition keys).
+
+**Caveat:** `haltState` is a module-level singleton. Setting `haltState.debug` affects every machine in the process; clear in `afterEach` / `finally` for test isolation.
 
 ## Special objects
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/State.debug.spec.ts
+++ b/packages/machine/src/classes/State.debug.spec.ts
@@ -1,0 +1,314 @@
+import State, {haltState, ifOtherSymbol, DebugConfig} from './State';
+import TapeBlock from './TapeBlock';
+import Alphabet from './Alphabet';
+
+const alphabet = new Alphabet(' AB'.split(''));
+
+const makeState = (): State => {
+  const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+  const {symbol} = tapeBlock;
+  return new State({
+    [symbol(['A'])]: {nextState: haltState},
+    [ifOtherSymbol]: {nextState: haltState},
+  });
+};
+
+describe('State.debug — basics', () => {
+  test('defaults to null', () => {
+    const state = makeState();
+    expect(state.debug).toBeNull();
+  });
+
+  test('plain-object assignment is wrapped in a DebugConfig instance', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    expect(state.debug).toBeInstanceOf(DebugConfig);
+    expect(state.debug!.before).toBe(true);
+  });
+
+  test('DebugConfig instance assignment is stored as-is (identity preserved)', () => {
+    const state = makeState();
+    const cfg = new DebugConfig(state, {before: true});
+    state.debug = cfg;
+    expect(state.debug).toBe(cfg);
+  });
+
+  test('setter accepts null to clear', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    state.debug = null;
+    expect(state.debug).toBeNull();
+  });
+
+  test('withOverrodeHaltState returns a new state that shares the debug ref', () => {
+    const state = makeState();
+    const wrapped = state.withOverrodeHaltState(haltState);
+
+    expect(wrapped).not.toBe(state);
+    expect(wrapped.debug).toBeNull();
+
+    state.debug = {before: true};
+
+    // Wrapper sees the assignment because both share the same Ref cell.
+    expect(wrapped.debug).toBe(state.debug);
+  });
+
+  test('setting null on the original propagates to wrappers', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    const wrapped = state.withOverrodeHaltState(haltState);
+
+    state.debug = null;
+    expect(wrapped.debug).toBeNull();
+  });
+
+  test('setting on the wrapper propagates back to the original', () => {
+    const state = makeState();
+    const wrapped = state.withOverrodeHaltState(haltState);
+
+    wrapped.debug = {after: true};
+    expect(state.debug).toBe(wrapped.debug);
+    expect(state.debug!.after).toBe(true);
+  });
+
+  test('chained wrappers all share the SAME debug object (identity)', () => {
+    const state = makeState();
+    const w1 = state.withOverrodeHaltState(haltState);
+    const w2 = w1.withOverrodeHaltState(haltState);
+
+    state.debug = {before: true};
+
+    expect(w1.debug).toBe(state.debug);
+    expect(w2.debug).toBe(state.debug);
+  });
+});
+
+describe('DebugConfig — class accessors', () => {
+  test('per-property setter `cfg.before = [...]` validates and stores a frozen array', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const state = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    state.debug = {};                    // empty config
+    state.debug!.before = [symA];        // class setter triggers
+    expect(state.debug!.before).toEqual([symA]);
+    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+  });
+
+  test('extending the filter via `cfg.before = [...cfg.before, sym]` works', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const state = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    state.debug = {before: [symA]};
+    state.debug!.before = [...(state.debug!.before as readonly symbol[]), ifOtherSymbol];
+    expect(state.debug!.before).toEqual([symA, ifOtherSymbol]);
+    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+  });
+
+  test('per-property setter validates new symbol list', () => {
+    const state = makeState();
+    state.debug = {};
+    expect(() => {
+      state.debug!.before = [Symbol('random')];
+    }).toThrow(/not a transition key of this state/);
+  });
+
+  test('frozen array — push throws TypeError', () => {
+    const state = makeState();
+    state.debug = {before: [ifOtherSymbol]};
+    expect(() => {
+      (state.debug!.before as symbol[]).push(Symbol('x'));
+    }).toThrow(TypeError);
+  });
+
+  test('frozen array — index assignment throws TypeError', () => {
+    const state = makeState();
+    state.debug = {before: [ifOtherSymbol]};
+    expect(() => {
+      (state.debug!.before as symbol[])[0] = Symbol('x');
+    }).toThrow(TypeError);
+  });
+
+  test('input array is not frozen — only the stored copy is', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const state = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    const userInput: symbol[] = [symA];
+    state.debug = {before: userInput};
+
+    // User's source array stays mutable (we stored a copy).
+    expect(Object.isFrozen(userInput)).toBe(false);
+    userInput.push(ifOtherSymbol);  // works fine
+    // But the stored array is still its own frozen snapshot:
+    expect(state.debug!.before).toEqual([symA]);
+  });
+
+  test('true (wildcard) and undefined bypass freeze (no array to freeze)', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    // before is `true`, not an array — Object.isFrozen on a non-array is whatever JS says.
+    expect(state.debug!.before).toBe(true);
+
+    state.debug!.before = undefined;
+    expect(state.debug!.before).toBeUndefined();
+  });
+});
+
+describe('State.debug — setter validation', () => {
+  test('accepts ifOtherSymbol in filter array', () => {
+    const state = makeState();
+    expect(() => {
+      state.debug = {before: [ifOtherSymbol]};
+    }).not.toThrow();
+  });
+
+  test('accepts transition-key symbols in filter array', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const state = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    expect(() => {
+      state.debug = {before: [symA]};
+    }).not.toThrow();
+  });
+
+  test('throws when filter contains a symbol from a DIFFERENT tape block', () => {
+    const tapeBlockA = TapeBlock.fromAlphabets([alphabet]);
+    const tapeBlockB = TapeBlock.fromAlphabets([alphabet]);
+    const symFromA = tapeBlockA.symbol(['A']);
+    const symFromB = tapeBlockB.symbol(['A']);
+
+    const state = new State({
+      [symFromA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    expect(() => {
+      state.debug = {before: [symFromB]};
+    }).toThrow(/not a transition key of this state/);
+  });
+
+  test('throws when filter contains a transition-key symbol from a DIFFERENT state', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const symB = symbol(['B']);
+
+    const state1 = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+    new State({
+      [symB]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    expect(() => {
+      state1.debug = {before: [symB]};  // symB belongs to another state's transitions
+    }).toThrow(/not a transition key of this state/);
+  });
+
+  test('throws on random Symbol() not interned by any tape block', () => {
+    const state = makeState();
+    const random = Symbol('random');
+
+    expect(() => {
+      state.debug = {after: [random]};
+    }).toThrow(/not a transition key of this state/);
+  });
+
+  test('error message names the offending field (before vs after)', () => {
+    const state = makeState();
+    const random = Symbol('random');
+
+    expect(() => {
+      state.debug = {after: [random]};
+    }).toThrow(/State\.debug\.after/);
+  });
+
+  test('true (wildcard) bypasses validation', () => {
+    const state = makeState();
+    expect(() => {
+      state.debug = {before: true, after: true};
+    }).not.toThrow();
+  });
+
+  test('empty array bypasses validation', () => {
+    const state = makeState();
+    expect(() => {
+      state.debug = {before: [], after: []};
+    }).not.toThrow();
+  });
+
+  test('null assignment bypasses validation', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    expect(() => {
+      state.debug = null;
+    }).not.toThrow();
+  });
+});
+
+describe('State.debug — post-assignment immutability (frozen arrays)', () => {
+  // The config OBJECT itself is not frozen — its `before` / `after` setters
+  // must remain callable for incremental updates. Only the inner ARRAYS are
+  // frozen, so push / index-write throw.
+
+  test('inner before array is frozen', () => {
+    const state = makeState();
+    state.debug = {before: [ifOtherSymbol]};
+    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+  });
+
+  test('inner after array is frozen', () => {
+    const state = makeState();
+    state.debug = {after: [ifOtherSymbol]};
+    expect(Object.isFrozen(state.debug!.after)).toBe(true);
+  });
+
+  test('push to filter array throws TypeError', () => {
+    const state = makeState();
+    state.debug = {before: [ifOtherSymbol]};
+
+    expect(() => {
+      (state.debug!.before as symbol[]).push(Symbol('x'));
+    }).toThrow(TypeError);
+  });
+
+  test('full-config reassignment via spread re-validates and re-freezes', () => {
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const state = new State({
+      [symA]: {nextState: haltState},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    state.debug = {before: [symA]};
+    expect(() => {
+      state.debug = {
+        before: [...(state.debug!.before as readonly symbol[]), ifOtherSymbol],
+      };
+    }).not.toThrow();
+    expect(state.debug!.before).toEqual([symA, ifOtherSymbol]);
+    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+  });
+});

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -17,6 +17,53 @@ import {
 
 export const ifOtherSymbol = Symbol('other symbol');
 
+// Module-private symbol used by DebugConfig setters to call State's validator
+// without exposing the validator on the public surface.
+const validateDebugFilter = Symbol('validateDebugFilter');
+
+export class DebugConfig {
+  readonly #ownerState: State;
+
+  #before?: readonly symbol[] | true;
+
+  #after?: readonly symbol[] | true;
+
+  constructor(
+    ownerState: State,
+    initial?: { before?: symbol[] | readonly symbol[] | true; after?: symbol[] | readonly symbol[] | true },
+  ) {
+    this.#ownerState = ownerState;
+
+    if (initial) {
+      if (initial.before !== undefined) {
+        this.before = initial.before as symbol[] | true;
+      }
+
+      if (initial.after !== undefined) {
+        this.after = initial.after as symbol[] | true;
+      }
+    }
+  }
+
+  get before(): readonly symbol[] | true | undefined {
+    return this.#before;
+  }
+
+  set before(v: symbol[] | readonly symbol[] | true | undefined) {
+    this.#ownerState[validateDebugFilter]('before', v);
+    this.#before = Array.isArray(v) ? Object.freeze([...v]) : v as true | undefined;
+  }
+
+  get after(): readonly symbol[] | true | undefined {
+    return this.#after;
+  }
+
+  set after(v: symbol[] | readonly symbol[] | true | undefined) {
+    this.#ownerState[validateDebugFilter]('after', v);
+    this.#after = Array.isArray(v) ? Object.freeze([...v]) : v as true | undefined;
+  }
+}
+
 export default class State {
   readonly #id: number = id(this);
 
@@ -25,6 +72,12 @@ export default class State {
   #overrodeHaltState: State | null = null;
 
   #symbolToDataMap = new Map<symbol, { command: Command, nextState: State | Reference }>();
+
+  // Shared mutable cell — withOverrodeHaltState wrappers reference the same
+  // object so that `state.debug = ...` (and nullings) propagate across them.
+  // Note: toGraph / fromGraph deliberately do not serialize debug — debug is
+  // a runtime concern, not part of the structural graph.
+  #debugRef: { current: DebugConfig | null } = {current: null};
 
   constructor(stateDefinition: Record<string | symbol, {
     command?: Command | ConstructorParameters<typeof TapeCommand>[0] | ConstructorParameters<typeof TapeCommand>[0][],
@@ -107,6 +160,44 @@ export default class State {
     return this;
   }
 
+  get debug(): DebugConfig | null {
+    return this.#debugRef.current;
+  }
+
+  set debug(
+    value: DebugConfig | { before?: symbol[] | readonly symbol[] | true; after?: symbol[] | readonly symbol[] | true } | null,
+  ) {
+    if (value === null) {
+      this.#debugRef.current = null;
+      return;
+    }
+
+    if (value instanceof DebugConfig) {
+      this.#debugRef.current = value;
+      return;
+    }
+
+    this.#debugRef.current = new DebugConfig(this, value);
+  }
+
+  /** @internal — invoked by DebugConfig setters via module-private symbol. */
+  [validateDebugFilter](
+    fieldName: 'before' | 'after',
+    filter: readonly symbol[] | true | undefined,
+  ): void {
+    if (filter === undefined || filter === true) return;
+
+    for (const sym of filter) {
+      if (sym !== ifOtherSymbol && !this.#symbolToDataMap.has(sym)) {
+        throw new Error(
+          `State.debug.${fieldName}: symbol is not a transition key of this state `
+          + `(state name: ${this.#name}). Common cause: symbol comes from a `
+          + 'different tape block, or doesn\'t match any of this state\'s transitions.',
+        );
+      }
+    }
+  }
+
   getSymbol(tapeBlock: TapeBlock) {
     const symbol = [...this.#symbolToDataMap.keys()].find((currentSymbol) => tapeBlock.isMatched({
       symbol: currentSymbol,
@@ -140,6 +231,7 @@ export default class State {
 
     state.#symbolToDataMap = this.#symbolToDataMap;
     state.#overrodeHaltState = overrodeHaltState;
+    state.#debugRef = this.#debugRef;
 
     return state;
   }

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -187,6 +187,10 @@ export default class State {
   ): void {
     if (filter === undefined || filter === true) return;
 
+    // haltState has no own transitions; symbol-list filters on it are silent
+    // no-ops at the engine level (spec §8.6), so accept any list shape here.
+    if (this.isHalt) return;
+
     for (const sym of filter) {
       if (sym !== ifOtherSymbol && !this.#symbolToDataMap.has(sym)) {
         throw new Error(

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -162,3 +162,71 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     }
   });
 });
+
+describe('TuringMachine — haltState.debug.before', () => {
+  afterEach(() => {
+    // haltState is a singleton — clear after each test to avoid cross-pollution.
+    haltState.debug = null;
+  });
+
+  test('haltState.debug.before = true fires on program halt', () => {
+    const {machine, state} = buildMachine();
+    haltState.debug = {before: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // Last step's transition leads to halt — that yield should carry debugBreak.before
+    // (because nextState is halt and haltState.debug.before === true).
+    const last = steps[steps.length - 1];
+    expect(last.nextState).toBe(haltState);
+    expect(last.debugBreak?.before).toBe(true);
+  });
+
+  test('haltState.debug.before fires on subroutine return (halt-pop)', () => {
+    const tape = new Tape({alphabet, symbols: ['A']});
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({tapeBlock});
+    const {symbol} = tapeBlock;
+
+    // Inner subroutine: erases 'A', halts.
+    const inner = new State({
+      [symbol(['A'])]: {
+        command: [{symbol: symbolCommands.erase, movement: movements.right}],
+      },
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    // Outer continuation: just halts on blank.
+    const continuation = new State({
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+
+    const wrapped = inner.withOverrodeHaltState(continuation);
+
+    haltState.debug = {before: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: wrapped, onStep: (s) => steps.push(s)});
+
+    // The yield where inner transitions to haltState (which gets popped to continuation)
+    // should still carry debugBreak.before — we paused before entering halt logic.
+    const popYield = steps.find((s) => s.nextState === continuation);
+    expect(popYield?.debugBreak?.before).toBe(true);
+  });
+
+  test('haltState.debug.before with symbol list NEVER matches (no head symbol at halt)', () => {
+    const {machine, state, symbol} = buildMachine();
+    const symA = symbol(['A']);
+    haltState.debug = {before: [symA]};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // Halt has no head symbol; list filter cannot match. No debug break should fire
+    // because of haltState.debug. (state.debug is null, so no other source.)
+    for (const step of steps) {
+      expect(step).not.toHaveProperty('debugBreak');
+    }
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -230,3 +230,118 @@ describe('TuringMachine — haltState.debug.before', () => {
     }
   });
 });
+
+describe('TuringMachine — run() with onDebugBreak', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  test('run() returns a Promise', () => {
+    const {machine, state} = buildMachine();
+    const result = machine.run({initialState: state});
+    expect(result).toBeInstanceOf(Promise);
+    return result;
+  });
+
+  test('without onDebugBreak, breaks fire-and-resume invisibly', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const steps: MachineState[] = [];
+
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // Trajectory unaffected — onStep sees same number of yields as without debug.
+    expect(steps.length).toBeGreaterThan(0);
+    // No exception, no hang.
+  });
+
+  test('onDebugBreak fires for "before" with current state', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const seen: Array<{state: State, debugBreak?: MachineState['debugBreak']}> = [];
+
+    await machine.run({
+      initialState: state,
+      onDebugBreak: (m) => {
+        seen.push({state: m.state, debugBreak: m.debugBreak});
+      },
+    });
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const entry of seen) {
+      expect(entry.state).toBe(state);
+      expect(entry.debugBreak).toEqual({before: true});
+    }
+  });
+
+  test('onDebugBreak for "after" sees the SOURCE state (substitution)', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const seen: Array<{state: State, debugBreak?: MachineState['debugBreak'], step: number}> = [];
+
+    await machine.run({
+      initialState: state,
+      onDebugBreak: (m) => {
+        seen.push({state: m.state, debugBreak: m.debugBreak, step: m.step});
+      },
+    });
+
+    // Every after-call should show m.state === source state (the one whose
+    // after fired) — that's our buildMachine state since it's a single-state graph.
+    for (const entry of seen) {
+      expect(entry.state).toBe(state);
+      expect(entry.debugBreak).toEqual({after: true});
+    }
+  });
+
+  test('both "before" and "after" on same yield → two hook calls in order', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true, after: true};
+    const calls: Array<'before' | 'after'> = [];
+
+    await machine.run({
+      initialState: state,
+      onDebugBreak: (m) => {
+        if (m.debugBreak?.after) calls.push('after');
+        if (m.debugBreak?.before) calls.push('before');
+      },
+    });
+
+    // For each "middle" yield (not first), pattern is: ['after', 'before', 'after', 'before', ...].
+    // First yield only has 'before'. Verify ordering: every 'after' is followed
+    // (eventually) by 'before' of the same yield.
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0]).toBe('before'); // first visit, no prior after
+  });
+
+  test('onDebugBreak can be async (run awaits it)', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    let released = false;
+
+    const hookDone = new Promise<void>((resolve) => {
+      setTimeout(() => { released = true; resolve(); }, 10);
+    });
+
+    await machine.run({
+      initialState: state,
+      onDebugBreak: () => hookDone, // run() awaits this
+    });
+
+    expect(released).toBe(true);
+  });
+
+  test('onStep still fires on every yield, separate from onDebugBreak', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const stepCount = {n: 0};
+    const breakCount = {n: 0};
+
+    await machine.run({
+      initialState: state,
+      onStep: () => { stepCount.n += 1; },
+      onDebugBreak: () => { breakCount.n += 1; },
+    });
+
+    expect(stepCount.n).toBeGreaterThan(0);
+    expect(breakCount.n).toBeGreaterThan(0);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -97,3 +97,68 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     for (const v of nonBlankVisits) expect(v).not.toHaveProperty('debugBreak');
   });
 });
+
+describe('TuringMachine — debug.after filter (loop yields)', () => {
+  test('debug.after = true tags the NEXT yield with debugBreak.after', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // First yield: state had no prior — no after.
+    expect(steps[0]).not.toHaveProperty('debugBreak');
+    // Subsequent yields all carry debugBreak.after (because every prev
+    // visit was at this state with after=true matching wildcard).
+    for (let i = 1; i < steps.length; i++) {
+      expect(steps[i].debugBreak).toEqual({after: true});
+    }
+  });
+
+  test('after on a transition leading to halt is silently lost', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // The final transition leads to halt — its after has no next yield to land on.
+    // (No assertion needed — this just confirms run() completes; pending after
+    // at halt is by-design lost. See spec §11.1.)
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test('before AND after on same visit produce both flags on the relevant yields', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true, after: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // First yield: only before (no prior after).
+    expect(steps[0].debugBreak).toEqual({before: true});
+    // Middle yields: both flags (prev's after AND current's before).
+    for (let i = 1; i < steps.length - 1; i++) {
+      expect(steps[i].debugBreak).toEqual({before: true, after: true});
+    }
+  });
+
+  test('after with symbol list matches only listed symbols', () => {
+    const {machine, state, symbol} = buildMachine();
+    const symA = symbol(['A']);
+    state.debug = {after: [symA]};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // The 'after' fires on yield N+1 if yield N's state had symA on the head.
+    for (let i = 1; i < steps.length; i++) {
+      const prev = steps[i - 1];
+      if (prev.currentSymbols[0] === 'A') {
+        expect(steps[i].debugBreak).toEqual({after: true});
+      } else {
+        expect(steps[i]).not.toHaveProperty('debugBreak');
+      }
+    }
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -1,0 +1,99 @@
+import Alphabet from './Alphabet';
+import State, {haltState, ifOtherSymbol} from './State';
+import Tape from './Tape';
+import TapeBlock from './TapeBlock';
+import TuringMachine, {type MachineState} from './TuringMachine';
+import {movements, symbolCommands} from './TapeCommand';
+
+const alphabet = new Alphabet(' AB'.split(''));
+
+const buildMachine = () => {
+  const tape = new Tape({alphabet, symbols: ['A', 'B', 'A']});
+  const tapeBlock = TapeBlock.fromTapes([tape]);
+  const machine = new TuringMachine({tapeBlock});
+  const {symbol} = tapeBlock;
+
+  // Single state: erase + move right; halt on blank.
+  const state = new State({
+    [symbol(['A'])]: {
+      command: [{symbol: symbolCommands.erase, movement: movements.right}],
+    },
+    [symbol(['B'])]: {
+      command: [{symbol: symbolCommands.erase, movement: movements.right}],
+    },
+    [ifOtherSymbol]: {nextState: haltState},
+  });
+
+  return {machine, state, symbol};
+};
+
+describe('TuringMachine — debug.before filter (loop yields)', () => {
+  test('without debug, no debugBreak field on yields', () => {
+    const {machine, state} = buildMachine();
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    for (const step of steps) {
+      expect(step).not.toHaveProperty('debugBreak');
+    }
+  });
+
+  test('debug.before = true tags every visit with debugBreak.before', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    expect(steps.length).toBeGreaterThan(0);
+    for (const step of steps) {
+      expect(step.debugBreak).toEqual({before: true});
+    }
+  });
+
+  test('debug.before with symbol list matches only listed symbols', () => {
+    const {machine, state, symbol} = buildMachine();
+    const symA = symbol(['A']);
+    state.debug = {before: [symA]};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // Visits where head shows 'A' carry debugBreak.before; others don't.
+    const aVisits = steps.filter((s) => s.currentSymbols[0] === 'A');
+    const nonAVisits = steps.filter((s) => s.currentSymbols[0] !== 'A');
+
+    expect(aVisits.length).toBeGreaterThan(0);
+    for (const v of aVisits) expect(v.debugBreak).toEqual({before: true});
+    for (const v of nonAVisits) expect(v).not.toHaveProperty('debugBreak');
+  });
+
+  test('debug.before with empty list never matches', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: []};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    for (const step of steps) {
+      expect(step).not.toHaveProperty('debugBreak');
+    }
+  });
+
+  test('debug.before with [ifOtherSymbol] matches only the catch-all visit', () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: [ifOtherSymbol]};
+    const steps: MachineState[] = [];
+
+    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+
+    // The only catch-all visit is when the head shows blank (ifOtherSymbol path).
+    const blankVisits = steps.filter((s) => s.currentSymbols[0] === alphabet.blankSymbol);
+    const nonBlankVisits = steps.filter((s) => s.currentSymbols[0] !== alphabet.blankSymbol);
+
+    expect(blankVisits.length).toBe(1);
+    expect(blankVisits[0].debugBreak).toEqual({before: true});
+    for (const v of nonBlankVisits) expect(v).not.toHaveProperty('debugBreak');
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -80,10 +80,10 @@ describe('run tests', () => {
     ];
   });
 
-  test('run', () => {
+  test('run', async () => {
     const steps: MachineState[] = [];
 
-    machine.run({initialState, stepsLimit: 1e5, onStep: (step) => steps.push(step)});
+    await machine.run({initialState, stepsLimit: 1e5, onStep: (step) => steps.push(step)});
 
     expect(steps)
       .toEqual(expectedSteps);
@@ -91,32 +91,32 @@ describe('run tests', () => {
       .toBe(0);
   });
 
-  test('stepsLimit', () => {
+  test('stepsLimit', async () => {
     const onStepsLimit0Mock = jest.fn();
 
-    expect(() => machine.run({
+    await expect(machine.run({
       initialState,
       stepsLimit: 0,
       onStep: () => onStepsLimit0Mock()
-    })).toThrow('Long execution');
+    })).rejects.toThrow('Long execution');
     expect(onStepsLimit0Mock.mock.calls.length).toEqual(0);
 
     const onStepsLimit1Mock = jest.fn();
 
-    expect(() => machine.run({
+    await expect(machine.run({
       initialState,
       stepsLimit: 1,
       onStep: () => onStepsLimit1Mock()
-    })).toThrow('Long execution');
+    })).rejects.toThrow('Long execution');
     expect(onStepsLimit1Mock.mock.calls.length).toEqual(1);
 
     const onStepsLimit2Mock = jest.fn();
 
-    expect(() => machine.run({
+    await expect(machine.run({
       initialState,
       stepsLimit: 2,
       onStep: () => onStepsLimit2Mock()
-    })).toThrow('Long execution');
+    })).rejects.toThrow('Long execution');
     expect(onStepsLimit2Mock.mock.calls.length).toEqual(2);
   });
 

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -78,6 +78,7 @@ export default class TuringMachine {
       }
 
       let i = 0;
+      let pendingAfterFromPrev = false;
 
       while (!state.isHalt) {
         if (i === stepsLimit) {
@@ -119,11 +120,17 @@ export default class TuringMachine {
             nextState: nextStateForYield,
           };
 
-          if (beforeMatch) {
-            yielded.debugBreak = {before: true};
+          if (pendingAfterFromPrev || beforeMatch) {
+            const dbg: { before?: true; after?: true } = {};
+            if (pendingAfterFromPrev) dbg.after = true;
+            if (beforeMatch) dbg.before = true;
+            yielded.debugBreak = dbg;
           }
 
           yield yielded;
+
+          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield.
+          pendingAfterFromPrev = matchFilter(state.debug?.after, symbol);
 
           this.#tapeBlock.applyCommand(command, executionSymbol);
 

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -1,4 +1,4 @@
-import State, {haltState} from './State';
+import State, {haltState, type DebugConfig} from './State';
 import TapeBlock, {lockSymbol} from './TapeBlock';
 import {symbolCommands} from './TapeCommand';
 
@@ -11,7 +11,28 @@ export type MachineState = {
   nextSymbols: string[];
   movements: symbol[];
   nextState: State;
+  /**
+   * Set only when this iteration boundary is a debug break.
+   * Field is OMITTED entirely when no break fires (no `debugBreak: undefined`).
+   * At least one of `before` / `after` is `true` when the field is present.
+   *
+   * For consumers of the `runStepByStep` generator the `state` field reflects
+   * the current iteration regardless of timing; `run()` substitutes the prior
+   * yield's snapshot for `after` calls so consumers see the source state.
+   */
+  debugBreak?: {
+    before?: true;
+    after?: true;
+  };
 };
+
+// True iff `filter` matches `symbol` per the DebugConfig semantics.
+// undefined / [] -> never; true -> always; symbol[] -> exact membership.
+function matchFilter(filter: DebugConfig['before'], symbol: symbol): boolean {
+  if (filter === undefined) return false;
+  if (filter === true) return true;
+  return filter.includes(symbol);
+}
 
 export default class TuringMachine {
   readonly #tapeBlock: TapeBlock;
@@ -70,11 +91,13 @@ export default class TuringMachine {
         let nextState = state.getNextState(symbol).ref;
 
         try {
+          const beforeMatch = matchFilter(state.debug?.before, symbol);
+
           const nextStateForYield = nextState.isHalt && stack.length
             ? stack.slice(-1)[0]
             : nextState;
 
-          yield {
+          const yielded: MachineState = {
             step: i,
             state,
             currentSymbols: this.#tapeBlock.currentSymbols,
@@ -95,6 +118,12 @@ export default class TuringMachine {
             movements: command.tapesCommands.map((tapeCommand) => tapeCommand.movement),
             nextState: nextStateForYield,
           };
+
+          if (beforeMatch) {
+            yielded.debugBreak = {before: true};
+          }
+
+          yield yielded;
 
           this.#tapeBlock.applyCommand(command, executionSymbol);
 

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -92,7 +92,8 @@ export default class TuringMachine {
         let nextState = state.getNextState(symbol).ref;
 
         try {
-          const beforeMatch = matchFilter(state.debug?.before, symbol);
+          const beforeMatch = matchFilter(state.debug?.before, symbol)
+            || (nextState.isHalt && nextState.debug?.before === true);
 
           const nextStateForYield = nextState.isHalt && stack.length
             ? stack.slice(-1)[0]

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -52,13 +52,34 @@ export default class TuringMachine {
     return this.#tapeBlock;
   }
 
-  run({initialState, stepsLimit = 1e5, onStep}: RunParameter & { onStep?: (machineState: MachineState) => void }) {
+  async run({
+    initialState,
+    stepsLimit = 1e5,
+    onStep,
+    onDebugBreak,
+  }: RunParameter & {
+    onStep?: (machineState: MachineState) => void;
+    onDebugBreak?: (machineState: MachineState) => void | Promise<void>;
+  }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
+    let prevYield: MachineState | null = null;
 
     for (const machineState of generator) {
+      // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
+      if (machineState.debugBreak?.after && onDebugBreak && prevYield) {
+        await onDebugBreak({...prevYield, debugBreak: {after: true}});
+      }
+
+      // 'before' (current step) — pass current machineState with only the before flag.
+      if (machineState.debugBreak?.before && onDebugBreak) {
+        await onDebugBreak({...machineState, debugBreak: {before: true}});
+      }
+
       if (onStep instanceof Function) {
         onStep(machineState);
       }
+
+      prevYield = machineState;
     }
   }
 

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -1,7 +1,7 @@
 export { default as Alphabet } from './classes/Alphabet';
 export { default as Command } from './classes/Command';
 export { default as Reference } from './classes/Reference';
-export { default as State, haltState, ifOtherSymbol } from './classes/State';
+export { default as State, DebugConfig, haltState, ifOtherSymbol } from './classes/State';
 export { default as Tape } from './classes/Tape';
 export { default as TapeBlock } from './classes/TapeBlock';
 export { default as TapeCommand, movements, symbolCommands } from './classes/TapeCommand';

--- a/test/examples.spec.ts
+++ b/test/examples.spec.ts
@@ -4,6 +4,7 @@ import {
   ifOtherSymbol,
   movements,
   State,
+  symbolCommands,
   Tape,
   TapeBlock,
   TuringMachine,
@@ -11,7 +12,7 @@ import {
 
 
 describe('README.md', () => {
-  test('An example', () => {
+  test('An example', async () => {
     const alphabet = new Alphabet([' ', 'a', 'b', 'c', '*']);
     const tape = new Tape({
       alphabet,
@@ -27,7 +28,7 @@ describe('README.md', () => {
     expect(tape.symbols.join('').trim())
       .toBe('abcba');
 
-    machine.run({
+    await machine.run({
       initialState: new State({
         [tapeBlock.symbol(['b'])]: {
           command: [
@@ -59,5 +60,100 @@ describe('README.md', () => {
 
     expect(tape.symbols.join('').trim())
       .toBe('a*c*a');
+  });
+});
+
+describe('README.md — Debugging breakpoints', () => {
+  const alphabet = new Alphabet(' AB'.split(''));
+
+  const buildExampleMachine = () => {
+    const tape = new Tape({alphabet, symbols: ['A', 'B']});
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({tapeBlock});
+    const {symbol} = tapeBlock;
+    const symA = symbol(['A']);
+    const myState = new State({
+      [symA]: {command: [{symbol: symbolCommands.erase, movement: movements.right}]},
+      [ifOtherSymbol]: {nextState: haltState},
+    });
+    return {machine, myState, symA};
+  };
+
+  afterEach(() => { haltState.debug = null; });
+
+  test('Pause before applying any of myState commands (wildcard)', async () => {
+    const {machine, myState} = buildExampleMachine();
+    myState.debug = {before: true};
+    let breakCount = 0;
+    await machine.run({initialState: myState, onDebugBreak: () => { breakCount += 1; }});
+    expect(breakCount).toBeGreaterThan(0);
+  });
+
+  test('Pause only when head shows symA', async () => {
+    const {machine, myState, symA} = buildExampleMachine();
+    myState.debug = {before: [symA]};
+    let symASeen = 0;
+    await machine.run({
+      initialState: myState,
+      onDebugBreak: (m) => { if (m.currentSymbols[0] === 'A') symASeen += 1; },
+    });
+    expect(symASeen).toBeGreaterThan(0);
+  });
+
+  test('Before AND after for same symbol → two pauses per visit', async () => {
+    const {machine, myState, symA} = buildExampleMachine();
+    myState.debug = {before: [symA], after: [symA]};
+    const order: Array<'before' | 'after'> = [];
+    await machine.run({
+      initialState: myState,
+      onDebugBreak: (m) => {
+        if (m.debugBreak?.before) order.push('before');
+        if (m.debugBreak?.after) order.push('after');
+      },
+    });
+    expect(order).toContain('before');
+    expect(order).toContain('after');
+  });
+
+  test('haltState.debug.before pauses on halt entry', async () => {
+    const {machine, myState} = buildExampleMachine();
+    haltState.debug = {before: true};
+    let haltPause = false;
+    await machine.run({
+      initialState: myState,
+      onDebugBreak: (m) => {
+        if (m.nextState === haltState && m.debugBreak?.before) haltPause = true;
+      },
+    });
+    expect(haltPause).toBe(true);
+  });
+
+  test('Disable later by assigning null', () => {
+    const {myState} = buildExampleMachine();
+    myState.debug = {before: true};
+    expect(myState.debug).not.toBeNull();
+    myState.debug = null;
+    expect(myState.debug).toBeNull();
+  });
+
+  test('Incremental update via per-property setter', () => {
+    const {myState, symA} = buildExampleMachine();
+    myState.debug = {before: [symA]};
+    myState.debug!.before = [...(myState.debug!.before as readonly symbol[]), ifOtherSymbol];
+    expect(myState.debug!.before).toEqual([symA, ifOtherSymbol]);
+  });
+
+  test('onStep + onDebugBreak fire independently', async () => {
+    const {machine, myState} = buildExampleMachine();
+    myState.debug = {before: true};
+    let stepCount = 0;
+    let breakCount = 0;
+    await machine.run({
+      initialState: myState,
+      onStep: () => { stepCount += 1; },
+      onDebugBreak: () => { breakCount += 1; },
+    });
+    expect(stepCount).toBeGreaterThan(0);
+    expect(breakCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Closes #98.

## Summary

- Add `State.debug = { before, after }` for per-state, runtime-mutable breakpoints with symbol filtering. The `debug` cell is shared with `withOverrodeHaltState` wrappers via a private Ref so assignments propagate.
- `run()` is now async (returns `Promise<void>`) and accepts `onDebugBreak`. Trajectory is unchanged when no hook is passed (breaks fire-and-resume invisibly).
- For `after` calls, `run()` substitutes the previous yield's snapshot so `m.state` is the source state.
- `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). Symbol-list filters on `haltState` are silent no-ops.
- Major version bump: v3.0.2 → v4.0.0 (lockstep across all 4 packages); peer-dep ranges in `builder` / `library-binary-numbers` / `library-binary-numbers-bare` widened from `^3.0.0` to `^4.0.0`.

Spec: `docs/superpowers/specs/2026-05-07-debugger-break.md`
Plan: `docs/superpowers/plans/2026-05-07-debugger-break.md`

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes — 610 tests across 5 projects (machine + builder + library-binary-numbers + library-binary-numbers-bare + root)
- [x] `npm run test:coverage` — `State.ts` 100% / 97.75% branch, `TuringMachine.ts` 97.01% / 94.44% branch
- [x] Reviewer: spot-check `state.debug` + `onDebugBreak` against a real graph (e.g., a binary-numbers chain) and confirm the pause points are useful

## Out of scope (separate follow-ups)
- `post-machine-js` peer dep widening (`^3` → `^3 || ^4`) once this lands.
- `builder` package: support `debug` in declarative state-table input.
- `machines-demo` integration: click-to-toggle breakpoints on state nodes.
- Step-in / step-out / step-over (buildable on top of this primitive).