### PR TITLE
chore(release): v6.0.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.0",
+  "version": "6.0.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,7 +10656,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10667,7 +10667,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10678,7 +10678,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10689,7 +10689,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
## Summary

Same-day patch release on top of v6.0.0. **Pure docs + housekeeping — zero source changes** (verified via \`git diff v6.0.0..master -- 'packages/*/src/**/*.ts' ':(exclude)*.spec.ts'\` → empty).

What lands on npmjs.com with this republish:

- **\`@turing-machine-js/machine\` README** — major rewrite with Mermaid diagrams (Quick Start state graph, Reference cycles, withOverrodeHaltState BEFORE/AFTER subgraphs), dual-layer pattern (hand-drawn primary + engine-source in \`<details>\`), MachineState field table, \`tape.viewport\` notes, \`haltState.debug.after\` caveat, full debugger writeup.
- **\`@turing-machine-js/builder\` README** — example replaced (verbose 27-state binary-string-duplicator → terse bit-flip) for digestibility; longer example link preserved.
- **\`@turing-machine-js/library-binary-numbers\` + \`-bare\` READMEs** — corrected the auto-generation note for \`states.md\` (parity preserved between the two; identical 2-line change).
- **All 4 packages** — \`author\` field email \`mellonis14@gmain.com\` → \`mellonis@yandex.ru\`.

\`peerDependencies: ^6.0.0\` already covers 6.0.1 — no peer-dep edits.

## Tag

\`v6.0.1\` is **already tagged on origin** (lerna pushed it before branch protection blocked the master push). The release commit is \`cde67c3\` and the tag points at it. **Merge this PR with the "Create a merge commit" strategy (NOT squash)** so commit \`cde67c3\` lands on master and the tag stays valid.

## Test plan

- [ ] CI green (\`build\`, \`coverage/coveralls\`)
- [ ] Merge with **merge-commit strategy** — commit \`cde67c3\` must remain in master's reachable history
- [ ] After merge: \`npx lerna publish from-package\` from a clean checkout