### PR TITLE
chore: update author email in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint ."
   },
-  "author": "Ruslan Gilmullin <mellonis14@gmain.com>",
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=7.0.0"
   },
-  "author": "Ruslan Gilmullin <mellonis14@gmain.com>",
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "homepage": "https://github.com/mellonis/turing-machine-js#readme",
   "license": "GPL-3.0-or-later",
   "publishConfig": {

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=7.0.0"
   },
-  "author": "Ruslan Gilmullin <mellonis14@gmain.com>",
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "homepage": "https://github.com/mellonis/turing-machine-js#readme",
   "license": "GPL-3.0-or-later",
   "publishConfig": {

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=7.0.0"
   },
-  "author": "Ruslan Gilmullin <mellonis14@gmain.com>",
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "homepage": "https://github.com/mellonis/turing-machine-js#readme",
   "license": "GPL-3.0-or-later",
   "publishConfig": {

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=7.0.0"
   },
-  "author": "Ruslan Gilmullin <mellonis14@gmain.com>",
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "homepage": "https://github.com/mellonis/turing-machine-js#readme",
   "license": "GPL-3.0-or-later",
   "publishConfig": {


### PR DESCRIPTION
Updates the \`author\` field across all 5 \`package.json\` files (root + 4 publishable packages):

\`\`\`diff
- \"author\": \"Ruslan Gilmullin <mellonis14@gmain.com>\",
+ \"author\": \"Ruslan Gilmullin <mellonis@yandex.ru>\",
\`\`\`

Replaces the legacy email (which had a typo — \`gmain.com\` instead of \`gmail.com\`) with the preferred address. Effects on npm: future publishes (v6.0.1+) carry the new author info; already-published versions on the registry keep their original author info forever — that's an immutable property of each published version.

Trivial 5-line change. No test/lint/build impact.