### PR TITLE
chore(ci): drop v5 from main.yml branch triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   pull_request:
-    branches: [ master, next, v5 ]
+    branches: [ master, next ]
   workflow_dispatch: # allow manual trigger from the Actions tab
 
 jobs:


### PR DESCRIPTION
The v5 integration branch was deleted after v5.0.0 shipped — tag pushed to master ([\`v5.0.0\`](https://github.com/mellonis/turing-machine-js/releases/tag/v5.0.0)), packages published, GitHub Release marked Latest. Removing \`v5\` from \`main.yml\`'s \`push\` and \`pull_request\` branch filters since the branch no longer exists.

Cosmetic — the workflow simply wouldn't fire on the non-existent branch otherwise.

If a v5.x patch series is ever needed, branch from the \`v5.0.0\` tag at that point and add the branch name back to the trigger list as part of that work.