### PR TITLE
test(machine): rewrite Alphabet.spec.ts + Tape.spec.ts

### DIFF
--- a/packages/machine/src/classes/Alphabet.spec.ts
+++ b/packages/machine/src/classes/Alphabet.spec.ts
@@ -1,93 +1,117 @@
 import Alphabet from './Alphabet';
 
 describe('Alphabet constructor', () => {
-  test('throws an error on empty array', () => {
-    expect(() => new Alphabet([]))
-      .toThrow('Invalid symbols length');
+  test('throws on empty array', () => {
+    expect(() => new Alphabet([])).toThrow('Invalid symbols length');
   });
 
-  test('throws an error on one element array', () => {
-    expect(() => new Alphabet(['1']))
-      .toThrow('Invalid symbols length');
+  test('throws on single-element array', () => {
+    expect(() => new Alphabet(['1'])).toThrow('Invalid symbols length');
   });
 
-  test('throws an error on one element array (unique)', () => {
-    expect(() => new Alphabet(['1', '1']))
-      .toThrow('Invalid symbols length');
+  test('throws when duplicates collapse to a single unique symbol', () => {
+    expect(() => new Alphabet(['1', '1'])).toThrow('Invalid symbols length');
   });
 
-  test('ok with two element array', () => {
-    expect(new Alphabet(['0', '1']))
-      .toBeTruthy();
+  test('throws on a multi-character symbol (audit gap: untested branch)', () => {
+    // Source: `every(symbol => symbol.length === 1)` — a multi-char entry
+    // takes the "symbols contains invalid symbol" throw path. Previously
+    // unexercised; now pinned.
+    expect(() => new Alphabet(['ab', 'cd'])).toThrow('symbols contains invalid symbol');
+    expect(() => new Alphabet(['0', 'longer'])).toThrow('symbols contains invalid symbol');
   });
 
-  test('copy alphabet', () => {
+  test('two-element array constructs an Alphabet with both symbols intact', () => {
     const alphabet = new Alphabet(['0', '1']);
-    const alphabetCopy = new Alphabet(alphabet);
 
-    expect(alphabet)
-      .toBeTruthy();
-    expect(alphabetCopy)
-      .toBeTruthy();
-    expect(alphabet)
-      .toEqual(alphabetCopy);
+    expect(alphabet.symbols).toEqual(['0', '1']);
+    expect(alphabet.symbols).toHaveLength(2);
+  });
+
+  test('duplicate-collapsing keeps the first occurrence order', () => {
+    // ['1', '0', '1'] → unique [1, 0] (first-seen order). Documents that the
+    // dedup uses uniquePredicate, which is order-preserving.
+    const alphabet = new Alphabet(['1', '0', '1']);
+
+    expect(alphabet.symbols).toEqual(['1', '0']);
+    expect(alphabet.blankSymbol).toBe('1');
+  });
+
+  test('copy constructor preserves the original symbols', () => {
+    const original = new Alphabet(['0', '1']);
+    const copy = new Alphabet(original);
+
+    expect(copy.symbols).toEqual(original.symbols);
+    // The copy's symbols array is a fresh array (the getter returns a fresh
+    // array each call), but contents match.
+    expect(copy.symbols).not.toBe(original.symbols);
   });
 });
 
-describe('Alphabet properties', () => {
-  const alphabetSymbols = '012345';
-  const alphabet = new Alphabet(alphabetSymbols.split(''));
+describe('Alphabet.symbols / .blankSymbol getters', () => {
+  const alphabetSymbols = '012345'.split('');
+  const alphabet = new Alphabet(alphabetSymbols);
 
-  test('symbolList', () => {
-    expect(alphabet.symbols)
-      .toEqual(alphabetSymbols.split(''));
+  test('symbols returns a fresh array each call (defensive copy)', () => {
+    expect(alphabet.symbols).toEqual(alphabetSymbols);
+    expect(alphabet.symbols).not.toBe(alphabet.symbols);
   });
 
-  test('blankSymbol', () => {
-    expect(alphabet.blankSymbol)
-      .toBe(alphabetSymbols[0]);
+  test('blankSymbol is the first element', () => {
+    expect(alphabet.blankSymbol).toBe('0');
+  });
+});
+
+describe('Alphabet.has', () => {
+  const alphabet = new Alphabet('012345'.split(''));
+
+  test('returns true for every alphabet member', () => {
+    for (const symbol of '012345') {
+      expect(alphabet.has(symbol)).toBe(true);
+    }
   });
 
-  test('has', () => {
-    const hasAllSymbols = alphabetSymbols.split('')
-      .every((symbol) => alphabet.has(symbol));
+  test('returns false for non-members', () => {
+    expect(alphabet.has('\0')).toBe(false);
+    expect(alphabet.has('')).toBe(false);
+    expect(alphabet.has('multi')).toBe(false); // multi-char query
+    expect(alphabet.has('A')).toBe(false);
+  });
+});
 
-    expect(hasAllSymbols)
-      .toBe(true);
+describe('Alphabet.get', () => {
+  const alphabet = new Alphabet('012345'.split(''));
+
+  test('returns the symbol at each valid index', () => {
+    for (let i = 0; i < 6; i += 1) {
+      expect(alphabet.get(i)).toBe(String(i));
+    }
   });
 
-  test('has not', () => {
-    expect(alphabet.has('\0'))
-      .toBe(false);
+  test('throws on negative index', () => {
+    expect(() => alphabet.get(-1)).toThrow('Invalid index');
   });
 
-  test('get', () => {
-    const areAllSymbolsCorrect = alphabetSymbols.split('')
-      .every((symbol, index) => symbol === alphabet.get(index));
-
-    expect(areAllSymbolsCorrect)
-      .toBe(true);
+  test('throws on index === length (off-by-one boundary)', () => {
+    expect(() => alphabet.get(6)).toThrow('Invalid index');
   });
 
-  test('get invalid index: -1', () => {
-    expect(() => {
-      alphabet.get(-1);
-    })
-      .toThrow('Invalid index');
+  test('throws on index way beyond length', () => {
+    expect(() => alphabet.get(100)).toThrow('Invalid index');
+  });
+});
+
+describe('Alphabet.index', () => {
+  const alphabet = new Alphabet('012345'.split(''));
+
+  test('returns the position of every alphabet member', () => {
+    '012345'.split('').forEach((symbol, ix) => {
+      expect(alphabet.index(symbol)).toBe(ix);
+    });
   });
 
-  test(`get invalid index: ${alphabetSymbols.length}`, () => {
-    expect(() => {
-      alphabet.get(alphabetSymbols.length);
-    })
-      .toThrow('Invalid index');
-  });
-
-  test('index.spec.ts', () => {
-    const areAllIndexesCorrect = alphabetSymbols.split('')
-      .every((symbol, index) => index === alphabet.index(symbol));
-
-    expect(areAllIndexesCorrect)
-      .toBe(true);
+  test('returns -1 for non-members', () => {
+    expect(alphabet.index('\0')).toBe(-1);
+    expect(alphabet.index('A')).toBe(-1);
   });
 });

--- a/packages/machine/src/classes/Tape.spec.ts
+++ b/packages/machine/src/classes/Tape.spec.ts
@@ -1,213 +1,217 @@
 import Alphabet from './Alphabet';
 import Tape from './Tape';
 
-
 describe('Tape constructor', () => {
-  test('emptySymbol is current if symbolList is empty', () => {
+  test('starts with the blank symbol when no symbols are provided', () => {
     const alphabet = new Alphabet(['0', '1']);
     const tape = new Tape({alphabet});
 
-    expect(tape.symbol === alphabet.blankSymbol)
-      .toBeTruthy();
+    expect(tape.symbol).toBe(alphabet.blankSymbol);
   });
-  test('position', () => {
+
+  test('honors the position parameter', () => {
+    // Pinned position (was Math.random — non-deterministic).
     const alphabet = new Alphabet(['0', '1']);
-    const position = Math.floor(Math.random() * Math.floor(100)) + 1;
-    const tape = new Tape({alphabet, position});
+    const tape = new Tape({alphabet, position: 42});
 
-    expect(tape.position === position)
-      .toBe(true);
+    expect(tape.position).toBe(42);
   });
-  test('copy tape', () => {
+
+  test('copy constructor preserves symbol/position/viewport/alphabet', () => {
     const alphabet = new Alphabet(['0', '1']);
-    const tape = new Tape({alphabet});
-    const tapeCopy = new Tape(tape);
+    const original = new Tape({alphabet});
+    const copy = new Tape(original);
 
-    expect(tape.symbol === tapeCopy.symbol)
-      .toBe(true);
-    expect(tape.viewportWidth)
-      .toEqual(tapeCopy.viewportWidth);
-    expect(tape.symbols)
-      .toEqual(tapeCopy.symbols);
-    expect(tape.alphabet)
-      .toEqual(tapeCopy.alphabet);
-    expect(tape.position)
-      .toEqual(tapeCopy.position);
-    expect(tape.viewportWidth)
-      .toEqual(tapeCopy.viewportWidth);
+    expect(copy.symbol).toBe(original.symbol);
+    expect(copy.position).toBe(original.position);
+    expect(copy.symbols).toEqual(original.symbols);
+    expect(copy.viewportWidth).toBe(original.viewportWidth);
+    expect(copy.alphabet.symbols).toEqual(original.alphabet.symbols);
   });
 
-  test('invalid symbol', () => {
-    expect(() => {
-      const alphabet = new Alphabet(['0', '1']);
+  test('throws when symbols contains a non-alphabet character', () => {
+    const alphabet = new Alphabet(['0', '1']);
 
-
-      new Tape({
-        alphabet,
-        symbols: ['a'],
-      });
-    })
-      .toThrow('symbolList contains invalid symbol');
-  });
-
-  test('viewportWidth normalises and pads symbols (issue #95)', () => {
-    const alphabet = new Alphabet(['␣', 'a', 'b']);
-    const tape = new Tape({
+    expect(() => new Tape({
       alphabet,
-      symbols: ['a', 'b', 'a', 'b'],
-      position: 0,
-      viewportWidth: 23,
+      symbols: ['a'],
+    })).toThrow('symbolList contains invalid symbol');
+  });
+
+  describe('viewportWidth (constructor)', () => {
+    const alphabet = new Alphabet(['0', '1']);
+
+    test('default is 1 — single-cell viewport', () => {
+      const tape = new Tape({alphabet});
+
+      expect(tape.viewportWidth).toBe(1);
+      expect(tape.viewport).toHaveLength(1);
     });
 
-    expect(tape.viewportWidth).toBe(23);
-    expect(tape.viewport.length).toBe(23);
-  });
+    test('explicit odd value is honored', () => {
+      const tape = new Tape({alphabet, viewportWidth: 5});
 
-  test('viewportWidth default leaves a single-cell viewport', () => {
-    const alphabet = new Alphabet(['0', '1']);
-    const tape = new Tape({ alphabet });
+      expect(tape.viewportWidth).toBe(5);
+      expect(tape.viewport).toHaveLength(5);
+    });
 
-    expect(tape.viewportWidth).toBe(1);
-    expect(tape.viewport.length).toBe(1);
-  });
+    test('even value is bumped to next odd', () => {
+      const tape = new Tape({alphabet, viewportWidth: 4});
 
-  test('even viewportWidth is bumped to the next odd value', () => {
-    const alphabet = new Alphabet(['0', '1']);
-    const tape = new Tape({ alphabet, viewportWidth: 4 });
+      expect(tape.viewportWidth).toBe(5);
+      expect(tape.viewport).toHaveLength(5);
+    });
 
-    expect(tape.viewportWidth).toBe(5);
-    expect(tape.viewport.length).toBe(5);
-  });
+    test('throws on 0', () => {
+      expect(() => new Tape({alphabet, viewportWidth: 0}))
+        .toThrow('Invalid viewportWidth');
+    });
 
-  test('viewportWidth < 1 throws from the constructor', () => {
-    const alphabet = new Alphabet(['0', '1']);
+    test('throws on negative', () => {
+      expect(() => new Tape({alphabet, viewportWidth: -1}))
+        .toThrow('Invalid viewportWidth');
+    });
 
-    expect(() => new Tape({ alphabet, viewportWidth: 0 }))
-      .toThrow('Invalid viewportWidth');
-    expect(() => new Tape({ alphabet, viewportWidth: -1 }))
-      .toThrow('Invalid viewportWidth');
+    test('normalises and pads symbols (issue #95)', () => {
+      const a = new Alphabet(['␣', 'a', 'b']);
+      const tape = new Tape({
+        alphabet: a,
+        symbols: ['a', 'b', 'a', 'b'],
+        position: 0,
+        viewportWidth: 23,
+      });
+
+      expect(tape.viewportWidth).toBe(23);
+      expect(tape.viewport).toHaveLength(23);
+    });
   });
 });
 
-describe('Tape properties', () => {
+describe('Tape.symbol setter', () => {
   let tape: Tape;
 
   beforeEach(() => {
-    const alphabetSymbols = '012345';
-    const alphabet = new Alphabet(alphabetSymbols.split(''));
-
+    const alphabet = new Alphabet('012345'.split(''));
     tape = new Tape({alphabet});
   });
 
-  test('write symbol valid symbol', () => {
+  test('writes a valid alphabet symbol to the head cell', () => {
     tape.alphabet.symbols.forEach((symbol) => {
       tape.symbol = symbol;
-
-      expect(tape.symbol === symbol)
-        .toBe(true);
+      expect(tape.symbol).toBe(symbol);
     });
   });
 
-  test('write symbol invalid symbol', () => {
+  test('throws on a symbol outside the alphabet', () => {
     expect(() => {
       tape.symbol = '\0';
-    })
-      .toThrow('Invalid symbol');
+    }).toThrow('Invalid symbol');
+  });
+});
+
+describe('Tape.left / .right movement', () => {
+  let tape: Tape;
+
+  beforeEach(() => {
+    const alphabet = new Alphabet('012345'.split(''));
+    tape = new Tape({alphabet});
   });
 
-  test('left blank', () => {
+  test('left() lands on a blank cell when moving past the start', () => {
     tape.symbol = tape.alphabet.get(1);
     tape.left();
 
-    expect(tape.symbol === tape.alphabet.blankSymbol)
-      .toBe(true);
+    expect(tape.symbol).toBe(tape.alphabet.blankSymbol);
   });
 
-  test('right blank', () => {
+  test('right() lands on a blank cell when moving past the end', () => {
     tape.symbol = tape.alphabet.get(1);
     tape.right();
 
-    expect(tape.symbol === tape.alphabet.blankSymbol)
-      .toBe(true);
+    expect(tape.symbol).toBe(tape.alphabet.blankSymbol);
   });
 
-  test('viewport / viewportWidth', () => {
-    expect(tape.viewportWidth)
-      .toEqual(1);
+  test('symbols sequence reads left-to-right after a series of right() moves', () => {
+    const alphabetSymbols = tape.alphabet.symbols;
+
+    alphabetSymbols.forEach((symbol, ix) => {
+      tape.symbol = symbol;
+      if (ix < alphabetSymbols.length - 1) tape.right();
+    });
+
+    expect(tape.symbols).toEqual(alphabetSymbols);
+  });
+
+  test('symbols sequence reads right-to-left after a series of left() moves', () => {
+    const alphabetSymbols = tape.alphabet.symbols;
+
+    alphabetSymbols.forEach((symbol, ix) => {
+      tape.symbol = symbol;
+      if (ix < alphabetSymbols.length - 1) tape.left();
+    });
+
+    expect(tape.symbols).toEqual(alphabetSymbols.slice().reverse());
+  });
+
+  test('repeated left() preserves all written symbols and pads blanks (#94)', () => {
+    const alphabet = new Alphabet(['␣', 'x']);
+    const ttape = new Tape({alphabet, symbols: ['x']});
+
+    for (let i = 0; i < 1000; i += 1) ttape.left();
+
+    expect(ttape.symbols).toHaveLength(1001);
+    expect(ttape.symbols[1000]).toBe('x');
+    expect(ttape.position).toBe(0);
+    expect(ttape.symbol).toBe('␣');
+  });
+});
+
+describe('Tape.viewportWidth (setter)', () => {
+  // Mega-test split into focused per-behavior tests.
+  let tape: Tape;
+
+  beforeEach(() => {
+    const alphabet = new Alphabet('012345'.split(''));
+    tape = new Tape({alphabet});
+  });
+
+  test('default is 1 (matches the constructor default)', () => {
+    expect(tape.viewportWidth).toBe(1);
+  });
+
+  test('throws on 0', () => {
     expect(() => {
       tape.viewportWidth = 0;
-    })
-      .toThrow('Invalid viewportWidth');
+    }).toThrow('Invalid viewportWidth');
+  });
+
+  test('throws on negative', () => {
     expect(() => {
       tape.viewportWidth = -1;
-    })
-      .toThrow('Invalid viewportWidth');
-    expect(() => {
-      tape.viewportWidth = 1;
-    })
-      .not.toThrow();
-    expect(() => {
-      tape.viewportWidth = 2;
-    })
-      .not.toThrow();
+    }).toThrow('Invalid viewportWidth');
+  });
+
+  test('odd value is stored verbatim', () => {
     tape.viewportWidth = 1;
-    expect(tape.viewportWidth)
-      .toBe(1);
-    expect(tape.viewport.length)
-      .toBe(1);
+    expect(tape.viewportWidth).toBe(1);
+    expect(tape.viewport).toHaveLength(1);
+  });
+
+  test('even value is bumped to next odd', () => {
     tape.viewportWidth = 2;
-    expect(tape.viewportWidth)
-      .toBe(3);
-    expect(tape.viewport.length)
-      .toBe(3);
+    expect(tape.viewportWidth).toBe(3);
+    expect(tape.viewport).toHaveLength(3);
+  });
 
+  test('viewport length tracks viewportWidth, not the underlying symbols length', () => {
+    // After moving the head leftward enough times, symbols grows past the
+    // viewport — viewport.length should still equal viewportWidth, NOT
+    // symbols.length.
+    tape.viewportWidth = 3;
     tape.left();
     tape.left();
 
-    expect(tape.viewport.length)
-      .not.toEqual(tape.symbols.length);
+    expect(tape.viewport).toHaveLength(3);
+    expect(tape.viewport.length).not.toBe(tape.symbols.length);
   });
-
-  test('symbolList right', () => {
-    const alphabetSymbols = tape.alphabet.symbols;
-
-    alphabetSymbols.forEach((symbol, ix) => {
-      tape.symbol = symbol;
-      if (ix < alphabetSymbols.length - 1) {
-        tape.right();
-      }
-    });
-
-    expect(tape.symbols)
-      .toEqual(alphabetSymbols);
-  });
-
-  test('symbolList left', () => {
-    const alphabetSymbols = tape.alphabet.symbols;
-
-    alphabetSymbols.forEach((symbol, ix) => {
-      tape.symbol = symbol;
-      if (ix < alphabetSymbols.length - 1) {
-        tape.left();
-      }
-    });
-
-    expect(tape.symbols)
-      .toEqual(alphabetSymbols.reverse());
-  });
-
-  test('many left() calls preserve symbols and position-as-index (issue #94)', () => {
-    const alphabet = new Alphabet(['␣', 'x']);
-    const tape = new Tape({ alphabet, symbols: ['x'] });
-
-    for (let i = 0; i < 1000; i += 1) {
-      tape.left();
-    }
-
-    expect(tape.symbols.length).toBe(1001);
-    expect(tape.symbols[1000]).toBe('x');
-    expect(tape.position).toBe(0);
-    expect(tape.symbol).toBe('␣');
-  });
-
 });


### PR DESCRIPTION
Task 8/10. Two specs in one PR — both small surfaces with the same kind of audit findings.

## Alphabet.spec.ts

- **Add multi-char-symbol throw test** (audit gap: source's \`every(s => s.length === 1)\` branch had zero coverage).
- Drop \`'ok with two element array'\` smoke; replace with \`.symbols\` content + length assertions.
- Rename \`'index.spec.ts'\` (accidental file-name-as-test-name).
- Strengthen \`.has\`/\`.get\`/\`.index\` non-member + boundary coverage.
- Add duplicate-collapsing order test + copy-constructor defensive-copy test.

## Tape.spec.ts

- **Pin position** — was \`Math.random() * 100 + 1\` (non-deterministic). Now fixed at 42.
- **Split the 35-line \`viewportWidth\` mega-test** into 6 focused per-behavior tests. Each failure now localizes.
- Switch \`expect(... === ...).toBe(true)\` → \`.toBe(...)\` form (file previously mixed both).
- Group movement tests in a dedicated describe.
- Rename for behavior-first naming.

## Numbers

- Alphabet: 13 → 19 tests.
- Tape: 16 → 21 tests.
- Total: 392 tests pass.
- Coverage: unchanged.