### PR TITLE
test(library-binary-numbers): move states.md doc-gen out of tests, structural specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "docs:states": "node ./scripts/build-states-md.mjs",
     "lint": "eslint ."
   },
   "author": "Ruslan Gilmullin <mellonis@yandex.ru>",

--- a/packages/library-binary-numbers-bare/src/graphs.spec.ts
+++ b/packages/library-binary-numbers-bare/src/graphs.spec.ts
@@ -1,35 +1,76 @@
-import {writeFileSync} from 'node:fs';
-import {resolve} from 'node:path';
-import {State, toMermaid} from '@turing-machine-js/machine';
+import {State, fromMermaid, toMermaid} from '@turing-machine-js/machine';
 import binaryNumbersBare from './index';
 
-describe('library-binary-numbers-bare state graphs', () => {
-  test('renders Mermaid for every exported state', () => {
-    const sections: string[] = ['# library-binary-numbers-bare — state graphs', ''];
-    const stateNames = Object.keys(binaryNumbersBare.states) as Array<keyof typeof binaryNumbersBare.states>;
+// Per-state node counts pinned from the source comments above each declaration
+// in `index.ts`. Each count includes haltState. The bare-alphabet variants are
+// notably smaller than their marker-based siblings — the headline trade-off
+// this library exists to demonstrate.
+const expectedNodeCount: Record<keyof typeof binaryNumbersBare['states'], number> = {
+  plusOne: 3,
+  minusOne: 3,
+  invertNumber: 2,
+  normalizeNumber: 2,
+};
 
-    for (const name of stateNames) {
+const stateNames = Object.keys(expectedNodeCount) as Array<keyof typeof expectedNodeCount>;
+
+describe('library-binary-numbers-bare state graphs', () => {
+  test.each(stateNames)(
+    '%s: toGraph produces the documented node count',
+    (name) => {
       const tapeBlock = binaryNumbersBare.getTapeBlock();
       const graph = State.toGraph(binaryNumbersBare.states[name], tapeBlock);
-      const mermaid = toMermaid(graph);
-      const nodeCount = Object.keys(graph.nodes).length;
 
-      sections.push(`## ${name}`);
-      sections.push('');
-      sections.push(`*${nodeCount} state${nodeCount === 1 ? '' : 's'} (including \`haltState\`)*`);
-      sections.push('');
-      sections.push('```mermaid');
-      sections.push(mermaid);
-      sections.push('```');
-      sections.push('');
+      expect(Object.keys(graph.nodes)).toHaveLength(expectedNodeCount[name]);
+    },
+  );
+
+  test.each(stateNames)(
+    '%s: graph has at least one halt-reachable node',
+    (name) => {
+      const tapeBlock = binaryNumbersBare.getTapeBlock();
+      const graph = State.toGraph(binaryNumbersBare.states[name], tapeBlock);
+
+      const haltNodes = Object.values(graph.nodes).filter((node) => node.isHalt);
+
+      expect(haltNodes).toHaveLength(1);
+    },
+  );
+
+  test.each(stateNames)(
+    '%s: toMermaid → fromMermaid round-trips with the same node count',
+    (name) => {
+      const tapeBlock = binaryNumbersBare.getTapeBlock();
+      const original = State.toGraph(binaryNumbersBare.states[name], tapeBlock);
+
+      const mermaid = toMermaid(original);
+      const reparsed = fromMermaid(mermaid);
+
+      expect(Object.keys(reparsed.nodes)).toHaveLength(Object.keys(original.nodes).length);
+      expect(mermaid).toMatch(/^flowchart\s+(?:LR|TD|TB|RL|BT)/);
+    },
+  );
+
+  test('every state in the public surface has a documented count', () => {
+    const exportedNames = Object.keys(binaryNumbersBare.states).sort();
+    const documentedNames = stateNames.slice().sort();
+
+    expect(exportedNames).toEqual(documentedNames);
+  });
+
+  test('bare-library algorithms are at most half the size of their marker-based siblings', () => {
+    // Headline claim of this paired library: the 3-symbol alphabet trade-off
+    // is "smaller graphs, multi-number tapes lost". This pins a numerical
+    // version of that claim.
+    const sharedAlgorithms = ['plusOne', 'minusOne', 'invertNumber', 'normalizeNumber'] as const;
+
+    for (const name of sharedAlgorithms) {
+      const bareSize = expectedNodeCount[name];
+      // Reference numbers from library-binary-numbers (asserted in its sibling
+      // graphs.spec.ts):
+      const markerSize = {plusOne: 5, minusOne: 17, invertNumber: 5, normalizeNumber: 7}[name];
+
+      expect(bareSize * 2).toBeLessThanOrEqual(markerSize + 1);
     }
-
-    const output = sections.join('\n');
-    const outputPath = resolve(__dirname, '..', 'states.md');
-
-    writeFileSync(outputPath, output);
-
-    expect(output.length).toBeGreaterThan(0);
-    expect(stateNames.length).toBeGreaterThan(0);
   });
 });

--- a/packages/library-binary-numbers/src/graphs.spec.ts
+++ b/packages/library-binary-numbers/src/graphs.spec.ts
@@ -1,35 +1,74 @@
-import {writeFileSync} from 'node:fs';
-import {resolve} from 'node:path';
-import {State, toMermaid} from '@turing-machine-js/machine';
+import {State, fromMermaid, toMermaid} from '@turing-machine-js/machine';
 import binaryNumbers from './index';
 
-describe('library-binary-numbers state graphs', () => {
-  test('renders Mermaid for every exported state', () => {
-    const sections: string[] = ['# library-binary-numbers — state graphs', ''];
-    const stateNames = Object.keys(binaryNumbers.states) as Array<keyof typeof binaryNumbers.states>;
+// Per-state node counts pinned from the source comments above each declaration
+// in `index.ts`. Each count includes haltState (`State.toGraph` walks the full
+// reachable graph, and every algorithm transitions to halt). Regressions caught:
+// a refactor that accidentally grows or shrinks an algorithm's state graph
+// fails this table.
+const expectedNodeCount: Record<keyof typeof binaryNumbers['states'], number> = {
+  goToNumber: 2,
+  goToNextNumber: 3,
+  goToPreviousNumber: 3,
+  goToNumbersStart: 2,
+  deleteNumber: 5,
+  invertNumber: 5,
+  normalizeNumber: 7,
+  plusOne: 5,
+  minusOne: 17,
+  minusOneFast: 10,
+};
 
-    for (const name of stateNames) {
+const stateNames = Object.keys(expectedNodeCount) as Array<keyof typeof expectedNodeCount>;
+
+describe('library-binary-numbers state graphs', () => {
+  test.each(stateNames)(
+    '%s: toGraph produces the documented node count',
+    (name) => {
       const tapeBlock = binaryNumbers.getTapeBlock();
       const graph = State.toGraph(binaryNumbers.states[name], tapeBlock);
-      const mermaid = toMermaid(graph);
-      const nodeCount = Object.keys(graph.nodes).length;
 
-      sections.push(`## ${name}`);
-      sections.push('');
-      sections.push(`*${nodeCount} state${nodeCount === 1 ? '' : 's'} (including \`haltState\`)*`);
-      sections.push('');
-      sections.push('```mermaid');
-      sections.push(mermaid);
-      sections.push('```');
-      sections.push('');
-    }
+      expect(Object.keys(graph.nodes)).toHaveLength(expectedNodeCount[name]);
+    },
+  );
 
-    const output = sections.join('\n');
-    const outputPath = resolve(__dirname, '..', 'states.md');
+  test.each(stateNames)(
+    '%s: graph has at least one halt-reachable node',
+    (name) => {
+      const tapeBlock = binaryNumbers.getTapeBlock();
+      const graph = State.toGraph(binaryNumbers.states[name], tapeBlock);
 
-    writeFileSync(outputPath, output);
+      const haltNodes = Object.values(graph.nodes).filter((node) => node.isHalt);
 
-    expect(output.length).toBeGreaterThan(0);
-    expect(stateNames.length).toBeGreaterThan(0);
+      // Every algorithm has exactly one halt node (the singleton's id is shared
+      // across all states' graphs).
+      expect(haltNodes).toHaveLength(1);
+    },
+  );
+
+  test.each(stateNames)(
+    '%s: toMermaid → fromMermaid round-trips with the same node count',
+    (name) => {
+      const tapeBlock = binaryNumbers.getTapeBlock();
+      const original = State.toGraph(binaryNumbers.states[name], tapeBlock);
+
+      const mermaid = toMermaid(original);
+      const reparsed = fromMermaid(mermaid);
+
+      expect(Object.keys(reparsed.nodes)).toHaveLength(Object.keys(original.nodes).length);
+      // Mermaid output starts with a `flowchart` directive — sanity check it's
+      // well-formed beyond just length > 0.
+      expect(mermaid).toMatch(/^flowchart\s+(?:LR|TD|TB|RL|BT)/);
+    },
+  );
+
+  test('every state in the public surface has a documented count', () => {
+    // If a state is added to `binaryNumbers.states` without an entry in
+    // `expectedNodeCount`, this catches it (rather than silently skipping
+    // the new state in the parametrised tests above).
+    const exportedNames = Object.keys(binaryNumbers.states).sort();
+    const documentedNames = stateNames.slice().sort();
+
+    expect(exportedNames).toEqual(documentedNames);
   });
 });

--- a/scripts/build-states-md.mjs
+++ b/scripts/build-states-md.mjs
@@ -1,0 +1,64 @@
+// Regenerates `packages/library-binary-numbers/states.md` and
+// `packages/library-binary-numbers-bare/states.md` — Mermaid graphs for every
+// exported state, used as a teaching artifact alongside the libraries.
+//
+// Usage: `npm run docs:states` (requires a prior `npm run build`, since this
+// imports from `dist/`). Not run during tests; doc artifacts are committed to
+// the repo and regenerated manually when the libraries' state graphs change.
+//
+// Heads-up: state IDs are auto-assigned at module-evaluation time (`State.ts`'s
+// `id(this)` increments a module-level counter). Re-running this script will
+// produce a deterministic-but-different ID renumbering if the import order or
+// other consumers shift; the resulting diff is cosmetic — only the `s<N>`
+// labels move, the graph topology is identical. If a renumber-only diff
+// surfaces during a refresh, it's safe to commit.
+
+import {writeFileSync} from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {State, toMermaid} from '../packages/machine/dist/index.mjs';
+import binaryNumbers from '../packages/library-binary-numbers/dist/index.mjs';
+import binaryNumbersBare from '../packages/library-binary-numbers-bare/dist/index.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function renderLibrary(libraryName, library) {
+  const sections = [`# ${libraryName} — state graphs`, ''];
+
+  for (const [stateName, state] of Object.entries(library.states)) {
+    const tapeBlock = library.getTapeBlock();
+    const graph = State.toGraph(state, tapeBlock);
+    const mermaid = toMermaid(graph);
+    const nodeCount = Object.keys(graph.nodes).length;
+
+    sections.push(`## ${stateName}`);
+    sections.push('');
+    sections.push(`*${nodeCount} state${nodeCount === 1 ? '' : 's'} (including \`haltState\`)*`);
+    sections.push('');
+    sections.push('```mermaid');
+    sections.push(mermaid);
+    sections.push('```');
+    sections.push('');
+  }
+
+  return sections.join('\n');
+}
+
+const libraries = [
+  {
+    libraryName: 'library-binary-numbers',
+    library: binaryNumbers,
+    outputPath: resolve(root, 'packages/library-binary-numbers/states.md'),
+  },
+  {
+    libraryName: 'library-binary-numbers-bare',
+    library: binaryNumbersBare,
+    outputPath: resolve(root, 'packages/library-binary-numbers-bare/states.md'),
+  },
+];
+
+for (const {libraryName, library, outputPath} of libraries) {
+  const content = renderLibrary(libraryName, library);
+  writeFileSync(outputPath, content);
+  console.log(`✓ Wrote ${outputPath}`);
+}


### PR DESCRIPTION
Task 2/10 in the test rewrite series. The two \`graphs.spec.ts\` files (one per binary-numbers library) had a real audit problem: they wrote \`states.md\` to disk during \`npm test\` and asserted only \`output.length > 0\` and \`stateNames.length > 0\`. Both trivially true. Tests passed even if \`toMermaid\` returned an empty flowchart.

## Changes

1. **Moved markdown emission to \`scripts/build-states-md.mjs\`** — exposed as \`npm run docs:states\`. Requires \`npm run build\` first (script imports from \`dist/index.mjs\`). Doc artifacts stay committed; refreshed manually when state graphs change.

2. **Rewrote both spec files with structural assertions:**
   - Pin per-state node count documented in source comments (e.g. \`// goToNumber — 2 nodes\`). A refactor that grows or shrinks an algorithm fails this table.
   - Verify each graph has exactly one halt-reachable node.
   - Verify \`toMermaid → fromMermaid\` round-trip preserves node count, output starts with \`flowchart\` directive.
   - Guard: every state in the public surface has a documented count (adding a state without updating the table fails this).
   - Bare library: pin the headline claim that bare-alphabet algorithms are at most ~half the size of marker-based siblings.

## Numbers

- Test count: 2 → 45 (across both files).
- Total: 371 tests pass on master.
- Coverage: unchanged.

## Note on doc refreshes

State IDs are auto-assigned at module-evaluation time — re-running \`docs:states\` may produce cosmetic renumber-only diffs (graph topology identical). Inline comment in the script flags this for future refreshers.