### PR TITLE
fix(machine)!: halt semantics for after-fire (#108)

### DIFF
--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -185,10 +185,24 @@ export default class State {
     fieldName: 'before' | 'after',
     filter: readonly symbol[] | true | undefined,
   ): void {
-    if (filter === undefined || filter === true) return;
+    if (filter === undefined) return;
 
-    // haltState has no own transitions; symbol-list filters on it are silent
-    // no-ops at the engine level (spec §8.6), so accept any list shape here.
+    // #108 part 2: `.after` on haltState has no semantic anchor — halt is
+    // terminal, so there is no iteration-after-halt for an after-fire to
+    // attach to. Reject any truthy assignment (true OR list) at write time
+    // so misuse surfaces immediately rather than silently no-op'ing.
+    if (this.isHalt && fieldName === 'after') {
+      throw new Error(
+        'haltState.debug.after is not supported: halt is terminal, so there is '
+        + 'no iteration-after-halt for an after-fire to anchor on. Use '
+        + '{ before: true } to pause on halt entry.',
+      );
+    }
+
+    if (filter === true) return;
+
+    // haltState has no own transitions; symbol-list filters on `before` are
+    // silent no-ops at the engine level (spec §8.6), so accept any list shape.
     if (this.isHalt) return;
 
     for (const sym of filter) {

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -115,18 +115,10 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     }
   });
 
-  test('after on a transition leading to halt is silently lost', () => {
-    const {machine, state} = buildMachine();
-    state.debug = {after: true};
-    const steps: MachineState[] = [];
-
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
-
-    // The final transition leads to halt — its after has no next yield to land on.
-    // (No assertion needed — this just confirms run() completes; pending after
-    // at halt is by-design lost. See spec §11.1.)
-    expect(steps.length).toBeGreaterThan(0);
-  });
+  // (Removed in v5 — the "by-design lost" semantics on halting after-fires
+  // was a #108 bug, not a design choice. The new behavior is verified in the
+  // dedicated `halt semantics for after-fire (#108)` describe block below,
+  // which exercises the run()-level drain.)
 
   test('before AND after on same visit produce both flags on the relevant yields', () => {
     const {machine, state} = buildMachine();
@@ -351,7 +343,7 @@ describe('TuringMachine — run() with onPause', () => {
 // land. The "after on a transition leading to halt is silently lost" test in
 // the second describe above (currently labelled by-design) is contradicted by
 // part-1 below and will be updated in lockstep with the fix.
-describe.skip('TuringMachine — halt semantics for after-fire (#108) [skipped on v5 baseline; un-skipped in #108 fix PR]', () => {
+describe('TuringMachine — halt semantics for after-fire (#108)', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('halting iter still fires its after (#108 part 1)', async () => {

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -78,7 +78,14 @@ export default class TuringMachine {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
 
-    for (const machineState of generator) {
+    // Manual iteration so we can pick up the generator's RETURN value (the
+    // post-loop after-fire drain from #108 part 1, signalled when the
+    // halting iter armed an after).
+    let result = generator.next();
+
+    while (!result.done) {
+      const machineState = result.value;
+
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
       if (machineState.debugBreak?.after && onPause && prevYield) {
         await onPause({...prevYield, debugBreak: {after: true}});
@@ -94,11 +101,23 @@ export default class TuringMachine {
       }
 
       prevYield = machineState;
+      result = generator.next();
+    }
+
+    // #108 part 1: drain the halting iter's after-fire if it armed one.
+    // The generator returns a non-null tail when the last visited state's
+    // `state.debug.after` matched its symbol but the loop exited before a
+    // next yield could carry the metadata. We dispatch using the source
+    // (prevYield), matching the in-loop after-fire payload shape.
+    if (result.value && onPause && prevYield) {
+      await onPause({...prevYield, debugBreak: {after: true}});
     }
   }
 
-  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState> {
+  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState, MachineState | null> {
     const executionSymbol = Symbol('execution');
+    let lastYielded: MachineState | null = null;
+    let pendingAfterFromPrev = false;
 
     try {
       this.#tapeBlock[lockSymbol].check(executionSymbol);
@@ -113,7 +132,6 @@ export default class TuringMachine {
       }
 
       let i = 0;
-      let pendingAfterFromPrev = false;
 
       while (!state.isHalt) {
         if (i === stepsLimit) {
@@ -164,8 +182,11 @@ export default class TuringMachine {
           }
 
           yield yielded;
+          lastYielded = yielded;
 
-          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield.
+          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield
+          // (or, if this turns out to be the halting iter, on the post-loop
+          // drain — see #108 part 1).
           pendingAfterFromPrev = matchFilter(state.debug?.after, symbol);
 
           this.#tapeBlock.applyCommand(command, executionSymbol);
@@ -190,5 +211,16 @@ export default class TuringMachine {
     } finally {
       this.#tapeBlock[lockSymbol].unlock(executionSymbol);
     }
+
+    // #108 part 1: signal the after-fire armed by the halting iter so run()
+    // (or any direct generator consumer) can dispatch one final after-break.
+    // Returning the synthesized MachineState (rather than yielding it) keeps
+    // `for..of` consumers — which ignore the return value — unaffected; only
+    // consumers that opt in via manual iteration see the drain.
+    if (pendingAfterFromPrev && lastYielded) {
+      return {...lastYielded, debugBreak: {after: true}};
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Closes #108. Two related halt-semantics changes for `state.debug.after`.

## Part 1 — drain post-loop after-fire (bug fix)

**Before:** when the halting iter set `state.debug.after` matching the current symbol, `run()` set `pendingAfterFromPrev` but the `while(!state.isHalt)` loop exited before the next yield could carry the metadata — the after-fire was silently dropped.

**After:** `runStepByStep` *returns* (does not yield) a synthesized tail `MachineState` with `debugBreak.after` when the halting iter armed an after. `run()` iterates manually so it can pick up the tail and dispatch one final `onPause` call using the source state (`prevYield` substitution, matching the in-loop after-fire payload shape).

`for..of` consumers ignore the generator's return value, so direct `runStepByStep` iterators are unaffected — only consumers that opt in via manual iteration (today: `run()` itself) see the drain. The yielded-metadata contract is unchanged: a yielded `MachineState` never carries `debugBreak.after` for the *halting* iter — that fires through the post-loop drain instead.

## Part 2 — reject `haltState.debug.after` at write time (BREAKING)

Halt is terminal — no iteration-after-halt for an after-fire to anchor on. The validator (`State[validateDebugFilter]`) now throws on any truthy assignment of `.after` to `haltState` (`true` OR symbol list), so misuse surfaces at the point of misuse instead of silently no-op'ing.

Symmetric `{ before: true, after: true }` writes also throw — use `{ before: true }`. Symbol-list filters on `haltState.debug.before` remain silent no-ops as in v4.

## Test changes

- Un-skipped the `halt semantics for after-fire (#108)` describe block (scaffolded on `v5` in `39b0345`, kept `describe.skip` in `36f4605` for green CI baseline). All three tests now turn green.
- Removed the obsolete `after on a transition leading to halt is silently lost` test from the `debug.after` describe block — its premise was the bug, not the design. The new post-loop behavior is exercised by the un-skipped #108 block.

## Verification

- `npm test`: **614 passed, 0 failed, 0 skipped** (was 610 + 6 skipped on the v5 baseline; the 6 un-skip + 2 fewer due to the deleted obsolete test = 614).
- `npm run lint`: clean.
- `npx tsc --build`: clean.