### PR TITLE
docs: reflect v4 async run() + state.debug in supporting docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Dependent packages and tests import the bare package name — `import { ... } fr
 
 ### Runtime model (`packages/machine`)
 
-A `TuringMachine` owns one `TapeBlock` (one or more `Tape`s sharing a head step). `machine.run({ initialState })` walks a graph of `State` nodes until it reaches `haltState`.
+A `TuringMachine` owns one `TapeBlock` (one or more `Tape`s sharing a head step). `await machine.run({ initialState })` walks a graph of `State` nodes until it reaches `haltState`. `run()` is `async` (`Promise<void>`) since v4 — see `state.debug` below.
 
 Key shapes that take reading multiple files to grasp:
 
@@ -44,6 +44,8 @@ Key shapes that take reading multiple files to grasp:
 - **`haltState` is identified by `id === 0`** (see `State.isHalt`). The module-level `haltState` is the single sentinel; do not construct another.
 
 - **`TapeBlock` has a `Lock`** that `TuringMachine.run` grabs for the duration of a run, asserting the block isn't being mutated by another machine. Calls to `applyCommand` from outside a run must pass the matching capture symbol.
+
+- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onDebugBreak` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
 
 ### Builder package
 

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -32,7 +32,7 @@ machine.tapeBlock.replaceTape(new Tape({
   symbols: '#011#'.split(''),
 }));
 
-machine.run({ initialState, stepsLimit: 100 });
+await machine.run({ initialState, stepsLimit: 100 });
 // tape now contains: #011#011#  (the input duplicated)
 ```
 

--- a/packages/library-binary-numbers-bare/README.md
+++ b/packages/library-binary-numbers-bare/README.md
@@ -49,7 +49,7 @@ tapeBlock.replaceTape(tape);
 
 const machine = new TuringMachine({ tapeBlock });
 
-machine.run({ initialState: binaryNumbersBare.states.plusOne });
+await machine.run({ initialState: binaryNumbersBare.states.plusOne });
 
 console.log(tape.symbols.join('').trim()); // "110" (binary 6)
 ```

--- a/packages/library-binary-numbers/README.md
+++ b/packages/library-binary-numbers/README.md
@@ -63,7 +63,7 @@ tapeBlock.replaceTape(tape);
 
 const machine = new TuringMachine({ tapeBlock });
 
-machine.run({ initialState: binaryNumbers.states.plusOne });
+await machine.run({ initialState: binaryNumbers.states.plusOne });
 
 console.log(tape.symbols.join('').trim()); // "^110$" (binary 6)
 ```


### PR DESCRIPTION
Documentation cleanup — v4.0.0's async \`run()\` + new \`state.debug\` were documented in \`packages/machine/README.md\` via #100, but the supporting docs (\`CLAUDE.md\`, the builder README, the two binary-number library READMEs) were left at the v3 sync style.

This PR adds \`await\` to every \`machine.run({...})\` example outside the core README, plus a \`state.debug\` bullet in the repo's \`CLAUDE.md\` runtime-model section so future Claude sessions reading project memory have the v4 model.

The two binary-number library READMEs are updated in matching shape per the doc-parity rule in \`CLAUDE.md\`.

No source / test changes — \`npm run lint\` / \`npm test\` should be unaffected.