### PR TITLE
Release v5.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   pull_request:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   workflow_dispatch: # allow manual trigger from the Actions tab
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, next ]
+    branches: [ master, next, v5 ]
   pull_request:
-    branches: [ master, next ]
+    branches: [ master, next, v5 ]
   workflow_dispatch: # allow manual trigger from the Actions tab
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Key shapes that take reading multiple files to grasp:
 
 - **`TapeBlock` has a `Lock`** that `TuringMachine.run` grabs for the duration of a run, asserting the block isn't being mutated by another machine. Calls to `applyCommand` from outside a run must pass the matching capture symbol.
 
-- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onDebugBreak` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
+- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onPause` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). Renamed from `onDebugBreak` in v5. `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
 
 ### Builder package
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.0.0",
+  "version": "5.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14020,40 +14020,40 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^4.0.0"
+        "@turing-machine-js/machine": "^5.0.0"
       }
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - UNRELEASED
+
+> Draft. Lands as v5.0.0 once the linked issues are closed.
+
+### Added
+
+- **`debug` parameter on `buildMachine()`** ([#101](https://github.com/mellonis/turing-machine-js/issues/101)). Optional per-state breakpoint config; maps to `state.debug = { before, after }` on the matching `State` after construction. Filter values are raw alphabet characters (matching the input-symbol notation in `states`); the builder translates each to a `tapeBlock.symbol([char])`-interned `Symbol` at build time. `true` is the wildcard.
+  - Errors at build time on: unknown state name, final-state name (alias for `haltState`, out of scope per the issue spec), symbol not in alphabet.
+  - `haltState.debug` declarative support is out of scope — set it directly on the imported singleton if you need to pause on halt entry.
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version. Note that the `onDebugBreak` → `onPause` rename in engine v5 doesn't affect this package (the builder doesn't call `run()`).
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - UNRELEASED
-
-> Draft. Lands as v5.0.0 once the linked issues are closed.
+## [5.0.0] - 2026-05-09
 
 ### Added
 

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "builder"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -1,4 +1,4 @@
-import {Tape} from '@turing-machine-js/machine';
+import {haltState, Tape} from '@turing-machine-js/machine';
 import buildMachine, {States} from './index';
 
 describe('buildMachine', () => {
@@ -74,5 +74,105 @@ describe('buildMachine', () => {
 
     expect(machine.tapeBlock.tapes[0].symbols)
       .toEqual('#011#011#'.split(''));
+  });
+});
+
+describe('buildMachine — debug config (#101)', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  // Compact two-symbol machine used by the debug-config tests:
+  //   Q0: on 'A' write A move R stay-in-Q0; on 'B' write B move R go halt.
+  // Configurable tape lets each test exercise a different trajectory.
+  const buildLoopMachine = (debug?: Parameters<typeof buildMachine>[0]['debug']) => {
+    const result = buildMachine({
+      alphabetString: '_AB',
+      initialState: 'Q0',
+      finalStateList: ['Qf'],
+      states: {
+        Q0: {
+          A: {symbol: 'A', movement: 'R', state: 'Q0'},
+          B: {symbol: 'B', movement: 'R', state: 'Qf'},
+        },
+      },
+      debug,
+    });
+
+    return result;
+  };
+
+  test('debug.before = true (wildcard) sets state.debug.before on the named state', () => {
+    const [, , states] = buildLoopMachine({Q0: {before: true}});
+    expect(states.Q0.debug?.before).toBe(true);
+  });
+
+  test('debug.before symbol-list fires onPause only for matching symbols', async () => {
+    const [machine, init] = buildLoopMachine({Q0: {before: ['A']}});
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['A', 'A', 'B'],
+    }));
+
+    const pausedSymbols: string[] = [];
+    await machine.run({
+      initialState: init,
+      onPause: (m) => { pausedSymbols.push(m.currentSymbols[0]); },
+    });
+
+    // Trajectory: A (pause) → A (pause) → B (no pause; B not in filter) → halt.
+    expect(pausedSymbols).toEqual(['A', 'A']);
+  });
+
+  test('debug.after symbol-list fires post-loop drain on halting iter (with #108 fix)', async () => {
+    // 'B' triggers the halting transition; after-fire on B should reach onPause
+    // via the post-loop drain landed in #108.
+    const [machine, init] = buildLoopMachine({Q0: {after: ['B']}});
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['B'],
+    }));
+
+    let afterCount = 0;
+    await machine.run({
+      initialState: init,
+      onPause: (m) => { if (m.debugBreak?.after) afterCount += 1; },
+    });
+
+    expect(afterCount).toBe(1);
+  });
+
+  test('debug accepts both before and after on the same state', async () => {
+    const [machine, init] = buildLoopMachine({Q0: {before: true, after: true}});
+    // Tape needs to terminate via a 'B' transition (which goes to halt) —
+    // Q0 has no blank-handling transition, so a tape that runs into blanks
+    // throws "No command for symbol".
+    machine.tapeBlock.replaceTape(new Tape({
+      alphabet: machine.tapeBlock.alphabets[0],
+      symbols: ['A', 'B'],
+    }));
+
+    let beforeCount = 0;
+    let afterCount = 0;
+    await machine.run({
+      initialState: init,
+      onPause: (m) => {
+        if (m.debugBreak?.before) beforeCount += 1;
+        if (m.debugBreak?.after) afterCount += 1;
+      },
+    });
+
+    expect(beforeCount).toBeGreaterThan(0);
+    expect(afterCount).toBeGreaterThan(0);
+  });
+
+  test('throws when debug references an unknown state name', () => {
+    expect(() => buildLoopMachine({Qx: {before: true}})).toThrow(/unknown state/);
+  });
+
+  test('throws when debug references a final-state name (out of scope per #101)', () => {
+    expect(() => buildLoopMachine({Qf: {before: true}})).toThrow(/final state/);
+  });
+
+  test('throws when a debug filter symbol is not in the alphabet', () => {
+    expect(() => buildLoopMachine({Q0: {before: ['Z']}})).toThrow(/not in the alphabet/);
   });
 });

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -23,6 +23,22 @@ export type States = Record<string, Record<string, {
   movement: keyof typeof movementsMap,
   state: string,
 }>>;
+
+/**
+ * Per-state breakpoint config for the declarative builder. Filter values are
+ * raw alphabet characters (matching the input-symbol notation in `states`);
+ * the builder translates each to a `tapeBlock.symbol([char])`-interned
+ * Symbol at construction time. `true` is the wildcard.
+ *
+ * Out of scope (#101): final-state entries — `finalStateList` names map to
+ * `haltState`, which is not a state in the table. Pass `before` / `after`
+ * directly on `haltState.debug` if you need to pause on halt entry.
+ */
+export type DebugConfigByState = Record<string, {
+  before?: true | string[];
+  after?: true | string[];
+}>;
+
 type StatesQq = Record<string, {
   [stateKey]?: State;
   [referenceKey]?: Reference;
@@ -33,11 +49,13 @@ export default function buildMachine({
                                        initialState,
                                        finalStateList,
                                        states: stateNameToStateDeclarationMap,
+                                       debug,
                                      }: {
   alphabetString: string;
   initialState: string;
   finalStateList: string[];
   states: States;
+  debug?: DebugConfigByState;
 }) {
   const alphabet = new Alphabet(alphabetString.split(''));
   const machine = new TuringMachine({
@@ -110,6 +128,51 @@ export default function buildMachine({
       ...result,
       [stateName]: stateOrReference[stateKey],
     }), {});
+
+  // #101: apply per-state debug config. Filter values are raw alphabet
+  // characters; translate each via tapeBlock.symbol([char]) so they match
+  // the same interned Symbol used in transitions. `true` passes through
+  // as-is (wildcard). final-state names are rejected — they alias to
+  // haltState which is out of scope per the issue spec.
+  if (debug) {
+    Object.entries(debug).forEach(([stateName, config]) => {
+      if (finalStateList.includes(stateName)) {
+        throw new Error(
+          `debug cannot be set on final state '${stateName}': finalStateList `
+          + 'entries map to haltState, which is out of scope for the builder. '
+          + 'Set haltState.debug directly on the imported singleton if needed.',
+        );
+      }
+
+      const state = resultStates[stateName];
+
+      if (!state) {
+        throw new Error(`debug references unknown state '${stateName}'`);
+      }
+
+      const translateFilter = (
+        f: true | string[] | undefined,
+      ): true | symbol[] | undefined => {
+        if (f === undefined) return undefined;
+        if (f === true) return true;
+
+        return f.map((c) => {
+          if (!alphabet.has(c)) {
+            throw new Error(
+              `debug filter symbol '${c}' for state '${stateName}' is not in the alphabet`,
+            );
+          }
+
+          return getSymbol([c]);
+        });
+      };
+
+      state.debug = {
+        before: translateFilter(config.before),
+        after: translateFilter(config.after),
+      };
+    });
+  }
 
   return [
     machine,

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 5.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,7 +28,7 @@
     "teaching"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^4.0.0` to `^5.0.0`** to match the v5 lockstep. Consumers pinned to `@turing-machine-js/machine@4` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 5.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [4.0.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"
@@ -27,7 +27,7 @@
     "numbers"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^4.0.0"
+    "@turing-machine-js/machine": "^5.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **`run({ debug: boolean })` flag** ([#106](https://github.com/mellonis/turing-machine-js/issues/106)). Gates whether `state.debug` assignments produce `debugBreak` metadata on yields, without editing the assignments. Defaults to `true` when an `onPause` hook is provided (preserves v4 behavior); set `false` to suppress all break dispatches while keeping `state.debug = ...` in code.
+- **`run({ debug: boolean })` flag** ([#106](https://github.com/mellonis/turing-machine-js/issues/106)). Master switch for `onPause` dispatch. When `false`, suppresses all pause-fires (before, after, and the post-loop after-drain) regardless of `state.debug` assignments. `onStep` is unaffected. Defaults to `true`. The `m.debugBreak` field is still populated on yields by the underlying generator (it's a property of the iteration); only `run()`'s hook dispatch is gated. Useful for toggling "debug mode" without editing `state.debug = ...` across the state graph.
 
 ### Migration
 

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.0.0] - UNRELEASED
-
-> Draft. Lands as v5.0.0 once the linked issues are closed.
+## [5.0.0] - 2026-05-09
 
 ### Changed (BREAKING)
 

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - UNRELEASED
+
+> Draft. Lands as v5.0.0 once the linked issues are closed.
+
+### Changed (BREAKING)
+
+- **Hook renamed: `onDebugBreak` → `onPause`** on `run()` ([#110](https://github.com/mellonis/turing-machine-js/issues/110)). Hard rename, no deprecation alias. The hook signature, payload shape, and dispatch semantics are unchanged — only the option key on `run()` differs. Resolution of the [#109 RFC](https://github.com/mellonis/turing-machine-js/issues/109): the hook now describes the consumer's relationship (this is where you can pause) rather than the engine's event (a debug break fired). The `m.debugBreak` payload field is unchanged.
+- **`haltState.debug.after` now throws on assignment** ([#108](https://github.com/mellonis/turing-machine-js/issues/108) part 2). Halt is terminal — there is no iteration-after-halt for an after-fire to anchor on. Symmetric `{ before: true, after: true }` writes also throw; use `{ before: true }`. Symbol-list filters on `haltState.debug.before` remain silent no-ops as in v4.
+
+### Fixed
+
+- **Halting iter's `state.debug.after` now fires** ([#108](https://github.com/mellonis/turing-machine-js/issues/108) part 1). Previously `pendingAfterFromPrev` set after the halting iter's yield was discarded when the `while (!state.isHalt)` loop exited — losing that after-fire. `run()` now drains a final after-fire after the loop when the prior yield armed one. Observable: a debugger UI sees a "we just halted because of state X's after-filter" event that was silent before.
+
+### Added
+
+- **`run({ debug: boolean })` flag** ([#106](https://github.com/mellonis/turing-machine-js/issues/106)). Gates whether `state.debug` assignments produce `debugBreak` metadata on yields, without editing the assignments. Defaults to `true` when an `onPause` hook is provided (preserves v4 behavior); set `false` to suppress all break dispatches while keeping `state.debug = ...` in code.
+
+### Migration
+
+```diff
+  await machine.run({
+    initialState,
+-   onDebugBreak: (m) => { ... },
++   onPause: (m) => { ... },
+  });
+```
+
+```diff
+- haltState.debug = { before: true, after: true }; // throws in v5
++ haltState.debug = { before: true };
+```
+
 ## [4.0.0] - 2026-05-07
 
 ### Added

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -256,13 +256,13 @@ myState.debug = null;
 
 The `debug` field is mutable — toggle breakpoints at runtime without rebuilding the graph. The internal cell is shared with `state.withOverrodeHaltState(...)` wrappers, so an assignment on the original is visible from every wrapper.
 
-`run()` is async and accepts an `onDebugBreak` hook:
+`run()` is async and accepts an `onPause` hook:
 
 ```ts
 await machine.run({
   initialState,
   onStep: (m) => { /* logger sees every step */ },
-  onDebugBreak: async (m) => {
+  onPause: async (m) => {
     // Awaited at every break — hold execution until you resolve.
     if (m.debugBreak?.before) console.log('before:', m.state.name);
     if (m.debugBreak?.after)  console.log('after:',  m.state.name);
@@ -272,7 +272,7 @@ await machine.run({
 
 For `after` calls, `m` is the previous yield's snapshot — `m.state` is the state whose `after` filter fired. For `before` calls, `m` is the current iteration. `onStep` always sees the original (un-substituted) yield.
 
-If `onDebugBreak` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
+If `onPause` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
 
 **Filter semantics:** `true` is a wildcard (match any symbol). `[ifOtherSymbol]` is NOT a wildcard — it matches only the catch-all resolution case (same meaning as in transition keys).
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -185,10 +185,24 @@ export default class State {
     fieldName: 'before' | 'after',
     filter: readonly symbol[] | true | undefined,
   ): void {
-    if (filter === undefined || filter === true) return;
+    if (filter === undefined) return;
 
-    // haltState has no own transitions; symbol-list filters on it are silent
-    // no-ops at the engine level (spec §8.6), so accept any list shape here.
+    // #108 part 2: `.after` on haltState has no semantic anchor — halt is
+    // terminal, so there is no iteration-after-halt for an after-fire to
+    // attach to. Reject any truthy assignment (true OR list) at write time
+    // so misuse surfaces immediately rather than silently no-op'ing.
+    if (this.isHalt && fieldName === 'after') {
+      throw new Error(
+        'haltState.debug.after is not supported: halt is terminal, so there is '
+        + 'no iteration-after-halt for an after-fire to anchor on. Use '
+        + '{ before: true } to pause on halt entry.',
+      );
+    }
+
+    if (filter === true) return;
+
+    // haltState has no own transitions; symbol-list filters on `before` are
+    // silent no-ops at the engine level (spec §8.6), so accept any list shape.
     if (this.isHalt) return;
 
     for (const sym of filter) {

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -345,3 +345,51 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     expect(breakCount.n).toBeGreaterThan(0);
   });
 });
+
+// These tests assert the v5 spec from #108. They are intentionally RED on the
+// v4 codebase — they turn green when the loop-drain fix and haltState rejection
+// land. The "after on a transition leading to halt is silently lost" test in
+// the second describe above (currently labelled by-design) is contradicted by
+// part-1 below and will be updated in lockstep with the fix.
+describe('TuringMachine — halt semantics for after-fire (#108)', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  test('halting iter still fires its after (#108 part 1)', async () => {
+    // Tape ['A','B','A'] traverses 4 visits in the single-state machine:
+    //   visit 1 head 'A'  → erase+right (state self-loops)
+    //   visit 2 head 'B'  → erase+right
+    //   visit 3 head 'A'  → erase+right
+    //   visit 4 head blank→ ifOtherSymbol → halt
+    // debug.after = true matches every visit. Today only 3 after-fires reach
+    // onDebugBreak (visit 4's after has no anchor yield); v5 must drain it
+    // and produce 4.
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const after: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onDebugBreak: (m) => { if (m.debugBreak?.after) after.push(m); },
+    });
+
+    expect(after.length).toBe(4);
+  });
+
+  test('haltState.debug.after = true throws on assignment (#108 part 2)', () => {
+    // Halt is terminal — no iteration-after-halt for an after-fire to anchor on.
+    // v5 rejects the assignment to surface the misuse rather than silently
+    // ignore it.
+    expect(() => {
+      haltState.debug = {after: true};
+    }).toThrow();
+  });
+
+  test('haltState.debug with both flags throws (#108 part 2)', () => {
+    // Setting before+after symmetrically is the most likely user mistake; the
+    // .after part is meaningless and v5 rejects the whole assignment. Use
+    // { before: true } alone.
+    expect(() => {
+      haltState.debug = {before: true, after: true};
+    }).toThrow();
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -351,7 +351,7 @@ describe('TuringMachine — run() with onPause', () => {
 // land. The "after on a transition leading to halt is silently lost" test in
 // the second describe above (currently labelled by-design) is contradicted by
 // part-1 below and will be updated in lockstep with the fix.
-describe('TuringMachine — halt semantics for after-fire (#108)', () => {
+describe.skip('TuringMachine — halt semantics for after-fire (#108) [skipped on v5 baseline; un-skipped in #108 fix PR]', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('halting iter still fires its after (#108 part 1)', async () => {

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -385,3 +385,88 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
     }).toThrow();
   });
 });
+
+describe('TuringMachine — run({debug}) flag (#106)', () => {
+  afterEach(() => { haltState.debug = null; });
+
+  test('debug: false suppresses onPause for "before" matches', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      debug: false,
+    });
+
+    expect(pauses).toHaveLength(0);
+  });
+
+  test('debug: false suppresses onPause for "after" matches AND the halting drain', async () => {
+    // With state.debug.after = true, the in-loop after-fires plus the #108
+    // post-loop drain would normally produce one onPause call per visit. The
+    // master switch must gate all of them.
+    const {machine, state} = buildMachine();
+    state.debug = {after: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      debug: false,
+    });
+
+    expect(pauses).toHaveLength(0);
+  });
+
+  test('debug: true (default) dispatches onPause as v4', async () => {
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const pauses: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onPause: (m) => { pauses.push(m); },
+      // debug omitted → defaults to true
+    });
+
+    expect(pauses.length).toBeGreaterThan(0);
+  });
+
+  test('debug: false does NOT suppress onStep', async () => {
+    // The flag is specifically about pause-capable dispatch; trace/logging
+    // continues regardless.
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    let stepCount = 0;
+
+    await machine.run({
+      initialState: state,
+      onStep: () => { stepCount += 1; },
+      onPause: () => {},
+      debug: false,
+    });
+
+    expect(stepCount).toBeGreaterThan(0);
+  });
+
+  test('debug: false leaves m.debugBreak metadata on yields (gating is run-level only)', async () => {
+    // Direct runStepByStep consumers see the metadata regardless of how run()
+    // is configured. Here we observe via onStep, which receives the original
+    // yielded MachineState — its debugBreak field is unaffected.
+    const {machine, state} = buildMachine();
+    state.debug = {before: true};
+    const yields: MachineState[] = [];
+
+    await machine.run({
+      initialState: state,
+      onStep: (m) => { yields.push(m); },
+      onPause: () => {},
+      debug: false,
+    });
+
+    // At least one yield carries the metadata even though no onPause fires.
+    expect(yields.some((y) => y.debugBreak?.before)).toBe(true);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -115,18 +115,10 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     }
   });
 
-  test('after on a transition leading to halt is silently lost', () => {
-    const {machine, state} = buildMachine();
-    state.debug = {after: true};
-    const steps: MachineState[] = [];
-
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
-
-    // The final transition leads to halt — its after has no next yield to land on.
-    // (No assertion needed — this just confirms run() completes; pending after
-    // at halt is by-design lost. See spec §11.1.)
-    expect(steps.length).toBeGreaterThan(0);
-  });
+  // (Removed in v5 — the "by-design lost" semantics on halting after-fires
+  // was a #108 bug, not a design choice. The new behavior is verified in the
+  // dedicated `halt semantics for after-fire (#108)` describe block below,
+  // which exercises the run()-level drain.)
 
   test('before AND after on same visit produce both flags on the relevant yields', () => {
     const {machine, state} = buildMachine();
@@ -351,7 +343,7 @@ describe('TuringMachine — run() with onPause', () => {
 // land. The "after on a transition leading to halt is silently lost" test in
 // the second describe above (currently labelled by-design) is contradicted by
 // part-1 below and will be updated in lockstep with the fix.
-describe.skip('TuringMachine — halt semantics for after-fire (#108) [skipped on v5 baseline; un-skipped in #108 fix PR]', () => {
+describe('TuringMachine — halt semantics for after-fire (#108)', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('halting iter still fires its after (#108 part 1)', async () => {

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -231,7 +231,7 @@ describe('TuringMachine — haltState.debug.before', () => {
   });
 });
 
-describe('TuringMachine — run() with onDebugBreak', () => {
+describe('TuringMachine — run() with onPause', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('run() returns a Promise', () => {
@@ -241,7 +241,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     return result;
   });
 
-  test('without onDebugBreak, breaks fire-and-resume invisibly', async () => {
+  test('without onPause, breaks fire-and-resume invisibly', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const steps: MachineState[] = [];
@@ -253,14 +253,14 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     // No exception, no hang.
   });
 
-  test('onDebugBreak fires for "before" with current state', async () => {
+  test('onPause fires for "before" with current state', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const seen: Array<{state: State, debugBreak?: MachineState['debugBreak']}> = [];
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         seen.push({state: m.state, debugBreak: m.debugBreak});
       },
     });
@@ -272,14 +272,14 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     }
   });
 
-  test('onDebugBreak for "after" sees the SOURCE state (substitution)', async () => {
+  test('onPause for "after" sees the SOURCE state (substitution)', async () => {
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const seen: Array<{state: State, debugBreak?: MachineState['debugBreak'], step: number}> = [];
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         seen.push({state: m.state, debugBreak: m.debugBreak, step: m.step});
       },
     });
@@ -299,7 +299,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.debugBreak?.after) calls.push('after');
         if (m.debugBreak?.before) calls.push('before');
       },
@@ -312,7 +312,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     expect(calls[0]).toBe('before'); // first visit, no prior after
   });
 
-  test('onDebugBreak can be async (run awaits it)', async () => {
+  test('onPause can be async (run awaits it)', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     let released = false;
@@ -323,13 +323,13 @@ describe('TuringMachine — run() with onDebugBreak', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: () => hookDone, // run() awaits this
+      onPause: () => hookDone, // run() awaits this
     });
 
     expect(released).toBe(true);
   });
 
-  test('onStep still fires on every yield, separate from onDebugBreak', async () => {
+  test('onStep still fires on every yield, separate from onPause', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const stepCount = {n: 0};
@@ -338,7 +338,7 @@ describe('TuringMachine — run() with onDebugBreak', () => {
     await machine.run({
       initialState: state,
       onStep: () => { stepCount.n += 1; },
-      onDebugBreak: () => { breakCount.n += 1; },
+      onPause: () => { breakCount.n += 1; },
     });
 
     expect(stepCount.n).toBeGreaterThan(0);
@@ -361,7 +361,7 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
     //   visit 3 head 'A'  → erase+right
     //   visit 4 head blank→ ifOtherSymbol → halt
     // debug.after = true matches every visit. Today only 3 after-fires reach
-    // onDebugBreak (visit 4's after has no anchor yield); v5 must drain it
+    // onPause (visit 4's after has no anchor yield); v5 must drain it
     // and produce 4.
     const {machine, state} = buildMachine();
     state.debug = {after: true};
@@ -369,7 +369,7 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
 
     await machine.run({
       initialState: state,
-      onDebugBreak: (m) => { if (m.debugBreak?.after) after.push(m); },
+      onPause: (m) => { if (m.debugBreak?.after) after.push(m); },
     });
 
     expect(after.length).toBe(4);

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -78,7 +78,14 @@ export default class TuringMachine {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
 
-    for (const machineState of generator) {
+    // Manual iteration so we can pick up the generator's RETURN value (the
+    // post-loop after-fire drain from #108 part 1, signalled when the
+    // halting iter armed an after).
+    let result = generator.next();
+
+    while (!result.done) {
+      const machineState = result.value;
+
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
       if (machineState.debugBreak?.after && onPause && prevYield) {
         await onPause({...prevYield, debugBreak: {after: true}});
@@ -94,11 +101,23 @@ export default class TuringMachine {
       }
 
       prevYield = machineState;
+      result = generator.next();
+    }
+
+    // #108 part 1: drain the halting iter's after-fire if it armed one.
+    // The generator returns a non-null tail when the last visited state's
+    // `state.debug.after` matched its symbol but the loop exited before a
+    // next yield could carry the metadata. We dispatch using the source
+    // (prevYield), matching the in-loop after-fire payload shape.
+    if (result.value && onPause && prevYield) {
+      await onPause({...prevYield, debugBreak: {after: true}});
     }
   }
 
-  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState> {
+  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState, MachineState | null> {
     const executionSymbol = Symbol('execution');
+    let lastYielded: MachineState | null = null;
+    let pendingAfterFromPrev = false;
 
     try {
       this.#tapeBlock[lockSymbol].check(executionSymbol);
@@ -113,7 +132,6 @@ export default class TuringMachine {
       }
 
       let i = 0;
-      let pendingAfterFromPrev = false;
 
       while (!state.isHalt) {
         if (i === stepsLimit) {
@@ -164,8 +182,11 @@ export default class TuringMachine {
           }
 
           yield yielded;
+          lastYielded = yielded;
 
-          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield.
+          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield
+          // (or, if this turns out to be the halting iter, on the post-loop
+          // drain — see #108 part 1).
           pendingAfterFromPrev = matchFilter(state.debug?.after, symbol);
 
           this.#tapeBlock.applyCommand(command, executionSymbol);
@@ -190,5 +211,16 @@ export default class TuringMachine {
     } finally {
       this.#tapeBlock[lockSymbol].unlock(executionSymbol);
     }
+
+    // #108 part 1: signal the after-fire armed by the halting iter so run()
+    // (or any direct generator consumer) can dispatch one final after-break.
+    // Returning the synthesized MachineState (rather than yielding it) keeps
+    // `for..of` consumers — which ignore the return value — unaffected; only
+    // consumers that opt in via manual iteration see the drain.
+    if (pendingAfterFromPrev && lastYielded) {
+      return {...lastYielded, debugBreak: {after: true}};
+    }
+
+    return null;
   }
 }

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -56,23 +56,37 @@ export default class TuringMachine {
     initialState,
     stepsLimit = 1e5,
     onStep,
-    onDebugBreak,
+    onPause,
   }: RunParameter & {
+    /**
+     * Sync, ~free hook fired on every iteration. Use for logging/tracing —
+     * the hot loop runs this without a microtask boundary, so it must not
+     * be async.
+     */
     onStep?: (machineState: MachineState) => void;
-    onDebugBreak?: (machineState: MachineState) => void | Promise<void>;
+    /**
+     * Async hook fired only when `state.debug[when]` matches at the current
+     * iteration. The promise is awaited inline, so the consumer can suspend
+     * execution by deferring its resolution. Use for pause-capable inspection
+     * (debugger UIs, conditional breakpoints in tests).
+     *
+     * Renamed from `onDebugBreak` in v5.0.0. The `m.debugBreak` payload field
+     * keeps its name (it describes the engine's reason for pausing).
+     */
+    onPause?: (machineState: MachineState) => void | Promise<void>;
   }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
 
     for (const machineState of generator) {
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
-      if (machineState.debugBreak?.after && onDebugBreak && prevYield) {
-        await onDebugBreak({...prevYield, debugBreak: {after: true}});
+      if (machineState.debugBreak?.after && onPause && prevYield) {
+        await onPause({...prevYield, debugBreak: {after: true}});
       }
 
       // 'before' (current step) — pass current machineState with only the before flag.
-      if (machineState.debugBreak?.before && onDebugBreak) {
-        await onDebugBreak({...machineState, debugBreak: {before: true}});
+      if (machineState.debugBreak?.before && onPause) {
+        await onPause({...machineState, debugBreak: {before: true}});
       }
 
       if (onStep instanceof Function) {

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -57,6 +57,7 @@ export default class TuringMachine {
     stepsLimit = 1e5,
     onStep,
     onPause,
+    debug = true,
   }: RunParameter & {
     /**
      * Sync, ~free hook fired on every iteration. Use for logging/tracing —
@@ -74,6 +75,18 @@ export default class TuringMachine {
      * keeps its name (it describes the engine's reason for pausing).
      */
     onPause?: (machineState: MachineState) => void | Promise<void>;
+    /**
+     * Master switch for `onPause` dispatch. When `false`, suppresses all
+     * pause-fires (before, after, and the post-loop after-drain) regardless
+     * of `state.debug` assignments. `onStep` is unaffected. Defaults to
+     * `true`.
+     *
+     * The `m.debugBreak` field is still populated on yields by the underlying
+     * generator (it's a property of the iteration, not of the consumer); only
+     * `run()`'s hook dispatch is gated. Direct `runStepByStep` consumers see
+     * the metadata regardless.
+     */
+    debug?: boolean;
   }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
     let prevYield: MachineState | null = null;
@@ -87,12 +100,12 @@ export default class TuringMachine {
       const machineState = result.value;
 
       // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
-      if (machineState.debugBreak?.after && onPause && prevYield) {
+      if (debug && machineState.debugBreak?.after && onPause && prevYield) {
         await onPause({...prevYield, debugBreak: {after: true}});
       }
 
       // 'before' (current step) — pass current machineState with only the before flag.
-      if (machineState.debugBreak?.before && onPause) {
+      if (debug && machineState.debugBreak?.before && onPause) {
         await onPause({...machineState, debugBreak: {before: true}});
       }
 
@@ -109,7 +122,7 @@ export default class TuringMachine {
     // `state.debug.after` matched its symbol but the loop exited before a
     // next yield could carry the metadata. We dispatch using the source
     // (prevYield), matching the in-loop after-fire payload shape.
-    if (result.value && onPause && prevYield) {
+    if (debug && result.value && onPause && prevYield) {
       await onPause({...prevYield, debugBreak: {after: true}});
     }
   }

--- a/test/examples.spec.ts
+++ b/test/examples.spec.ts
@@ -85,7 +85,7 @@ describe('README.md — Debugging breakpoints', () => {
     const {machine, myState} = buildExampleMachine();
     myState.debug = {before: true};
     let breakCount = 0;
-    await machine.run({initialState: myState, onDebugBreak: () => { breakCount += 1; }});
+    await machine.run({initialState: myState, onPause: () => { breakCount += 1; }});
     expect(breakCount).toBeGreaterThan(0);
   });
 
@@ -95,7 +95,7 @@ describe('README.md — Debugging breakpoints', () => {
     let symASeen = 0;
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => { if (m.currentSymbols[0] === 'A') symASeen += 1; },
+      onPause: (m) => { if (m.currentSymbols[0] === 'A') symASeen += 1; },
     });
     expect(symASeen).toBeGreaterThan(0);
   });
@@ -106,7 +106,7 @@ describe('README.md — Debugging breakpoints', () => {
     const order: Array<'before' | 'after'> = [];
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.debugBreak?.before) order.push('before');
         if (m.debugBreak?.after) order.push('after');
       },
@@ -121,7 +121,7 @@ describe('README.md — Debugging breakpoints', () => {
     let haltPause = false;
     await machine.run({
       initialState: myState,
-      onDebugBreak: (m) => {
+      onPause: (m) => {
         if (m.nextState === haltState && m.debugBreak?.before) haltPause = true;
       },
     });
@@ -143,7 +143,7 @@ describe('README.md — Debugging breakpoints', () => {
     expect(myState.debug!.before).toEqual([symA, ifOtherSymbol]);
   });
 
-  test('onStep + onDebugBreak fire independently', async () => {
+  test('onStep + onPause fire independently', async () => {
     const {machine, myState} = buildExampleMachine();
     myState.debug = {before: true};
     let stepCount = 0;
@@ -151,7 +151,7 @@ describe('README.md — Debugging breakpoints', () => {
     await machine.run({
       initialState: myState,
       onStep: () => { stepCount += 1; },
-      onDebugBreak: () => { breakCount += 1; },
+      onPause: () => { breakCount += 1; },
     });
     expect(stepCount).toBeGreaterThan(0);
     expect(breakCount).toBeGreaterThan(0);


### PR DESCRIPTION
Releases **v5.0.0** of all four packages: `@turing-machine-js/machine`, `@turing-machine-js/builder`, `@turing-machine-js/library-binary-numbers`, `@turing-machine-js/library-binary-numbers-bare`.

## Headline changes

| | Issue | Type | Package |
|---|---|---|---|
| Hook renamed `onDebugBreak` → `onPause` | [#110](https://github.com/mellonis/turing-machine-js/issues/110) | **BREAKING** | `machine` |
| `haltState.debug.after` rejected at write time | [#108](https://github.com/mellonis/turing-machine-js/issues/108) part 2 | **BREAKING** | `machine` |
| Halt-after-fire post-loop drain | [#108](https://github.com/mellonis/turing-machine-js/issues/108) part 1 | Fix | `machine` |
| `run({ debug: boolean })` flag | [#106](https://github.com/mellonis/turing-machine-js/issues/106) | Additive | `machine` |
| `debug` parameter on `buildMachine()` | [#101](https://github.com/mellonis/turing-machine-js/issues/101) | Additive | `builder` |
| Peer-dep `^4.0.0` → `^5.0.0` | — | Lockstep | `builder`, `library-binary-numbers`, `library-binary-numbers-bare` |

## Migration

See the v5.0.0 entries in:
- [`packages/machine/CHANGELOG.md`](packages/machine/CHANGELOG.md) — rename diff block, halt-rejection rationale, debug-flag semantics.
- [`packages/builder/CHANGELOG.md`](packages/builder/CHANGELOG.md) — `debug` parameter API, build-time validation, peer-dep widening.

The two `library-binary-numbers*` packages are pure lockstep peer-dep widenings (no source changes).

## RFC closed in this release

- [#109](https://github.com/mellonis/turing-machine-js/issues/109) — `onStep` + `onDebugBreak` relationship. Resolved as a rename (#110); see comments on #109 and the [PR #111 description](https://github.com/mellonis/turing-machine-js/pull/111) for the design walkthrough.

## Postponed to v5.1

- [#102](https://github.com/mellonis/turing-machine-js/issues/102) — step-in / step-out / step-over (IDE-style debugger UX, larger feature).
- [#107](https://github.com/mellonis/turing-machine-js/issues/107) — un-substituted `MachineState` for after-break consumers (only consumer is #102).

Both labeled `v5.1`.

## Verification

- `npm test`: **638 passed, 0 failed**.
- `npm run lint`: clean.
- `npx tsc --build`: clean.
- CI green on all 5 PRs that landed on v5 (#111, #112, #113, #114, #115).

## After merge

1. `git checkout master && git pull`
2. `git tag v5.0.0 && git push origin v5.0.0`
3. `npx lerna publish from-git`
4. Once publish succeeds: delete `v5` (`git push origin --delete v5`) and the v5 branch protection rule.
5. Follow-up cosmetic commit on master to drop `v5` from `.github/workflows/main.yml`'s trigger list.

Closes #110, #108, #106, #101.
