### PR TITLE
feat(machine): lazy-init DebugConfig + seal instance (closes #150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Key shapes that take reading multiple files to grasp:
   Cross-version notes:
   - **v5**: hook renamed `onDebugBreak` → `onPause` (#110). `haltState.debug.after = true` (or `{ before, after }` together) now throws at write-time — halt is terminal, no iteration-after-halt to anchor on (#108 part 2). Halting iter's after-fire stopped being silently lost (#108 part 1). New `run({ debug: boolean })` master switch suppresses all `onPause` dispatches without editing `state.debug` assignments (#106).
   - **v6**: `onPause(after, K)` now fires on iter K's *own* yield, alongside `onPause(before, K)` and `onStep(K)` — per-iter lifecycle is `before → step → after` (#119). Previously `after` fired on iter K+1's tick with a `prevYield` substitution dance; that substitution is gone. Implication: tests asserting cross-hook ordering at the lifecycle level need v6-aware shape.
+  - **v6.1**: `state.debug` is now always a non-null `DebugConfig` (lazy-initialized on first read), so chained writes like `state.debug.before = true` work on a fresh state without a prior whole-object assignment. The instance is `Object.seal`-ed — typos throw `TypeError`. `state.debug = null` continues to work but now means "reset filters" (next read returns a fresh empty config). Type signature narrowed `DebugConfig | null` → `DebugConfig` on the getter; setter still accepts `null`. (#150)
 
 ### Visualization & round-trip
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -473,25 +473,26 @@ import { State, haltState, ifOtherSymbol } from '@turing-machine-js/machine';
 
 const myState = new State({...});
 
-// Pause before applying any of myState's commands:
+// state.debug is always a DebugConfig instance — chained writes work
+// without prior whole-object assignment:
+myState.debug.before = true;
+myState.debug.after = [symA];
+
+// Whole-object assignment also works for one-shot setup:
 myState.debug = { before: true };
-
-// Pause only when the head shows symA:
 myState.debug = { before: [symA] };
-
-// Pause both before and after for the same symbol — two pauses per visit:
 myState.debug = { before: [symA], after: [symA] };
 
 // Pause when the engine is about to enter halt (program exit OR subroutine pop):
 haltState.debug = { before: true };
 
-// Disable later:
+// Reset filters later — next read returns a fresh empty DebugConfig:
 myState.debug = null;
 ```
 
 > ⚠️ **`haltState.debug.after` throws.** Halt is terminal — there is no iteration-after-halt for an after-fire to anchor on. Assigning a truthy `.after` to `haltState.debug` (including `{ before: true, after: true }`) throws at write time. Symbol-list filters on `haltState.debug.before` are silent no-ops, since halt has no head symbol; only the wildcard `true` activates.
 
-The `debug` field is mutable — toggle breakpoints at runtime without rebuilding the graph. The internal cell is shared with `state.withOverrodeHaltState(...)` wrappers, so an assignment on the original is visible from every wrapper. Plain-object input (`state.debug = { before: true }`) is wrapped in a `DebugConfig` instance automatically; the wrapper's per-property setters validate and freeze the stored array, so `state.debug.before.push(...)` throws `TypeError`.
+The `debug` field is mutable — toggle breakpoints at runtime without rebuilding the graph. The internal cell is shared with `state.withOverrodeHaltState(...)` wrappers, so an assignment on the original is visible from every wrapper. `state.debug` is always a `DebugConfig` instance (lazy-initialized on first read); plain-object input (`state.debug = { before: true }`) is wrapped in a fresh `DebugConfig` automatically. The instance itself is `Object.seal`-ed — typos like `state.debug.bofore = true` throw `TypeError` instead of silently creating a useless property. Per-property setters validate and freeze the stored array, so `state.debug.before.push(...)` also throws `TypeError`.
 
 `run()` is async and accepts an `onPause` hook:
 
@@ -588,6 +589,7 @@ API surface changes since v3, in past tense so the timing of each piece is expli
 - **v4** — `run()` became async (`Promise<void>`). Per-state runtime breakpoints landed (`state.debug.before` / `state.debug.after`); `run()` accepted an `onDebugBreak` hook. `MachineState` exposed on each yield.
 - **v5** — `onDebugBreak` renamed to `onPause`. New `run({ debug: boolean })` master switch suppresses all `onPause` dispatches without unsetting `state.debug` assignments. Assigning a truthy `.after` to `haltState.debug` now throws at write time (halt is terminal — no iteration-after-halt to anchor on).
 - **v6** — Per-iter lifecycle reordered to `before → step → after`, all firing on the same yield. Previously `after` fired on iter K+1's tick with a `prevYield` substitution dance; that substitution is gone. The `MachineState.debugBreak` field shape is unchanged across all three versions.
+- **v6.1** — `state.debug` ergonomics: the field is now always a non-null `DebugConfig` instance (lazy-initialized on first read), so chained field writes like `state.debug.before = true` work on a fresh state without a prior whole-object assignment. The `DebugConfig` instance is `Object.seal`-ed, so typos like `state.debug.bofore = true` throw `TypeError` at write time instead of silently creating a useless property. `state.debug = null` continues to work but semantically means "reset filters" — the next read returns a fresh empty `DebugConfig` (#150).
 
 For the full release history, see the [GitHub releases page](https://github.com/mellonis/turing-machine-js/releases).
 

--- a/packages/machine/src/classes/State.debug.spec.ts
+++ b/packages/machine/src/classes/State.debug.spec.ts
@@ -13,17 +13,56 @@ const makeState = (): State => {
   });
 };
 
-describe('State.debug — basics', () => {
-  test('defaults to null', () => {
+describe('DebugConfig — sealed instance (defensive against typos)', () => {
+  test('the DebugConfig instance is Object.seal-ed', () => {
     const state = makeState();
-    expect(state.debug).toBeNull();
+    expect(Object.isSealed(state.debug)).toBe(true);
+  });
+
+  test('typo on field name throws TypeError (strict mode)', () => {
+    const state = makeState();
+    expect(() => {
+      // @ts-expect-error — deliberate typo to assert it fails loudly.
+      state.debug.bofore = true;
+    }).toThrow(TypeError);
+  });
+
+  test('legitimate fields (before, after) remain writable through setters', () => {
+    const state = makeState();
+    expect(() => {
+      state.debug.before = true;
+      state.debug.after = true;
+    }).not.toThrow();
+    expect(state.debug.before).toBe(true);
+    expect(state.debug.after).toBe(true);
+  });
+});
+
+describe('State.debug — basics', () => {
+  test('returns an empty DebugConfig by default (lazy-init)', () => {
+    const state = makeState();
+    expect(state.debug).toBeInstanceOf(DebugConfig);
+    expect(state.debug.before).toBeUndefined();
+    expect(state.debug.after).toBeUndefined();
+  });
+
+  test('chained field write `state.debug.before = true` works on a fresh state', () => {
+    const state = makeState();
+    state.debug.before = true;
+    expect(state.debug.before).toBe(true);
+  });
+
+  test('chained field write `state.debug.after = true` works on a fresh state', () => {
+    const state = makeState();
+    state.debug.after = true;
+    expect(state.debug.after).toBe(true);
   });
 
   test('plain-object assignment is wrapped in a DebugConfig instance', () => {
     const state = makeState();
     state.debug = {before: true};
     expect(state.debug).toBeInstanceOf(DebugConfig);
-    expect(state.debug!.before).toBe(true);
+    expect(state.debug.before).toBe(true);
   });
 
   test('DebugConfig instance assignment is stored as-is (identity preserved)', () => {
@@ -33,11 +72,22 @@ describe('State.debug — basics', () => {
     expect(state.debug).toBe(cfg);
   });
 
-  test('setter accepts null to clear', () => {
+  test('null assignment resets filters; next read returns a fresh empty DebugConfig', () => {
     const state = makeState();
     state.debug = {before: true};
     state.debug = null;
-    expect(state.debug).toBeNull();
+    expect(state.debug).toBeInstanceOf(DebugConfig);
+    expect(state.debug.before).toBeUndefined();
+    expect(state.debug.after).toBeUndefined();
+  });
+
+  test('chained write works again after `state.debug = null`', () => {
+    const state = makeState();
+    state.debug = {before: true};
+    state.debug = null;
+    state.debug.before = true;
+    expect(state.debug.before).toBe(true);
+    expect(state.debug.after).toBeUndefined();
   });
 
   test('withOverrodeHaltState returns a new state that shares the debug ref', () => {
@@ -45,21 +95,27 @@ describe('State.debug — basics', () => {
     const wrapped = state.withOverrodeHaltState(haltState);
 
     expect(wrapped).not.toBe(state);
-    expect(wrapped.debug).toBeNull();
+    // Both lazy-init through the shared ref, so reading either returns the
+    // same DebugConfig instance.
+    expect(wrapped.debug).toBeInstanceOf(DebugConfig);
+    expect(wrapped.debug).toBe(state.debug);
 
     state.debug = {before: true};
 
     // Wrapper sees the assignment because both share the same Ref cell.
     expect(wrapped.debug).toBe(state.debug);
+    expect(wrapped.debug.before).toBe(true);
   });
 
-  test('setting null on the original propagates to wrappers', () => {
+  test('null assignment on the original propagates to wrappers (filters reset for both)', () => {
     const state = makeState();
     state.debug = {before: true};
     const wrapped = state.withOverrodeHaltState(haltState);
 
     state.debug = null;
-    expect(wrapped.debug).toBeNull();
+    expect(state.debug.before).toBeUndefined();
+    expect(wrapped.debug.before).toBeUndefined();
+    expect(wrapped.debug).toBe(state.debug);
   });
 
   test('setting on the wrapper propagates back to the original', () => {
@@ -68,7 +124,7 @@ describe('State.debug — basics', () => {
 
     wrapped.debug = {after: true};
     expect(state.debug).toBe(wrapped.debug);
-    expect(state.debug!.after).toBe(true);
+    expect(state.debug.after).toBe(true);
   });
 
   test('chained wrappers all share the SAME debug object (identity)', () => {
@@ -94,9 +150,9 @@ describe('DebugConfig — class accessors', () => {
     });
 
     state.debug = {};                    // empty config
-    state.debug!.before = [symA];        // class setter triggers
-    expect(state.debug!.before).toEqual([symA]);
-    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+    state.debug.before = [symA];        // class setter triggers
+    expect(state.debug.before).toEqual([symA]);
+    expect(Object.isFrozen(state.debug.before)).toBe(true);
   });
 
   test('extending the filter via `cfg.before = [...cfg.before, sym]` works', () => {
@@ -109,16 +165,16 @@ describe('DebugConfig — class accessors', () => {
     });
 
     state.debug = {before: [symA]};
-    state.debug!.before = [...(state.debug!.before as readonly symbol[]), ifOtherSymbol];
-    expect(state.debug!.before).toEqual([symA, ifOtherSymbol]);
-    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+    state.debug.before = [...(state.debug.before as readonly symbol[]), ifOtherSymbol];
+    expect(state.debug.before).toEqual([symA, ifOtherSymbol]);
+    expect(Object.isFrozen(state.debug.before)).toBe(true);
   });
 
   test('per-property setter validates new symbol list', () => {
     const state = makeState();
     state.debug = {};
     expect(() => {
-      state.debug!.before = [Symbol('random')];
+      state.debug.before = [Symbol('random')];
     }).toThrow(/not a transition key of this state/);
   });
 
@@ -126,7 +182,7 @@ describe('DebugConfig — class accessors', () => {
     const state = makeState();
     state.debug = {before: [ifOtherSymbol]};
     expect(() => {
-      (state.debug!.before as symbol[]).push(Symbol('x'));
+      (state.debug.before as symbol[]).push(Symbol('x'));
     }).toThrow(TypeError);
   });
 
@@ -134,7 +190,7 @@ describe('DebugConfig — class accessors', () => {
     const state = makeState();
     state.debug = {before: [ifOtherSymbol]};
     expect(() => {
-      (state.debug!.before as symbol[])[0] = Symbol('x');
+      (state.debug.before as symbol[])[0] = Symbol('x');
     }).toThrow(TypeError);
   });
 
@@ -154,17 +210,17 @@ describe('DebugConfig — class accessors', () => {
     expect(Object.isFrozen(userInput)).toBe(false);
     userInput.push(ifOtherSymbol);  // works fine
     // But the stored array is still its own frozen snapshot:
-    expect(state.debug!.before).toEqual([symA]);
+    expect(state.debug.before).toEqual([symA]);
   });
 
   test('true (wildcard) and undefined bypass freeze (no array to freeze)', () => {
     const state = makeState();
     state.debug = {before: true};
     // before is `true`, not an array — Object.isFrozen on a non-array is whatever JS says.
-    expect(state.debug!.before).toBe(true);
+    expect(state.debug.before).toBe(true);
 
-    state.debug!.before = undefined;
-    expect(state.debug!.before).toBeUndefined();
+    state.debug.before = undefined;
+    expect(state.debug.before).toBeUndefined();
   });
 });
 
@@ -275,13 +331,13 @@ describe('State.debug — post-assignment immutability (frozen arrays)', () => {
   test('inner before array is frozen', () => {
     const state = makeState();
     state.debug = {before: [ifOtherSymbol]};
-    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+    expect(Object.isFrozen(state.debug.before)).toBe(true);
   });
 
   test('inner after array is frozen', () => {
     const state = makeState();
     state.debug = {after: [ifOtherSymbol]};
-    expect(Object.isFrozen(state.debug!.after)).toBe(true);
+    expect(Object.isFrozen(state.debug.after)).toBe(true);
   });
 
   test('push to filter array throws TypeError', () => {
@@ -289,7 +345,7 @@ describe('State.debug — post-assignment immutability (frozen arrays)', () => {
     state.debug = {before: [ifOtherSymbol]};
 
     expect(() => {
-      (state.debug!.before as symbol[]).push(Symbol('x'));
+      (state.debug.before as symbol[]).push(Symbol('x'));
     }).toThrow(TypeError);
   });
 
@@ -305,10 +361,10 @@ describe('State.debug — post-assignment immutability (frozen arrays)', () => {
     state.debug = {before: [symA]};
     expect(() => {
       state.debug = {
-        before: [...(state.debug!.before as readonly symbol[]), ifOtherSymbol],
+        before: [...(state.debug.before as readonly symbol[]), ifOtherSymbol],
       };
     }).not.toThrow();
-    expect(state.debug!.before).toEqual([symA, ifOtherSymbol]);
-    expect(Object.isFrozen(state.debug!.before)).toBe(true);
+    expect(state.debug.before).toEqual([symA, ifOtherSymbol]);
+    expect(Object.isFrozen(state.debug.before)).toBe(true);
   });
 });

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -43,6 +43,13 @@ export class DebugConfig {
         this.after = initial.after as symbol[] | true;
       }
     }
+
+    // Seal the instance so typos like `cfg.bofore = true` throw at write
+    // time (in strict mode, which TS-emitted modules use) instead of
+    // silently creating a useless own property. The class's `before`/`after`
+    // setters still work — they resolve through the prototype chain and
+    // write to private fields, neither of which Object.seal restricts.
+    Object.seal(this);
   }
 
   get before(): readonly symbol[] | true | undefined {
@@ -160,7 +167,16 @@ export default class State {
     return this;
   }
 
-  get debug(): DebugConfig | null {
+  get debug(): DebugConfig {
+    // Lazy-init: `state.debug` is never null at read time, so chained writes
+    // like `state.debug.before = true` work on a fresh state without a prior
+    // whole-object assignment. The setter still accepts `null` to reset the
+    // filters; the next read recreates a fresh empty `DebugConfig` on demand.
+    // See #150.
+    if (this.#debugRef.current === null) {
+      this.#debugRef.current = new DebugConfig(this);
+    }
+
     return this.#debugRef.current;
   }
 

--- a/test/examples.spec.ts
+++ b/test/examples.spec.ts
@@ -159,25 +159,35 @@ describe('README.md — Debugging breakpoints', () => {
     expect(haltPauses[0].atVisit).toBe(VISIT_COUNT - 1);
   });
 
-  test('Disable later by assigning null', () => {
+  test('Reset filters by assigning null', () => {
     const {myState} = buildExampleMachine();
     myState.debug = {before: true};
 
-    expect(myState.debug).not.toBeNull();
-    expect(myState.debug?.before).toBe(true);
+    expect(myState.debug.before).toBe(true);
 
     myState.debug = null;
 
-    expect(myState.debug).toBeNull();
+    // Reading after null assignment lazy-recreates a fresh empty DebugConfig.
+    expect(myState.debug.before).toBeUndefined();
+    expect(myState.debug.after).toBeUndefined();
+  });
+
+  test('Chained field write works on a fresh state', () => {
+    const {myState, symA} = buildExampleMachine();
+    myState.debug.before = true;
+    myState.debug.after = [symA];
+
+    expect(myState.debug.before).toBe(true);
+    expect(myState.debug.after).toEqual([symA]);
   });
 
   test('Incremental update via per-property setter', () => {
     const {myState, symA} = buildExampleMachine();
     myState.debug = {before: [symA]};
 
-    myState.debug!.before = [...(myState.debug!.before as readonly symbol[]), ifOtherSymbol];
+    myState.debug.before = [...(myState.debug.before as readonly symbol[]), ifOtherSymbol];
 
-    expect(myState.debug!.before).toEqual([symA, ifOtherSymbol]);
+    expect(myState.debug.before).toEqual([symA, ifOtherSymbol]);
   });
 
   test('onStep + onPause fire independently — same count on this fixture', async () => {


### PR DESCRIPTION
## Summary

Two coordinated ergonomic improvements to `State.debug`, both backward-compatible at the runtime level:

1. **Lazy-init**: `state.debug` is now always a non-null `DebugConfig` instance — created on demand on first read. Chained writes like `state.debug.before = true` work on a fresh state without a prior \`state.debug = {}\` setup. Setter still accepts \`null\` to reset filters; next read recreates a fresh empty config.

2. **Object.seal** on `DebugConfig` instances: typos like \`state.debug.bofore = true\` throw \`TypeError\` (in strict mode — TS-emitted modules use it by default) instead of silently creating a useless own property. Legitimate \`before\` / \`after\` setters keep working — they resolve through the prototype chain into private fields, which \`Object.seal\` doesn't restrict.

Closes #150.

## Type narrowing

Getter return type: \`DebugConfig | null\` → \`DebugConfig\`. Setter parameter type unchanged (still accepts \`null\` for reset). Consumer code that checked \`if (state.debug === null)\` becomes dead code but doesn't crash. Runtime: \`state.debug?.before\` / \`?.after\` patterns keep working (the \`?.\` is now redundant but correct).

## Wrapper sharing preserved

`withOverrodeHaltState`'s shared `#debugRef` cell semantic is unchanged — first read on either bare or wrapper triggers lazy-init through the same ref, and both subsequent reads return the same `DebugConfig` instance. The `chained wrappers all share the SAME debug object (identity)` test continues to pass without modification.

## Test plan

- [x] \`npm test\` — **413/413 passing** (was 408; +5 new tests: 3 sealed-behavior + 2 chained-write).
- [x] \`npm run lint\` — clean.
- [x] \`npm run build\` — clean (TypeScript narrowing accepted).
- [x] All existing State.debug tests passing after updates (rewrote 4 tests that asserted \`state.debug === null\` after construction or null-assignment; cleaned up \`!\` non-null assertions throughout the spec).
- [x] README mirror test rewritten: \`Disable later by assigning null\` → \`Reset filters by assigning null\` (matches new README wording).

## Docs

- README: \`## Debugging breakpoints\` — added chained-write examples as preferred form; updated surrounding paragraph; added v6.1 entry to \`## Versioning notes\`.
- CLAUDE.md: \`state.debug\` cross-version notes — added v6.1 entry.
- No cross-repo doc changes needed — post-machine-js and machines-demo reference \`state.debug\` only as a generic API surface, no null-state assertions.

## Why v6.1, not v7

Ergonomic API polish, not part of the composition-representation overhaul (#138 / #148 / #149) defining v7. Runtime behavior is unchanged; only the surface gets friendlier. Type narrowing is a strictly-stricter signature, which TS treats safely. Labelled \`v6.1\`; ships as a focused minor release whenever ready.