### PR TITLE
chore(test): tighten vitest config (clearMocks, coverage.all, thresholds)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ const root = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   test: {
     globals: true,
+    // Reset call-history of vi.fn()/vi.spyOn() between tests so state
+    // can't leak across the few tests that use mocks.
+    clearMocks: true,
     include: [
       'packages/*/src/**/*.spec.ts',
       'test/**/*.spec.ts',
@@ -14,16 +17,31 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],
+      // Surface untested files in the report instead of ignoring files that
+      // were never imported during the test run.
+      all: true,
       include: ['packages/*/src/**/*.ts'],
       exclude: [
         '**/*.spec.ts',
+        '**/*.d.ts',
         '**/dist/**',
+        'vitest.config.ts',
       ],
+      // Hard floor for `npm run test:coverage` (CI). Daily `npm test` is
+      // unaffected (no coverage run). Numbers chosen as ~current floor with
+      // 1-2pt headroom — tighten if real coverage climbs.
+      thresholds: {
+        statements: 97,
+        branches: 90,
+        functions: 95,
+        lines: 97,
+      },
     },
   },
   resolve: {
-    // Source-import aliases — match the moduleNameMapper from jest.config.mjs
-    // so per-package specs resolve to source instead of requiring a prior build.
+    // Source-import aliases — same set the moduleNameMapper from the previous
+    // jest.config.mjs files mapped, so per-package specs resolve to source
+    // instead of requiring a prior build.
     alias: {
       '@turing-machine-js/machine': resolve(root, './packages/machine/src'),
       '@turing-machine-js/builder': resolve(root, './packages/builder/src'),


### PR DESCRIPTION
Audit of the just-migrated vitest setup. Four guardrails that cost nothing today but catch regressions later.

## Changes

| Setting | Before | After | Rationale |
|---|---|---|---|
| \`clearMocks\` | (default false) | \`true\` | Reset \`vi.fn()\` call history between tests — prevents mock state leak. We have one mock-using test today; free hygiene that scales. |
| \`coverage.all\` | (default false) | \`true\` | Files matching \`coverage.include\` but never imported during a test run are now reported (0% if untested). Surfaces new-untested-file gaps previously invisible. |
| \`coverage.exclude\` | \`['**/*.spec.ts', '**/dist/**']\` | + \`'**/*.d.ts'\`, \`'vitest.config.ts'\` | Ambient type files aren't executable; the config file shouldn't count toward source coverage. |
| \`coverage.thresholds\` | (none) | 97/90/95/97 | Hard floor for \`npm run test:coverage\`. Daily \`npm test\` unaffected (no coverage run). Numbers chosen as current floor + 1-2pt headroom. |

## What I considered and rejected

- **\`test.projects\` for monorepo displayName parity with jest.** With 4 packages × 21 specs, 5 project blocks of config isn't worth the per-package output label. \`vitest run packages/machine\` already filters by path. Skip unless we find ourselves wanting \`vitest run --project machine\` regularly.
- **Per-package vitest configs.** Same reason — single root config is simpler, no per-project setup needs.
- **Renaming \`*.spec.ts\` → \`*.test.ts\`** to match vitest defaults. Would be 21 file renames; our explicit \`include\` already covers it. No real benefit.

## Verification

- \`npm run test:coverage\`: 326 pass, all thresholds satisfied (98.85% statements / 94.87% branches / 100% functions / 98.8% lines vs 97/90/95/97 floors).
- \`npm test\`: 326 pass.
- \`npm run lint\`: clean.

## Future test work (separate PR)

The other side request — \"please review tests, maybe they are weak\" — gets its own focused PR. This one only touches config.