### PR TITLE
test(machine): rewrite Reference.spec.ts — pin sticky-bind contract

### DIFF
--- a/packages/machine/src/classes/Reference.spec.ts
+++ b/packages/machine/src/classes/Reference.spec.ts
@@ -1,45 +1,77 @@
 import Reference from './Reference';
 import State from './State';
 
-describe('Reference constructor', () => {
-  test('Reference', () => {
-    const reference = new Reference();
+describe('Reference', () => {
+  describe('unbounded behavior', () => {
+    test('reading .ref before bind throws "unbounded reference"', () => {
+      const reference = new Reference();
 
-    expect(() => reference.ref)
-      .toThrow('unbounded reference');
-  });
-});
-
-describe('Reference properties', () => {
-  test('Reference ref', () => {
-    const reference = new Reference();
-    const state = new State();
-
-    reference.bind(state);
-
-    expect(reference.ref)
-      .toBe(state);
+      expect(() => reference.ref).toThrow('unbounded reference');
+    });
   });
 
-  test('Reference bind return the passed parameter', () => {
-    const reference = new Reference();
-    const state = new State();
+  describe('first bind', () => {
+    test('stores the state so .ref returns it', () => {
+      const reference = new Reference();
+      const state = new State();
 
-    const returnedValue = reference.bind(state);
+      reference.bind(state);
 
-    expect(returnedValue)
-      .toBe(state);
+      expect(reference.ref).toBe(state);
+    });
+
+    test('returns the bound state', () => {
+      const reference = new Reference();
+      const state = new State();
+
+      const returned = reference.bind(state);
+
+      expect(returned).toBe(state);
+    });
   });
 
-  test('Reference redefine ref', () => {
-    const reference = new Reference();
-    const state = new State();
-    const antherState = new State();
+  describe('subsequent binds (sticky — first binding wins)', () => {
+    // The previous spec called this "redefine ref" but the source's bind is
+    // sticky: the second bind() is a no-op and the original binding is kept.
+    // Pin that contract explicitly.
 
-    reference.bind(state);
-    reference.bind(antherState);
+    test('second bind() does not replace the existing binding', () => {
+      const reference = new Reference();
+      const first = new State();
+      const second = new State();
 
-    expect(reference.ref)
-      .toBe(state);
+      reference.bind(first);
+      reference.bind(second);
+
+      expect(reference.ref).toBe(first);
+      expect(reference.ref).not.toBe(second);
+    });
+
+    test('second bind() returns the EXISTING binding, not the passed argument', () => {
+      // This was the subtle case the previous "Reference bind return the passed
+      // parameter" test under-asserted. The first bind happens to satisfy that
+      // claim, but it's not the contract — the contract is "return the current
+      // binding."
+      const reference = new Reference();
+      const first = new State();
+      const second = new State();
+
+      reference.bind(first);
+      const returnedFromSecond = reference.bind(second);
+
+      expect(returnedFromSecond).toBe(first);
+      expect(returnedFromSecond).not.toBe(second);
+    });
+  });
+
+  describe('.ref idempotence', () => {
+    test('reading .ref multiple times returns the same instance', () => {
+      const reference = new Reference();
+      const state = new State();
+
+      reference.bind(state);
+
+      expect(reference.ref).toBe(reference.ref);
+    });
   });
 });


### PR DESCRIPTION
Task 3/10 in the test rewrite series. The audit caught two real test bugs in this small spec:

1. **\`'Reference redefine ref'\` test name lied.** The body asserts that \`.bind(antherState)\` after a prior \`.bind(state)\` keeps \`state\` — i.e., bind is sticky, not redefine-able. Test passed for the wrong reason.

2. **\`'Reference bind return the passed parameter'\` under-pinned the contract.** It only tests the first-bind path, where the passed argument happens to equal the binding. The actual contract is \"return the current binding, not the passed argument\" — only observable on second-bind.

## What this commit pins

- Unbounded \`.ref\` throws with the specific \`'unbounded reference'\` message.
- First \`bind(state)\` stores the state and returns it.
- Second \`bind(otherState)\` is a no-op for the binding AND returns the existing first binding (not the passed argument). **Two separate assertions** for the two facets of the contract.
- \`.ref\` reads are idempotent.

## Numbers

- Test count: 4 → 6.
- Total: 373 tests pass.
- Coverage unchanged.

Also: \`antherState\` typo gone.