### PR TITLE
test(machine): strengthen equivalence.spec.ts + tighten Command.spec.ts

### DIFF
--- a/packages/machine/src/classes/Command.spec.ts
+++ b/packages/machine/src/classes/Command.spec.ts
@@ -7,18 +7,25 @@ describe('Command constructor', () => {
       .toThrow('invalid parameter');
   });
 
-  test('valid tapeCommand', () => {
+  test('stores the passed TapeCommand list on .tapesCommands', () => {
+    // Previously: two separate `new Command([tapeCommand])` calls — first
+    // wrapped in `expect(() => ...).not.toThrow()`, second to inspect the
+    // result. Single construction is enough; if the constructor throws,
+    // the next assertion would fail.
     const tapeCommand = new TapeCommand({});
+    const command = new Command([tapeCommand]);
 
-    expect(() => new Command([
-      tapeCommand,
-    ]))
-      .not
-      .toThrow();
+    expect(command.tapesCommands).toEqual([tapeCommand]);
+  });
 
-    expect(new Command([
-      tapeCommand,
-    ]).tapesCommands)
-      .toEqual([tapeCommand]);
+  test('preserves the order of multiple TapeCommands', () => {
+    // The original spec didn't pin order — this catches a refactor that
+    // would, say, sort or reverse the input.
+    const a = new TapeCommand({});
+    const b = new TapeCommand({});
+    const c = new TapeCommand({});
+    const command = new Command([a, b, c]);
+
+    expect(command.tapesCommands).toEqual([a, b, c]);
   });
 });

--- a/packages/machine/src/utilities/equivalence.spec.ts
+++ b/packages/machine/src/utilities/equivalence.spec.ts
@@ -90,7 +90,7 @@ describe('equivalentOn', () => {
     // comparable step but lengths differ" fallback path, force outputs to disagree
     // (compareOutputs: () => false) and snapshots to always agree
     // (compareSnapshots: () => true). The post-loop length-mismatch branch then
-    // sets firstDivergenceStep = minLen.
+    // sets firstDivergenceStep = minLen (the smaller of the two step counts).
     const report = equivalentOn(
       {state: binaryNumbers.states.minusOne, getTapeBlock: binaryNumbers.getTapeBlock},
       {state: binaryNumbers.states.minusOneFast, getTapeBlock: binaryNumbers.getTapeBlock},
@@ -101,7 +101,34 @@ describe('equivalentOn', () => {
       },
     );
 
+    const {referenceSteps, candidateSteps, firstDivergenceStep} = report.results[0];
+
     expect(report.results[0].agree).toBe(false);
-    expect(report.results[0].firstDivergenceStep).not.toBeNull();
+    // Pin the exact fallback value: 1-indexed step number at which the
+    // SHORTER side ran out of comparable iterations, i.e. minLen + 1
+    // (the first step the longer side took without a reference snapshot
+    // to compare against).
+    expect(firstDivergenceStep).toBe(Math.min(referenceSteps, candidateSteps) + 1);
+    // Sanity: the heavy composition really does run more steps than the
+    // direct-borrow variant on this input.
+    expect(referenceSteps).toBeGreaterThan(candidateSteps);
+  });
+
+  test('compareSnapshots: null skips mid-run divergence detection on same alphabet', () => {
+    // Audit gap: the `compareSnapshots: null` branch was exercised only in
+    // cross-alphabet tests. This test pins the same-alphabet contract:
+    // when outputs disagree but compareSnapshots is null, firstDivergenceStep
+    // is null (the engine doesn't probe step-by-step).
+    const report = equivalentOn(
+      {state: binaryNumbers.states.plusOne, getTapeBlock: binaryNumbers.getTapeBlock},
+      {state: binaryNumbers.states.minusOne, getTapeBlock: binaryNumbers.getTapeBlock},
+      ['^10$'],
+      {
+        compareSnapshots: null,
+      },
+    );
+
+    expect(report.results[0].agree).toBe(false);
+    expect(report.results[0].firstDivergenceStep).toBeNull();
   });
 });


### PR DESCRIPTION
**Final task — 10/10 — in the test-rewrite series.**

## equivalence.spec.ts

1. **Pin the minLen fallback value.** \`'firstDivergenceStep falls back to minLen…'\` previously asserted only \`!== null\`. Pin the actual contract: \`firstDivergenceStep === min(refSteps, candSteps) + 1\` (1-indexed step number where the longer side ran out of comparable iterations). Plus a sanity check that the heavy composition really does run more steps than the direct-borrow variant on the test input.
2. **Add same-alphabet \`compareSnapshots: null\` test** (audit gap). The branch was previously exercised only via cross-alphabet pathways. The new test pins the same-alphabet contract: outputs disagree but compareSnapshots is null → firstDivergenceStep === null (no step-by-step probing).

## Command.spec.ts

- Merge two redundant \`new Command([tapeCommand])\` calls in the same test into one (the wrapper \`expect(() => …).not.toThrow()\` was redundant — if construction failed, the next assertion would too).
- Add an order-preservation test for multi-tapeCommand input.

## Series totals

After this PR merges, the entire 10-PR test rewrite series is complete:

| | PR | File | Δ tests |
|---|---|---|---|
| 1 | #125 | library-binary-numbers/index.spec.ts | 35 → 57 |
| 2 | #126 | graphs.spec.ts × 2 + scripts/build-states-md.mjs | 2 → 45 |
| 3 | #127 | Reference.spec.ts | 4 → 6 |
| 4 | #128 | Lock.spec.ts | 1 → 11 |
| 5 | #129 | TapeBlock.spec.ts | 27 → 33 |
| 6 | #130 | TuringMachine.debug.spec.ts | 24 → 26 |
| 7 | #131 | State.spec.ts | 21 → 18 |
| 8 | #132 | Alphabet.spec.ts + Tape.spec.ts | 13+16 → 19+21 |
| 9 | #133 | examples.spec.ts | 7 → 8 |
| 10 | this PR | equivalence.spec.ts + Command.spec.ts | 6+2 → 7+3 |

Test count over the series: ~158 → ~254 (cumulative; net +96).
Real bugs found and fixed: 2 (Reference's misleading "redefine" test, TapeBlock's inverted "throws on non-string/array" test).
Audit-gap branches now covered: 5+ (Alphabet multi-char, Lock silent no-op variants, equivalence compareSnapshots: null, deleteNumber/normalizeNumber/etc no-op halts in library-binary-numbers).

## Numbers (this PR)

- equivalence: 6 → 7 tests.
- Command: 2 → 3 tests.
- Total: 394 tests pass.
- Coverage: unchanged.