### PR TITLE
docs(root): replace ASCII trace with Mermaid graph + step table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,73 +74,28 @@ machine.run({
 console.log(tape.symbols.join('').trim()); // a*c*a
 ```
 
-## Execution steps explanation
+## How it runs
 
-- `S` stands for the initial state
-- `H` stands for the `haltState`
+Just one state — call it **S** — that loops on every cell, writing `*` whenever the head reads `b` and stopping at the trailing blank:
 
-### Step 1
-
-- Current state: S
-- Current symbol: 'a'
-- Transition: 'a'/S,R
-
-```
-[       abcba   ]    [       abcba   ]
-        ^         >>          ^
+```mermaid
+flowchart LR
+    S(("**S**"))
+    H((("**halt**")))
+    S -- "b → *, R" --> S
+    S -- "_ → keep, L" --> H
+    S -- "any other → keep, R" --> S
 ```
 
-### Step 2
+*Reading the labels: `read → write, move`. `_` is the blank symbol.*
 
-- Current state: S
-- Current symbol: 'b'
-- Transition: '*'/S,R
+Trace on the input tape `abcba`:
 
-```
-[      abcba    ]    [      a*cba    ]
-        ^         >>          ^
-```
-
-### Step 3
-
-- Current state: S
-- Current symbol: 'c'
-- Transition: 'c'/S,R
-
-```
-[     a*cba     ]    [     a*cba     ]
-        ^         >>          ^
-```
-
-### Step 4
-
-- Current state: S
-- Current symbol: 'b'
-- Transition: '*'/S,R
-
-```
-[    a*cba      ]    [    a*c*a      ]
-        ^         >>          ^
-```
-
-### Step 5
-
-- Current state: S
-- Current symbol: 'a'
-- Transition: 'a'/S,R
-
-```
-[   a*c*a       ]    [   a*c*a       ]
-        ^         >>          ^
-```
-
-### Step 6
-
-- Current state: S
-- Current symbol: ' '
-- Transition: ' '/H,L
-
-```
-[  a*c*a        ]    [  a*c*a        ]
-        ^         >>        ^
-```
+| Step | State | Head reads | Write | Move | Goto | Tape after (head: `‹›`) |
+|---|---|---|---|---|---|---|
+| 1 | S | `a` | keep | R | S | `a‹b›cba` |
+| 2 | S | `b` | `*` | R | S | `a*‹c›ba` |
+| 3 | S | `c` | keep | R | S | `a*c‹b›a` |
+| 4 | S | `b` | `*` | R | S | `a*c*‹a›` |
+| 5 | S | `a` | keep | R | S | `a*c*a‹_›` |
+| 6 | S | `_` | keep | L | halt | `a*c*‹a›_` |


### PR DESCRIPTION
First docs PR after the test rewrite series. Targets the root README's *\"Execution steps explanation\"* (now retitled *\"How it runs\"*).

## Why

The previous shape had real problems beyond \"text-based\":

- **Animation-style ASCII boxes don't translate to static markdown.** Each box showed the tape sliding under a fixed-position head (`^`) — the demo's animation model. In a static document, a reader sees the same `^` in adjacent steps and can't tell what changed without close reading.
- **The transition notation \`'a'/S,R\` was unexplained** and non-standard. \`S\` was ambiguous (state name? \`stay\` movement?).
- **Every step said \"Current state: S\"** — uninformative when there's only one state.

## What this PR does

Replaces the 6 ASCII step blocks with:

1. **A Mermaid flowchart of the state graph** — GitHub renders Mermaid natively, and the library's own \`toMermaid\` helper produces this same shape. Eats its own dog food.
2. **A trace table** — one row per iteration, columns: \`Step / State / Head reads / Write / Move / Goto / Tape after (head: ‹›)\`. Notation defined inline.

Section also renamed \"Execution steps explanation\" → \"How it runs\" (less stilted).

## Diff size

- 64 lines removed (the 6 ASCII boxes + their headings).
- 19 lines added (Mermaid block + table + legend).

Net: smaller, more illustrative.

## Preview

You can see the rendered Mermaid + table on the PR's *Files changed* tab — GitHub's preview renders Mermaid in markdown.

## Next docs PR (queued, not in this PR)

\`packages/machine/README.md\` — \`haltState.debug.after\` caveat + \`MachineState\` field table + \`tape.viewport\` mention + \`DebugConfig\` one-line. Want to land this one first to confirm direction.