### PR TITLE
Release v6.0.0: collapse after-fire dispatch (#119, closes #107)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.0.0",
+  "version": "6.0.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14020,40 +14020,40 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^5.0.0"
+        "@turing-machine-js/machine": "^6.0.0"
       }
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^5.0.0"
+        "@turing-machine-js/machine": "^6.0.0"
       }
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^5.0.0"
+        "@turing-machine-js/machine": "^6.0.0"
       }
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^5.0.0` to `^6.0.0`** to match the v6 lockstep. Consumers pinned to `@turing-machine-js/machine@5` will see an unmet-peer warning when installing this version. The v6 dispatch-order change in the engine ([#119](https://github.com/mellonis/turing-machine-js/issues/119)) doesn't affect this package directly (the builder doesn't call `run()`).
+
+Released in lockstep with `@turing-machine-js/machine` 6.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [5.0.0] - 2026-05-09
 
 ### Added

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "builder"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^5.0.0"
+    "@turing-machine-js/machine": "^6.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -122,9 +122,9 @@ describe('buildMachine — debug config (#101)', () => {
     expect(pausedSymbols).toEqual(['A', 'A']);
   });
 
-  test('debug.after symbol-list fires post-loop drain on halting iter (with #108 fix)', async () => {
-    // 'B' triggers the halting transition; after-fire on B should reach onPause
-    // via the post-loop drain landed in #108.
+  test('debug.after symbol-list fires on the halting iter\'s own yield', async () => {
+    // 'B' triggers the halting transition; the after-fire for B reaches
+    // onPause on B's own yield (post-#119 dispatch model).
     const [machine, init] = buildLoopMachine({Q0: {after: ['B']}});
     machine.tapeBlock.replaceTape(new Tape({
       alphabet: machine.tapeBlock.alphabets[0],

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^5.0.0` to `^6.0.0`** to match the v6 lockstep. Consumers pinned to `@turing-machine-js/machine@5` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 6.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [5.0.0] - 2026-05-09
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,7 +28,7 @@
     "teaching"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^5.0.0"
+    "@turing-machine-js/machine": "^6.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`peerDependencies."@turing-machine-js/machine"` widened from `^5.0.0` to `^6.0.0`** to match the v6 lockstep. Consumers pinned to `@turing-machine-js/machine@5` will see an unmet-peer warning when installing this version.
+
+Released in lockstep with `@turing-machine-js/machine` 6.0.0. No source or behavior changes in this package beyond the peer-dep widening.
+
 ## [5.0.0] - 2026-05-09
 
 ### Changed (BREAKING)

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"
@@ -27,7 +27,7 @@
     "numbers"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^5.0.0"
+    "@turing-machine-js/machine": "^6.0.0"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-05-09
+
+### Changed (BREAKING)
+
+- **`onPause` dispatch order rewritten** ([#119](https://github.com/mellonis/turing-machine-js/issues/119)). `onPause(after, K)` now fires on iter K's *own* yield, alongside `onPause(before, K)` and `onStep(K)` — instead of v5's behavior of firing on iter K+1's yield with a `prevYield` substitution. The set of dispatched calls per run and per-iter semantics are unchanged; only the cross-hook *sequence* differs. Per-iter lifecycle inside `run()` is now `before → step → after`. Consumers using both `onStep` and `onPause` and asserting cross-hook ordering must update; consumers treating the hooks as independent observers see no change.
+
+  Subordinate consequences:
+  - `onPause(after)` carries the iteration's own `MachineState` directly — no `prevYield` substitution dance.
+  - `runStepByStep` no longer tracks `pendingAfterFromPrev` across yields; `debugBreak.after` on a yield refers to *that* iter's after-arm.
+  - The v5 post-loop after-fire drain (#108 part 1) collapses — the halting iter's after rides along on its own yield like any other iter.
+  - The generator's return type narrows back from `Generator<MachineState, MachineState | null>` to `Generator<MachineState>`; `for..of` consumers (the canonical pattern) are unaffected.
+
+### Closes
+
+- [#107](https://github.com/mellonis/turing-machine-js/issues/107) — "expose un-substituted `machineState` for after-break consumers" disappears as a problem: there is no substitution to expose around.
+
+### Migration
+
+No call-site change to `run()`'s API:
+
+```ts
+await machine.run({
+  initialState,
+  onStep:  (m) => { /* unchanged */ },
+  onPause: (m) => {
+    if (m.debugBreak?.before) console.log('before:', m.state.name);
+    if (m.debugBreak?.after)  console.log('after:',  m.state.name);
+  },
+});
+```
+
+Tests asserting the v5 sequence (`pause(after K-1) → pause(before K) → step(K)`) need updating to the v6 sequence (`pause(before K) → step(K) → pause(after K)`).
+
 ## [5.0.0] - 2026-05-09
 
 ### Changed (BREAKING)

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -270,7 +270,7 @@ await machine.run({
 });
 ```
 
-For `after` calls, `m` is the previous yield's snapshot — `m.state` is the state whose `after` filter fired. For `before` calls, `m` is the current iteration. `onStep` always sees the original (un-substituted) yield.
+Both `before` and `after` for the same iteration fire on the iteration's own yield, in the order **before → step → after**. `m.state` is always the iteration's own state; the `m.debugBreak` flag (`{before: true}` or `{after: true}`) tells the consumer which timing fired.
 
 If `onPause` is not provided, breaks fire-and-resume invisibly — the trajectory is identical to running without `debug` set.
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -99,39 +99,38 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
 });
 
 describe('TuringMachine — debug.after filter (loop yields)', () => {
-  test('debug.after = true tags the NEXT yield with debugBreak.after', () => {
+  // v6.0.0 (#119): both `before` and `after` refer to THIS iter, dispatched
+  // on the same yield. Previously `after` was on the NEXT yield with a
+  // substituted source-state payload — see #109/#119 for the rationale.
+
+  test('debug.after = true tags every yield with debugBreak.after', () => {
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const steps: MachineState[] = [];
 
     machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
-    // First yield: state had no prior — no after.
-    expect(steps[0]).not.toHaveProperty('debugBreak');
-    // Subsequent yields all carry debugBreak.after (because every prev
-    // visit was at this state with after=true matching wildcard).
-    for (let i = 1; i < steps.length; i++) {
-      expect(steps[i].debugBreak).toEqual({after: true});
+    // Every yield (including the first) carries debugBreak.after because the
+    // wildcard filter matches every visit's resolved symbol.
+    expect(steps.length).toBeGreaterThan(0);
+    for (const step of steps) {
+      expect(step.debugBreak).toEqual({after: true});
     }
   });
 
-  // (Removed in v5 — the "by-design lost" semantics on halting after-fires
-  // was a #108 bug, not a design choice. The new behavior is verified in the
-  // dedicated `halt semantics for after-fire (#108)` describe block below,
-  // which exercises the run()-level drain.)
-
-  test('before AND after on same visit produce both flags on the relevant yields', () => {
+  test('before AND after on same visit produce both flags on every yield', () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true, after: true};
     const steps: MachineState[] = [];
 
     machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
-    // First yield: only before (no prior after).
-    expect(steps[0].debugBreak).toEqual({before: true});
-    // Middle yields: both flags (prev's after AND current's before).
-    for (let i = 1; i < steps.length - 1; i++) {
-      expect(steps[i].debugBreak).toEqual({before: true, after: true});
+    // No "first yield is special" anymore: each iter's before and after both
+    // refer to that iter, so both flags appear together on every yield where
+    // the wildcard filters match.
+    expect(steps.length).toBeGreaterThan(0);
+    for (const step of steps) {
+      expect(step.debugBreak).toEqual({before: true, after: true});
     }
   });
 
@@ -143,13 +142,13 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
 
     machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
-    // The 'after' fires on yield N+1 if yield N's state had symA on the head.
-    for (let i = 1; i < steps.length; i++) {
-      const prev = steps[i - 1];
-      if (prev.currentSymbols[0] === 'A') {
-        expect(steps[i].debugBreak).toEqual({after: true});
+    // The 'after' fires on yield N if yield N's resolved symbol matches the
+    // filter (no longer "yield N+1 if yield N's symbol matched").
+    for (const step of steps) {
+      if (step.currentSymbols[0] === 'A') {
+        expect(step.debugBreak).toEqual({after: true});
       } else {
-        expect(steps[i]).not.toHaveProperty('debugBreak');
+        expect(step).not.toHaveProperty('debugBreak');
       }
     }
   });
@@ -264,7 +263,7 @@ describe('TuringMachine — run() with onPause', () => {
     }
   });
 
-  test('onPause for "after" sees the SOURCE state (substitution)', async () => {
+  test('onPause for "after" carries the same iter\'s state', async () => {
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const seen: Array<{state: State, debugBreak?: MachineState['debugBreak'], step: number}> = [];
@@ -276,15 +275,16 @@ describe('TuringMachine — run() with onPause', () => {
       },
     });
 
-    // Every after-call should show m.state === source state (the one whose
-    // after fired) — that's our buildMachine state since it's a single-state graph.
+    // v6.0.0: the after-call's `m.state` is the iter that armed the after
+    // (no substitution dance — `before` and `after` for the SAME iter both
+    // fire on that iter's own yield).
     for (const entry of seen) {
       expect(entry.state).toBe(state);
       expect(entry.debugBreak).toEqual({after: true});
     }
   });
 
-  test('both "before" and "after" on same yield → two hook calls in order', async () => {
+  test('both "before" and "after" on same yield → two hook calls in lifecycle order', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true, after: true};
     const calls: Array<'before' | 'after'> = [];
@@ -292,16 +292,18 @@ describe('TuringMachine — run() with onPause', () => {
     await machine.run({
       initialState: state,
       onPause: (m) => {
-        if (m.debugBreak?.after) calls.push('after');
         if (m.debugBreak?.before) calls.push('before');
+        if (m.debugBreak?.after) calls.push('after');
       },
     });
 
-    // For each "middle" yield (not first), pattern is: ['after', 'before', 'after', 'before', ...].
-    // First yield only has 'before'. Verify ordering: every 'after' is followed
-    // (eventually) by 'before' of the same yield.
+    // v6.0.0 per-iter lifecycle: before → step → after. Every yield (including
+    // the first) dispatches both hooks in this order.
     expect(calls.length).toBeGreaterThan(0);
-    expect(calls[0]).toBe('before'); // first visit, no prior after
+    // Pattern is purely alternating: [before, after, before, after, ...].
+    for (let i = 0; i < calls.length; i++) {
+      expect(calls[i]).toBe(i % 2 === 0 ? 'before' : 'after');
+    }
   });
 
   test('onPause can be async (run awaits it)', async () => {
@@ -338,11 +340,6 @@ describe('TuringMachine — run() with onPause', () => {
   });
 });
 
-// These tests assert the v5 spec from #108. They are intentionally RED on the
-// v4 codebase — they turn green when the loop-drain fix and haltState rejection
-// land. The "after on a transition leading to halt is silently lost" test in
-// the second describe above (currently labelled by-design) is contradicted by
-// part-1 below and will be updated in lockstep with the fix.
 describe('TuringMachine — halt semantics for after-fire (#108)', () => {
   afterEach(() => { haltState.debug = null; });
 
@@ -352,9 +349,8 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
     //   visit 2 head 'B'  → erase+right
     //   visit 3 head 'A'  → erase+right
     //   visit 4 head blank→ ifOtherSymbol → halt
-    // debug.after = true matches every visit. Today only 3 after-fires reach
-    // onPause (visit 4's after has no anchor yield); v5 must drain it
-    // and produce 4.
+    // debug.after = true matches every visit. v6.0.0 (#119) dispatches the
+    // halting iter's after directly on its own yield, so all 4 visits fire.
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const after: MachineState[] = [];
@@ -403,9 +399,9 @@ describe('TuringMachine — run({debug}) flag (#106)', () => {
     expect(pauses).toHaveLength(0);
   });
 
-  test('debug: false suppresses onPause for "after" matches AND the halting drain', async () => {
-    // With state.debug.after = true, the in-loop after-fires plus the #108
-    // post-loop drain would normally produce one onPause call per visit. The
+  test('debug: false suppresses onPause for "after" matches (every visit, including halting iter)', async () => {
+    // With state.debug.after = true, every visit normally produces an
+    // after-fire dispatch (including the halting iter, post-#108/#119). The
     // master switch must gate all of them.
     const {machine, state} = buildMachine();
     state.debug = {after: true};

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -225,3 +225,12 @@ describe('parallel execution with same tape block', () => {
     }).not.toThrow();
   });
 });
+
+describe('TuringMachine constructor', () => {
+  test('throws when tapeBlock is missing', () => {
+    // The constructor's destructured tapeBlock has a default of {} — calling
+    // without arguments hits the validator's "no tapeBlock" branch.
+    expect(() => new TuringMachine()).toThrow(/invalid tapeBlock/);
+    expect(() => new TuringMachine({} as never)).toThrow(/invalid tapeBlock/);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -12,13 +12,15 @@ export type MachineState = {
   movements: symbol[];
   nextState: State;
   /**
-   * Set only when this iteration boundary is a debug break.
+   * Set only when this iteration is a debug break point.
    * Field is OMITTED entirely when no break fires (no `debugBreak: undefined`).
    * At least one of `before` / `after` is `true` when the field is present.
    *
-   * For consumers of the `runStepByStep` generator the `state` field reflects
-   * the current iteration regardless of timing; `run()` substitutes the prior
-   * yield's snapshot for `after` calls so consumers see the source state.
+   * Both flags refer to THIS iter — `before` means the iter's `state.debug.before`
+   * matched, `after` means the iter's `state.debug.after` matched. `run()`
+   * dispatches the two timings as separate `onPause` calls (before-call has
+   * `debugBreak: {before: true}` only; after-call has `debugBreak: {after: true}`
+   * only) so consumers can distinguish without ambiguity.
    */
   debugBreak?: {
     before?: true;
@@ -66,20 +68,23 @@ export default class TuringMachine {
      */
     onStep?: (machineState: MachineState) => void;
     /**
-     * Async hook fired only when `state.debug[when]` matches at the current
+     * Async hook fired when `state.debug[when]` matches at the current
      * iteration. The promise is awaited inline, so the consumer can suspend
      * execution by deferring its resolution. Use for pause-capable inspection
      * (debugger UIs, conditional breakpoints in tests).
      *
-     * Renamed from `onDebugBreak` in v5.0.0. The `m.debugBreak` payload field
-     * keeps its name (it describes the engine's reason for pausing).
+     * Renamed from `onDebugBreak` in v5.0.0. In v6.0.0 the dispatch order
+     * was changed so that `before` and `after` for the SAME iter fire on the
+     * same yield (per-iter lifecycle: before → step → after); previously the
+     * `after` of iter K fired on iter K+1's tick with a substituted source
+     * view. The `m.debugBreak` payload field keeps its name (it describes the
+     * engine's reason for pausing).
      */
     onPause?: (machineState: MachineState) => void | Promise<void>;
     /**
      * Master switch for `onPause` dispatch. When `false`, suppresses all
-     * pause-fires (before, after, and the post-loop after-drain) regardless
-     * of `state.debug` assignments. `onStep` is unaffected. Defaults to
-     * `true`.
+     * pause-fires (before and after) regardless of `state.debug` assignments.
+     * `onStep` is unaffected. Defaults to `true`.
      *
      * The `m.debugBreak` field is still populated on yields by the underlying
      * generator (it's a property of the iteration, not of the consumer); only
@@ -89,22 +94,11 @@ export default class TuringMachine {
     debug?: boolean;
   }): Promise<void> {
     const generator = this.runStepByStep({initialState, stepsLimit});
-    let prevYield: MachineState | null = null;
 
-    // Manual iteration so we can pick up the generator's RETURN value (the
-    // post-loop after-fire drain from #108 part 1, signalled when the
-    // halting iter armed an after).
-    let result = generator.next();
-
-    while (!result.done) {
-      const machineState = result.value;
-
-      // 'after' (from prev step) — fire FIRST, with prev yield substituted as the source view.
-      if (debug && machineState.debugBreak?.after && onPause && prevYield) {
-        await onPause({...prevYield, debugBreak: {after: true}});
-      }
-
-      // 'before' (current step) — pass current machineState with only the before flag.
+    for (const machineState of generator) {
+      // Per-iter lifecycle: before → step → after. All three operate on the
+      // same yielded MachineState, so the consumer sees a coherent ordering
+      // within each iteration without cross-tick coordination.
       if (debug && machineState.debugBreak?.before && onPause) {
         await onPause({...machineState, debugBreak: {before: true}});
       }
@@ -113,24 +107,14 @@ export default class TuringMachine {
         onStep(machineState);
       }
 
-      prevYield = machineState;
-      result = generator.next();
-    }
-
-    // #108 part 1: drain the halting iter's after-fire if it armed one.
-    // The generator returns a non-null tail when the last visited state's
-    // `state.debug.after` matched its symbol but the loop exited before a
-    // next yield could carry the metadata. We dispatch using the source
-    // (prevYield), matching the in-loop after-fire payload shape.
-    if (debug && result.value && onPause && prevYield) {
-      await onPause({...prevYield, debugBreak: {after: true}});
+      if (debug && machineState.debugBreak?.after && onPause) {
+        await onPause({...machineState, debugBreak: {after: true}});
+      }
     }
   }
 
-  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState, MachineState | null> {
+  * runStepByStep({initialState, stepsLimit = 1e5}: RunParameter): Generator<MachineState> {
     const executionSymbol = Symbol('execution');
-    let lastYielded: MachineState | null = null;
-    let pendingAfterFromPrev = false;
 
     try {
       this.#tapeBlock[lockSymbol].check(executionSymbol);
@@ -158,8 +142,12 @@ export default class TuringMachine {
         let nextState = state.getNextState(symbol).ref;
 
         try {
+          // Both before and after refer to THIS iter (#119 / v6.0.0).
+          // The halting iter's after-fire just rides along on the iter's
+          // own yield — no post-loop drain needed.
           const beforeMatch = matchFilter(state.debug?.before, symbol)
             || (nextState.isHalt && nextState.debug?.before === true);
+          const afterMatch = matchFilter(state.debug?.after, symbol);
 
           const nextStateForYield = nextState.isHalt && stack.length
             ? stack.slice(-1)[0]
@@ -187,20 +175,14 @@ export default class TuringMachine {
             nextState: nextStateForYield,
           };
 
-          if (pendingAfterFromPrev || beforeMatch) {
+          if (beforeMatch || afterMatch) {
             const dbg: { before?: true; after?: true } = {};
-            if (pendingAfterFromPrev) dbg.after = true;
             if (beforeMatch) dbg.before = true;
+            if (afterMatch) dbg.after = true;
             yielded.debugBreak = dbg;
           }
 
           yield yielded;
-          lastYielded = yielded;
-
-          // Re-evaluate 'after' for THIS visit, to fire on the NEXT yield
-          // (or, if this turns out to be the halting iter, on the post-loop
-          // drain — see #108 part 1).
-          pendingAfterFromPrev = matchFilter(state.debug?.after, symbol);
 
           this.#tapeBlock.applyCommand(command, executionSymbol);
 
@@ -224,16 +206,5 @@ export default class TuringMachine {
     } finally {
       this.#tapeBlock[lockSymbol].unlock(executionSymbol);
     }
-
-    // #108 part 1: signal the after-fire armed by the halting iter so run()
-    // (or any direct generator consumer) can dispatch one final after-break.
-    // Returning the synthesized MachineState (rather than yielding it) keeps
-    // `for..of` consumers — which ignore the return value — unaffected; only
-    // consumers that opt in via manual iteration see the drain.
-    if (pendingAfterFromPrev && lastYielded) {
-      return {...lastYielded, debugBreak: {after: true}};
-    }
-
-    return null;
   }
 }


### PR DESCRIPTION
Releases **v6.0.0**: collapses the dispatch-tick asymmetry between `onStep(K)` and `onPause(after, K)` that surfaced after v5 shipped, plus the lockstep version bump.

Closes #119, #107.

## What changes

`onPause(after, K)` now fires on iter K's own yield, alongside `onPause(before, K)` and `onStep(K)` — instead of v5's behavior of firing on iter K+1's yield with a `prevYield` substitution. Per-iter lifecycle inside `run()` is now `before → step → after`.

| Hook | v5 timing | v6 timing |
|---|---|---|
| `onPause(before, K)` | yield K | yield K |
| `onStep(K)` | yield K | yield K |
| `onPause(after, K)` | yield K+1 (with `prevYield` substitution) | yield K |

The set of dispatched calls and per-iter semantics are unchanged. Only the cross-hook *sequence* differs. Major bump → v6.0.0.

## Subordinate consequences

- `onPause(after)` carries the iteration's own `MachineState` directly — no `prevYield` substitution dance. **Closes #107.**
- `runStepByStep` no longer tracks `pendingAfterFromPrev` across yields; `debugBreak.after` on a yield refers to *that* iter's after-arm.
- The v5 post-loop after-fire drain ([#108](https://github.com/mellonis/turing-machine-js/issues/108) part 1) collapses — the halting iter's after rides along on its own yield like any other iter.
- Generator return type narrows back from `Generator<MachineState, MachineState | null>` to `Generator<MachineState>`; `for..of` consumers (the canonical pattern) are unaffected.

## Test changes

- Three tests in `TuringMachine.debug.spec.ts`'s `debug.after filter (loop yields)` describe block updated for the new "fires on same yield" behavior:
  - "tags every yield with debugBreak.after" (was "tags the NEXT yield…").
  - "before AND after on same visit produce both flags on every yield" (was "on the relevant yields").
  - "after with symbol list matches only listed symbols" — the assertion now reads from the *current* yield, not yield N+1.
- Test name updates (no behavior change): "onPause for 'after' carries the same iter's state" (was "sees the SOURCE state (substitution)"). Builder spec test title updated similarly. Comments referencing "post-loop drain" replaced with "halting iter's own yield."

## Migration

No call-site change to `run()`'s API. Consumer code that uses `onPause` only — or uses both `onStep` and `onPause` independently — needs no update.

Tests asserting the v5 cross-hook sequence (`pause(after K-1) → pause(before K) → step(K)`) need updating to the v6 sequence (`pause(before K) → step(K) → pause(after K)`).

## Lockstep

`builder` / `library-binary-numbers` / `library-binary-numbers-bare` all bumped to `6.0.0` with peer-dep widening to `^6.0.0`. No source changes in those three packages beyond the peer-dep.

## Verification

- `npm test`: **638 passed, 0 failed**.
- `npm run lint`: clean.
- `npx tsc --build`: clean.

## After merge (release flow)

1. `git tag v6.0.0 && git push origin v6.0.0`
2. `npx lerna publish from-package --yes`
3. Create GitHub Release for `v6.0.0`.
4. Drop the cleanup commit on `main.yml`'s trigger list (no `v6` was ever added since we went direct-to-master this time).
