### PR TITLE
feat(machine): add run({debug: boolean}) flag (#106)

### DIFF
--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **`run({ debug: boolean })` flag** ([#106](https://github.com/mellonis/turing-machine-js/issues/106)). Gates whether `state.debug` assignments produce `debugBreak` metadata on yields, without editing the assignments. Defaults to `true` when an `onPause` hook is provided (preserves v4 behavior); set `false` to suppress all break dispatches while keeping `state.debug = ...` in code.
+- **`run({ debug: boolean })` flag** ([#106](https://github.com/mellonis/turing-machine-js/issues/106)). Master switch for `onPause` dispatch. When `false`, suppresses all pause-fires (before, after, and the post-loop after-drain) regardless of `state.debug` assignments. `onStep` is unaffected. Defaults to `true`. The `m.debugBreak` field is still populated on yields by the underlying generator (it's a property of the iteration); only `run()`'s hook dispatch is gated. Useful for toggling "debug mode" without editing `state.debug = ...` across the state graph.
 
 ### Migration
 

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -385,3 +385,88 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
     }).toThrow();
   });
 });
+
+describe('TuringMachine — run({debug}) flag (#106)', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  test('debug: false suppresses onPause for "before" matches', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      debug: false,
+    });
+
+    expect(pauses).toHaveLength(0);
+  });
+
+  test('debug: false suppresses onPause for "after" matches AND the halting drain', async () => {
+    // With state.debug.after = true, the in-loop after-fires plus the #108
+    // post-loop drain would normally produce one onPause call per visit. The
+    // master switch must gate all of them.
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      debug: false,
+    });
+
+    expect(pauses).toHaveLength(0);
+  });
+
+  test('debug: true (default) dispatches onPause as v4', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      // debug omitted → defaults to true
+    });
+
+    expect(pauses.length).toBeGreaterThan(0);
+  });
+
+  test('debug: false does NOT suppress onStep', async () => {
+    // The flag is specifically about pause-capable dispatch; trace/logging
+    // continues regardless.
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    let stepCount = 0;
+
+    await machine.run({
+      initialState: state,
+      onStep: () => { stepCount += 1; },
+      onPause: () => {},
+      debug: false,
+    });
+
+    expect(stepCount).toBeGreaterThan(0);
+  });
+
+  test('debug: false leaves m.debugBreak metadata on yields (gating is run-level only)', async () => {
+    // Direct runStepByStep consumers see the metadata regardless of how run()
+    // is configured. Here we observe via onStep, which receives the original
+    // yielded MachineState — its debugBreak field is unaffected.
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const yields: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onStep: (m) => { yields.push(m); },
+      onPause: () => {},
+      debug: false,
+    });
+
+    // At least one yield carries the metadata even though no onPause fires.
+    expect(yields.some((y) => y.debugBreak?.before)).toBe(true);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -57,6 +57,7 @@ export default class TuringMachine {
     stepsLimit = 1e5,
     onStep,
     onPause,
+    debug = true,
   }: RunParameter & {
     /**
      * Sync, ~free hook fired on every iteration. Use for logging/tracing —
@@ -74,6 +75,18 @@ export default class TuringMachine {
      * keeps its name (it describes the engine's reason for pausing).
      */
     onPause?: (machineState: MachineState) => void | Promise<void>;
+    /**
+     * Master switch for `onPause` dispatch. When `false`, suppresses all
+     * pause-fires (before, after, and the post-loop after-drain) regardless
+     * of `state.debug` assignments. `onStep` is unaffected. Defaults to
+     * `true`.
+     *
+     * The `m.debugBreak` field is still populated on yields by the underlying
+     * generator (it's a property of the iteration, not of the consumer); only
+     * `run()`'s hook dispatch is gated. Direct `runStepByStep` consumers see
+     * the metadata regardless.
+     */
+    debug?: boolean;
   }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
@@ -87,12 +100,12 @@ export default class TuringMachine {
       const machineState = result.value;
 
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
-      if (machineState.debugBreak?.after && onPause && prevYield) {
+      if (debug && machineState.debugBreak?.after && onPause && prevYield) {
         await onPause({...prevYield, debugBreak: {after: true}});
       }
 
       // 'before' (current step) — pass current machineState with only the before flag.
-      if (machineState.debugBreak?.before && onPause) {
+      if (debug && machineState.debugBreak?.before && onPause) {
         await onPause({...machineState, debugBreak: {before: true}});
       }
 
@@ -109,7 +122,7 @@ export default class TuringMachine {
     // `state.debug.after` matched its symbol but the loop exited before a
     // next yield could carry the metadata. We dispatch using the source
     // (prevYield), matching the in-loop after-fire payload shape.
-    if (result.value && onPause && prevYield) {
+    if (debug && result.value && onPause && prevYield) {
       await onPause({...prevYield, debugBreak: {after: true}});
     }
   }


### PR DESCRIPTION
Closes #106. Adds a master switch for `onPause` dispatch on `TuringMachine.run()`.

## Behavior

`run({ debug: boolean })` — when `false`, suppresses all pause-fires (before, after, and the post-loop after-drain from #108) regardless of `state.debug` assignments. `onStep` is unaffected. Defaults to `true`.

```ts
// today (and v4): the only way to disable breaks while keeping state.debug
// definitions in code is to null out every assignment.
state.debug = null;
otherState.debug = null;
// ...

// v5 + #106: one switch.
await machine.run({
  initialState,
  onPause: someHook,
  debug: false, // breaks short-circuited; onStep still fires
});
```

## What's gated, what isn't

- ✅ Gated: `onPause` dispatch in `run()` (in-loop before, in-loop after, post-loop drain).
- ❌ Not gated: `m.debugBreak` field on yields. The generator (`runStepByStep`) populates it as a property of the iteration; direct consumers see the metadata regardless. Only `run()`'s hook dispatch is run-level gated.
- ❌ Not gated: `onStep`. The flag is specifically about pause-capable dispatch; trace/logging continues.

## Tests

Added a `run({debug}) flag (#106)` describe block with 5 tests:
- `debug: false` suppresses `onPause` for `before` matches.
- `debug: false` suppresses `onPause` for `after` matches AND the halting drain.
- `debug: true` (default) dispatches as v4.
- `debug: false` does NOT suppress `onStep`.
- `debug: false` leaves `m.debugBreak` metadata on yields (gating is run-level only).

## Verification

- `npm test`: **624 passed, 0 failed** (was 614).
- `npm run lint`: clean.
- `npx tsc --build`: clean.