### PR TITLE
docs(claude): expand v5/v6 cross-version notes + visualization section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,15 @@ Key shapes that take reading multiple files to grasp:
 
 - **`TapeBlock` has a `Lock`** that `TuringMachine.run` grabs for the duration of a run, asserting the block isn't being mutated by another machine. Calls to `applyCommand` from outside a run must pass the matching capture symbol.
 
-- **`state.debug` (v4)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onPause` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). Renamed from `onDebugBreak` in v5. `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
+- **`state.debug` (v4+)** — runtime-mutable breakpoint cell with `{ before, after }` symbol filtering. Shared across `withOverrodeHaltState` wrappers via a private `Ref` so an assignment on the original is visible from every wrapper instance — useful when the same primitive is reused in composition chains. Pauses dispatch via the optional `onPause` hook on `run()` (awaited; without the hook, breaks fire-and-resume invisibly). `haltState.debug.before = true` pauses on every halt entry (program exit + subroutine pop). See `packages/machine/README.md` "Debugging breakpoints (v4+)" for the full API.
+
+  Cross-version notes:
+  - **v5**: hook renamed `onDebugBreak` → `onPause` (#110). `haltState.debug.after = true` (or `{ before, after }` together) now throws at write-time — halt is terminal, no iteration-after-halt to anchor on (#108 part 2). Halting iter's after-fire stopped being silently lost (#108 part 1). New `run({ debug: boolean })` master switch suppresses all `onPause` dispatches without editing `state.debug` assignments (#106).
+  - **v6**: `onPause(after, K)` now fires on iter K's *own* yield, alongside `onPause(before, K)` and `onStep(K)` — per-iter lifecycle is `before → step → after` (#119). Previously `after` fired on iter K+1's tick with a `prevYield` substitution dance; that substitution is gone. Implication: tests asserting cross-hook ordering at the lifecycle level need v6-aware shape.
+
+### Visualization & round-trip
+
+`packages/machine` ships `State.toGraph(state, tapeBlock)` → `Graph` and `State.fromGraph(graph)` → `{start, tapeBlock, states}` for serialization. `toMermaid(graph)` and `fromMermaid(text)` round-trip the same Graph through Mermaid flowchart syntax. The round-trip is **behaviorally** lossless (rebuilt graph runs to same outputs on same inputs — covered by `test/round-trip.spec.ts`); not bytewise lossless because state IDs auto-reassign, and for `withOverrodeHaltState` wrappers the composite name accumulates `>${override.name}` suffixes on each pass. Tracked in [#138](https://github.com/mellonis/turing-machine-js/issues/138) (cleaner emit for wrapped states) + [#139](https://github.com/mellonis/turing-machine-js/issues/139) (regression test that fails until #138 is fixed).
 
 ### Builder package
 


### PR DESCRIPTION
Second of three CLAUDE.md cleanups (continuing from #140). Closes the gap where the engine CLAUDE.md only mentioned v4 features and a single-line "renamed from onDebugBreak in v5" reference.

## What's added

**Cross-version notes** under the \`state.debug\` bullet:

- **v5**: \`onDebugBreak\` → \`onPause\` rename (#110); \`haltState.debug.after\` rejection (#108 part 2); halting-iter after-fire fix (#108 part 1); \`run({ debug })\` master switch (#106).
- **v6**: \`onPause(after, K)\` fires on iter K's own yield (#119); per-iter lifecycle \`before → step → after\`; \`prevYield\` substitution dance gone.

**New "Visualization & round-trip" subsection** after the runtime model:

- Documents \`toGraph\` / \`fromGraph\` + \`toMermaid\` / \`fromMermaid\`.
- Calls out the round-trip as **behaviorally** lossless (\`test/round-trip.spec.ts\`) but **not bytewise** lossless — state IDs reassign, wrapper names stretch.
- Links to #138 (cleaner emit) and #139 (bytewise round-trip regression test).

**Wording**: \`state.debug (v4)\` → \`(v4+)\` to match the README and reflect that semantics extended through v5/v6.

## Diff size

+9 / -1 lines, \`CLAUDE.md\` only.

## Follow-up (3 — separate PRs)

Parent CLAUDE.mds in the workspace + machines umbrella still reference v4.0.0 as the current published version; that one's a different repo (\`mellonis/mellonis-workspace\`).