### PR TITLE
docs(library-binary-numbers,bare): trim internal-test ref

### DIFF
--- a/packages/library-binary-numbers-bare/README.md
+++ b/packages/library-binary-numbers-bare/README.md
@@ -74,7 +74,7 @@ The marker library's extra states are mostly bookkeeping for the `^`/`$` markers
 
 For a teaching context, both libraries shipping in parallel makes the cost of representation choices tangible.
 
-See the rendered Mermaid graphs for every state in [`states.md`](states.md) (regenerated via `npm run docs:states` from the repo root; the spec at `src/graphs.spec.ts` only verifies structural properties of the graphs, not the markdown file).
+See the rendered Mermaid graphs for every state in [`states.md`](states.md) — regenerated via `npm run docs:states` from the repo root.
 
 ## Links
 

--- a/packages/library-binary-numbers/README.md
+++ b/packages/library-binary-numbers/README.md
@@ -88,7 +88,7 @@ The extra states this library spends are mostly bookkeeping for the `^`/`$` mark
 
 For a teaching context, both libraries shipping in parallel makes the cost of representation choices tangible.
 
-See the rendered Mermaid graphs for every state in [`states.md`](states.md) (regenerated via `npm run docs:states` from the repo root; the spec at `src/graphs.spec.ts` only verifies structural properties of the graphs, not the markdown file).
+See the rendered Mermaid graphs for every state in [`states.md`](states.md) — regenerated via `npm run docs:states` from the repo root.
 
 ## Links
 


### PR DESCRIPTION
## Summary

Both library READMEs ended with a parenthetical referencing the internal spec file \`src/graphs.spec.ts\`. The note is maintainer-facing trivia — npm consumers don't need to know how the maintainer keeps \`states.md\` in sync.

Trimmed to one clean sentence per file:

> See the rendered Mermaid graphs for every state in \`states.md\` — regenerated via \`npm run docs:states\` from the repo root.

\`npm run docs:states\` stays — it's user-actionable for anyone who clones the repo.

**Paired change.** The two libraries' READMEs are kept structurally identical per the rule in the engine CLAUDE.md ("Documentation parity for the two binary libraries"). Both get the exact same edit in the same diff.

## Test plan

Doc-only, no code touched.