### PR TITLE
refactor(machine)!: rename onDebugBreak hook to onPause (#110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Key shapes that take reading multiple files to grasp:
 
 - **`TapeBlock` has a `Lock`** that `TuringMachine.run` grabs for the duration of a run, asserting the block isn't being mutated by another machine. Calls to `applyCommand` from outside a run must pass the matching capture symbol.
 
-- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onDebugBreak` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
+- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onPause` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). Renamed from `onDebugBreak` in v5. `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
 
 ### Builder package
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -256,13 +256,13 @@ myState.debug = null;
 
 The `debug` field is mutable — toggle breakpoints at runtime without rebuilding the graph. The internal cell is shared with `state.withOverrodeHaltState(...)` wrappers, so an assignment on the original is visible from every wrapper.
 
-`run()` is async and accepts an `onDebugBreak` hook:
+`run()` is async and accepts an `onPause` hook:
 
 ```ts
 await machine.run({
   initialState,
   onStep: (m) => { /* logger sees every step */ },
-  onDebugBreak: async (m) => {
+  onPause: async (m) => {
     // Awaited at every break — hold execution until you resolve.
     if (m.debugBreak?.before) console.log('before:', m.state.name);
     if (m.debugBreak?.after)  console.log('after:',  m.state.name);
@@ -272,7 +272,7 @@ await machine.run({
 
 For `after` calls, `m` is the previous yield's snapshot — `m.state` is the state whose `after` filter fired. For `before` calls, `m` is the current iteration. `onStep` always sees the original (un-substituted) yield.
 
-If `onDebugBreak` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
+If `onPause` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
 
 **Filter semantics:** `true` is a wildcard (match any symbol). `[ifOtherSymbol]` is NOT a wildcard — it matches only the catch-all resolution case (same meaning as in transition keys).
 

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -231,7 +231,7 @@ describe('TuringMachine — haltState.debug.before', () => {
   });
 });
 
-describe('TuringMachine — run() with onDebugBreak', () => {
+describe('TuringMachine — run() with onPause', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('run() returns a Promise', () => {
@@ -241,7 +241,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     return result;
   });
 
-  test('without onDebugBreak, breaks fire-and-resume invisibly', async () => {
+  test('without onPause, breaks fire-and-resume invisibly', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const steps: MachineState[] = [];
@@ -253,14 +253,14 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     // No exception, no hang.
   });
 
-  test('onDebugBreak fires for "before" with current state', async () => {
+  test('onPause fires for "before" with current state', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const seen: Array<{state: State, debugBreak?: MachineState['debugBreak']}> = [];
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         seen.push({state: m.state, debugBreak: m.debugBreak});
       },
     });
@@ -272,14 +272,14 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     }
   });
 
-  test('onDebugBreak for "after" sees the SOURCE state (substitution)', async () => {
+  test('onPause for "after" sees the SOURCE state (substitution)', async () => {
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const seen: Array<{state: State, debugBreak?: MachineState['debugBreak'], step: number}> = [];
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         seen.push({state: m.state, debugBreak: m.debugBreak, step: m.step});
       },
     });
@@ -299,7 +299,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.debugBreak?.after) calls.push('after');
         if (m.debugBreak?.before) calls.push('before');
       },
@@ -312,7 +312,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     expect(calls[0]).toBe('before'); // first visit, no prior after
   });
 
-  test('onDebugBreak can be async (run awaits it)', async () => {
+  test('onPause can be async (run awaits it)', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     let released = false;
@@ -323,13 +323,13 @@ describe('TuringMachine — run() with onDebugBreak', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: () => hookDone, // run() awaits this
+      onPause: () => hookDone, // run() awaits this
     });
 
     expect(released).toBe(true);
   });
 
-  test('onStep still fires on every yield, separate from onDebugBreak', async () => {
+  test('onStep still fires on every yield, separate from onPause', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const stepCount = {n: 0};
@@ -338,7 +338,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     await machine.run({
       initialState: state,
       onStep: () => { stepCount.n += 1; },
-      onDebugBreak: () => { breakCount.n += 1; },
+      onPause: () => { breakCount.n += 1; },
     });
 
     expect(stepCount.n).toBeGreaterThan(0);
@@ -361,7 +361,7 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
     //   visit 3 head 'A'  → erase+right
     //   visit 4 head blank→ ifOtherSymbol → halt
     // debug.after = true matches every visit. Today only 3 after-fires reach
-    // onDebugBreak (visit 4's after has no anchor yield); v5 must drain it
+    // onPause (visit 4's after has no anchor yield); v5 must drain it
     // and produce 4.
     const {machine, state} = buildMachine();
     state.debug = {after: true};
@@ -369,7 +369,7 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => { if (m.debugBreak?.after) after.push(m); },
+      onPause: (m) => { if (m.debugBreak?.after) after.push(m); },
     });
 
     expect(after.length).toBe(4);

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -56,23 +56,37 @@ export default class TuringMachine {
     initialState,
     stepsLimit = 1e5,
     onStep,
-    onDebugBreak,
+    onPause,
   }: RunParameter & {
+    /**
+     * Sync, ~free hook fired on every iteration. Use for logging/tracing —
+     * the hot loop runs this without a microtask boundary, so it must not
+     * be async.
+     */
     onStep?: (machineState: MachineState) => void;
-    onDebugBreak?: (machineState: MachineState) => void | Promise<void>;
+    /**
+     * Async hook fired only when `state.debug[when]` matches at the current
+     * iteration. The promise is awaited inline, so the consumer can suspend
+     * execution by deferring its resolution. Use for pause-capable inspection
+     * (debugger UIs, conditional breakpoints in tests).
+     *
+     * Renamed from `onDebugBreak` in v5.0.0. The `m.debugBreak` payload field
+     * keeps its name (it describes the engine's reason for pausing).
+     */
+    onPause?: (machineState: MachineState) => void | Promise<void>;
   }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
 
     for (const machineState of generator) {
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
-      if (machineState.debugBreak?.after && onDebugBreak && prevYield) {
-        await onDebugBreak({...prevYield, debugBreak: {after: true}});
+      if (machineState.debugBreak?.after && onPause && prevYield) {
+        await onPause({...prevYield, debugBreak: {after: true}});
       }
 
       // 'before' (current step) — pass current machineState with only the before flag.
-      if (machineState.debugBreak?.before && onDebugBreak) {
-        await onDebugBreak({...machineState, debugBreak: {before: true}});
+      if (machineState.debugBreak?.before && onPause) {
+        await onPause({...machineState, debugBreak: {before: true}});
       }
 
       if (onStep instanceof Function) {

--- a/test/examples.spec.ts
+++ b/test/examples.spec.ts
@@ -85,7 +85,7 @@ describe('README.md — Debugging breakpoints', () => {
     const {machine, myState} = buildExampleMachine();
     myState.debug = {before: true};
     let breakCount = 0;
-    await machine.run({initialState: myState, onDebugBreak: () => { breakCount += 1; }});
+    await machine.run({initialState: myState, onPause: () => { breakCount += 1; }});
     expect(breakCount).toBeGreaterThan(0);
   });
 
@@ -95,7 +95,7 @@ describe('README.md — Debugging breakpoints', () => {
     let symASeen = 0;
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => { if (m.currentSymbols[0] === 'A') symASeen += 1; },
+      onPause: (m) => { if (m.currentSymbols[0] === 'A') symASeen += 1; },
     });
     expect(symASeen).toBeGreaterThan(0);
   });
@@ -106,7 +106,7 @@ describe('README.md — Debugging breakpoints', () => {
     const order: Array<'before' | 'after'> = [];
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.debugBreak?.before) order.push('before');
         if (m.debugBreak?.after) order.push('after');
       },
@@ -121,7 +121,7 @@ describe('README.md — Debugging breakpoints', () => {
     let haltPause = false;
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.nextState === haltState && m.debugBreak?.before) haltPause = true;
       },
     });
@@ -143,7 +143,7 @@ describe('README.md — Debugging breakpoints', () => {
     expect(myState.debug!.before).toEqual([symA, ifOtherSymbol]);
   });
 
-  test('onStep + onDebugBreak fire independently', async () => {
+  test('onStep + onPause fire independently', async () => {
     const {machine, myState} = buildExampleMachine();
     myState.debug = {before: true};
     let stepCount = 0;
@@ -151,7 +151,7 @@ describe('README.md — Debugging breakpoints', () => {
     await machine.run({
       initialState: myState,
       onStep: () => { stepCount += 1; },
-      onDebugBreak: () => { breakCount += 1; },
+      onPause: () => { breakCount += 1; },
     });
     expect(stepCount).toBeGreaterThan(0);
     expect(breakCount).toBeGreaterThan(0);


### PR DESCRIPTION
Resolution of the [#109 RFC](https://github.com/mellonis/turing-machine-js/issues/109). Renames the async pause-capable hook on `TuringMachine.run()`:

- `onDebugBreak` → `onPause`

Hard rename, no deprecation alias. The hook signature, payload shape, and dispatch semantics are unchanged — only the option key on `run()` differs. The `m.debugBreak` payload field keeps its name (it describes the engine's reason for pausing; the hook describes the consumer's action).

JSDoc added on both hooks:
- `onStep` — sync, ~free; for logging/tracing.
- `onPause` — async, can suspend; for pause-capable inspection.

## Files changed

- `packages/machine/src/classes/TuringMachine.ts` — signature + body
- `packages/machine/src/classes/TuringMachine.debug.spec.ts`
- `packages/machine/README.md`
- `test/examples.spec.ts`
- `CLAUDE.md` (workspace memory)

## Not touched (historical record)

- v4.0.0 CHANGELOG entry — documents what shipped at v4.
- `docs/superpowers/specs/2026-05-07-debugger-break.md`
- `docs/superpowers/plans/2026-05-07-debugger-break.md`

## Verification

- `npm test`: 610 passed, 6 failed — the 6 are the 3 #108 expected reds × 2 jest projects (scaffolded in the prior `v5` commit `39b0345`).
- `npm run lint`: clean.
- `npx tsc --build`: clean.

Closes #110.