### PR TITLE
feat(builder): add debug parameter to buildMachine() (#101)

### DIFF
--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - UNRELEASED
+
+> Draft. Lands as v5.0.0 once the linked issues are closed.
+
+### Added
+
+- **`debug` parameter on `buildMachine()`** ([#101](https://github.com/mellonis/turing-machine-js/issues/101)). Optional per-state breakpoint config; maps to `state.debug = { before, after }` on the matching `State` after construction. Filter values are raw alphabet characters (matching the input-symbol notation in `states`); the builder translates each to a `tapeBlock.symbol([char])`-interned `Symbol` at build time. `true` is the wildcard.
+  - Errors at build time on: unknown state name, final-state name (alias for `haltState`, out of scope per the issue spec), symbol not in alphabet.
+  - `haltState.debug` declarative support is out of scope — set it directly on the imported singleton if you need to pause on halt entry.
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version. Note that the `onDebugBreak` → `onPause` rename in engine v5 doesn't affect this package (the builder doesn't call `run()`).
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -1,4 +1,4 @@
-import {Tape} from '@turing-machine-js/machine';
+import {haltState, Tape} from '@turing-machine-js/machine';
 import buildMachine, {States} from './index';
 
 describe('buildMachine', () => {
@@ -74,5 +74,105 @@ describe('buildMachine', () => {
 
     expect(machine.tapeBlock.tapes[0].symbols)
       .toEqual('#011#011#'.split(''));
+  });
+});
+
+describe('buildMachine — debug config (#101)', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  // Compact two-symbol machine used by the debug-config tests:
+  //   Q0: on 'A' write A move R stay-in-Q0; on 'B' write B move R go halt.
+  // Configurable tape lets each test exercise a different trajectory.
+  const buildLoopMachine = (debug?: Parameters<typeof buildMachine>[0]['debug']) => {
+    const result = buildMachine({
+      alphabetString: '_AB',
+      initialState: 'Q0',
+      finalStateList: ['Qf'],
+      states: {
+        Q0: {
+          A: {symbol: 'A', movement: 'R', state: 'Q0'},
+          B: {symbol: 'B', movement: 'R', state: 'Qf'},
+        },
+      },
+      debug,
+    });
+
+    return result;
+  };
+
+  test('debug.before = true (wildcard) sets state.debug.before on the named state', () => {
+    const [, , states] = buildLoopMachine({Q0: {before: true}});
+    expect(states.Q0.debug?.before).toBe(true);
+  });
+
+  test('debug.before symbol-list fires onPause only for matching symbols', async () => {
+    const [machine, init] = buildLoopMachine({Q0: {before: ['A']}});
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['A', 'A', 'B'],
+    }));
+
+    const pausedSymbols: string[] = [];
+    await machine.run({
+      initialState: init,
+      onPause: (m) => { pausedSymbols.push(m.currentSymbols[0]); },
+    });
+
+    // Trajectory: A (pause) → A (pause) → B (no pause; B not in filter) → halt.
+    expect(pausedSymbols).toEqual(['A', 'A']);
+  });
+
+  test('debug.after symbol-list fires post-loop drain on halting iter (with #108 fix)', async () => {
+    // 'B' triggers the halting transition; after-fire on B should reach onPause
+    // via the post-loop drain landed in #108.
+    const [machine, init] = buildLoopMachine({Q0: {after: ['B']}});
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['B'],
+    }));
+
+    let afterCount = 0;
+    await machine.run({
+      initialState: init,
+      onPause: (m) => { if (m.debugBreak?.after) afterCount += 1; },
+    });
+
+    expect(afterCount).toBe(1);
+  });
+
+  test('debug accepts both before and after on the same state', async () => {
+    const [machine, init] = buildLoopMachine({Q0: {before: true, after: true}});
+    // Tape needs to terminate via a 'B' transition (which goes to halt) —
+    // Q0 has no blank-handling transition, so a tape that runs into blanks
+    // throws "No command for symbol".
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['A', 'B'],
+    }));
+
+    let beforeCount = 0;
+    let afterCount = 0;
+    await machine.run({
+      initialState: init,
+      onPause: (m) => {
+        if (m.debugBreak?.before) beforeCount += 1;
+        if (m.debugBreak?.after) afterCount += 1;
+      },
+    });
+
+    expect(beforeCount).toBeGreaterThan(0);
+    expect(afterCount).toBeGreaterThan(0);
+  });
+
+  test('throws when debug references an unknown state name', () => {
+    expect(() => buildLoopMachine({Qx: {before: true}})).toThrow(/unknown state/);
+  });
+
+  test('throws when debug references a final-state name (out of scope per #101)', () => {
+    expect(() => buildLoopMachine({Qf: {before: true}})).toThrow(/final state/);
+  });
+
+  test('throws when a debug filter symbol is not in the alphabet', () => {
+    expect(() => buildLoopMachine({Q0: {before: ['Z']}})).toThrow(/not in the alphabet/);
   });
 });

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -23,6 +23,22 @@ export type States = Record<string, Record<string, {
   movement: keyof typeof movementsMap,
   state: string,
 }>>;
+
+/**
+ * Per-state breakpoint config for the declarative builder. Filter values are
+ * raw alphabet characters (matching the input-symbol notation in `states`);
+ * the builder translates each to a `tapeBlock.symbol([char])`-interned
+ * Symbol at construction time. `true` is the wildcard.
+ *
+ * Out of scope (#101): final-state entries — `finalStateList` names map to
+ * `haltState`, which is not a state in the table. Pass `before` / `after`
+ * directly on `haltState.debug` if you need to pause on halt entry.
+ */
+export type DebugConfigByState = Record<string, {
+  before?: true | string[];
+  after?: true | string[];
+}>;
+
 type StatesQq = Record<string, {
   [stateKey]?: State;
   [referenceKey]?: Reference;
@@ -33,11 +49,13 @@ export default function buildMachine({
                                        initialState,
                                        finalStateList,
                                        states: stateNameToStateDeclarationMap,
+                                       debug,
                                      }: {
   alphabetString: string;
   initialState: string;
   finalStateList: string[];
   states: States;
+  debug?: DebugConfigByState;
 }) {
   const alphabet = new Alphabet(alphabetString.split(''));
   const machine = new TuringMachine({
@@ -110,6 +128,51 @@ export default function buildMachine({
       ...result,
       [stateName]: stateOrReference[stateKey],
     }), {});
+
+  // #101: apply per-state debug config. Filter values are raw alphabet
+  // characters; translate each via tapeBlock.symbol([char]) so they match
+  // the same interned Symbol used in transitions. `true` passes through
+  // as-is (wildcard). final-state names are rejected — they alias to
+  // haltState which is out of scope per the issue spec.
+  if (debug) {
+    Object.entries(debug).forEach(([stateName, config]) => {
+      if (finalStateList.includes(stateName)) {
+        throw new Error(
+          `debug cannot be set on final state '${stateName}': finalStateList `
+          + 'entries map to haltState, which is out of scope for the builder. '
+          + 'Set haltState.debug directly on the imported singleton if needed.',
+        );
+      }
+
+      const state = resultStates[stateName];
+
+      if (!state) {
+        throw new Error(`debug references unknown state '${stateName}'`);
+      }
+
+      const translateFilter = (
+        f: true | string[] | undefined,
+      ): true | symbol[] | undefined => {
+        if (f === undefined) return undefined;
+        if (f === true) return true;
+
+        return f.map((c) => {
+          if (!alphabet.has(c)) {
+            throw new Error(
+              `debug filter symbol '${c}' for state '${stateName}' is not in the alphabet`,
+            );
+          }
+
+          return getSymbol([c]);
+        });
+      };
+
+      state.debug = {
+        before: translateFilter(config.before),
+        after: translateFilter(config.after),
+      };
+    });
+  }
 
   return [
     machine,


### PR DESCRIPTION
Closes #101. Adds an optional `debug` parameter on `buildMachine()` for setting per-state breakpoints declaratively.

## API

```ts
const [machine, init] = buildMachine({
  alphabetString: '_AB',
  initialState: 'Q0',
  finalStateList: ['Qf'],
  states: { Q0: {
    A: { symbol: 'A', movement: 'R', state: 'Q0' },
    B: { symbol: 'B', movement: 'R', state: 'Qf' },
  } },
  debug: {
    Q0: { before: ['A'] },  // pause when head shows 'A' at Q0
  },
});
```

Filter values are raw alphabet characters (matching the input-symbol notation used elsewhere in the table); the builder translates each to a `tapeBlock.symbol([char])`-interned `Symbol` at build time so they match the same identity used in transitions and in the engine's `matchFilter`. `true` is the wildcard.

## Validation (build-time errors)

- Unknown state name in `debug`.
- Final-state name (alias for `haltState`) — out of scope per the issue spec.
- Filter symbol not in `alphabetString`.

(The engine's own `State.validateDebugFilter` continues to enforce that filter symbols are transition keys of the owning state.)

## Out of scope

- Declarative `haltState.debug` — set it directly on the imported singleton if you need to pause on halt entry.

## Other changes

- Widen `peerDependencies."@turing-machine-js/machine"` from `^4.0.0` to `^5.0.0` to match the v5 lockstep. The `onDebugBreak` → `onPause` rename in engine v5 doesn't affect this package (the builder doesn't call `run()`).

## Tests

Added a `buildMachine — debug config (#101)` describe block with 7 tests covering: wildcard, symbol-list filter behavior under run, post-loop drain on halting iter (pairs with #108), both-flags combination, and the three error paths.

## Verification

- `npm test`: **638 passed, 0 failed** (was 624 before).
- `npm run lint`: clean.
- `npx tsc --build`: clean.
