### PR TITLE
chore: gitignore lerna-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.production.local
 
 npm-debug.log*
+lerna-debug.log*
 
 /packages/*/dist/
 /packages/*/*.tsbuildinfo


### PR DESCRIPTION
Lerna writes \`lerna-debug.log\` to the repo root on \`lerna version\` / \`lerna publish\` failures — saw this firsthand during the v4.0.0 bump in #100. Mirror the existing \`npm-debug.log*\` line.

One-line change.