### PR TITLE
chore(release): v5.0.0 prep (CHANGELOG dates + lerna bump)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   pull_request:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   workflow_dispatch: # allow manual trigger from the Actions tab
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, next ]
+    branches: [ master, next, v5 ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ master, next, v5 ]
   workflow_dispatch: # allow manual trigger from the Actions tab
 
 jobs:

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0",
+  "version": "5.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14020,40 +14020,40 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - UNRELEASED
-
-> Draft. Lands as v5.0.0 once the linked issues are closed.
+## [5.0.0] - 2026-05-09
 
 ### Added
 

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "builder"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 5.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,7 +28,7 @@
     "teaching"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 5.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"
@@ -27,7 +27,7 @@
     "numbers"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - UNRELEASED
-
-> Draft. Lands as v5.0.0 once the linked issues are closed.
+## [5.0.0] - 2026-05-09
 
 ### Changed (BREAKING)
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
Release prep for v5.0.0. Three commits:

1. **`chore(release): finalize v5.0.0 CHANGELOG dates + drop v5 from CI triggers`** — stamps `[5.0.0] - 2026-05-09` on `packages/machine/CHANGELOG.md` and `packages/builder/CHANGELOG.md`; restores `main.yml`'s branch trigger filter to `[ master, next ]` (drops `v5` since it'll merge to master).
2. **`chore(release): add v5.0.0 CHANGELOG entries to library-binary-numbers packages`** — lockstep peer-dep widening entries (`^4.0.0` → `^5.0.0`) in both `library-binary-numbers/CHANGELOG.md` and `library-binary-numbers-bare/CHANGELOG.md`. Matches the v4 pattern.
3. **`chore: bump version to v5.0.0 (lockstep)`** — version bump across `lerna.json` + all four `packages/*/package.json` from `4.0.0` to `5.0.0`. Also widens the three peer-dep ranges (`builder`, `library-binary-numbers`, `library-binary-numbers-bare`) on `@turing-machine-js/machine` from `^4.0.0` to `^5.0.0`. Lockfile refreshed via `npm install`.

## Verification

- `npm test`: **638 passed, 0 failed**.
- `npm run lint`: clean.
- `npx tsc --build`: clean.

## After merge

1. Open `v5 → master` PR.
2. Tag `v5.0.0` on master once that merges.
3. `npx lerna publish from-git`.