### PR TITLE
chore(release): v6.1.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.1",
+  "version": "6.1.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,7 +10656,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10667,7 +10667,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10678,7 +10678,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10689,7 +10689,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
## Summary

Lockstep bump from \`6.0.1\` → \`6.1.0\` across all four packages + \`lerna.json\` + \`package-lock.json\`.

## What's new in v6.1.0

One additive ergonomic improvement to \`State.debug\`, no breaking changes:

- **[#150](https://github.com/mellonis/turing-machine-js/issues/150)** — Lazy-init \`DebugConfig\` + Object.seal on instance. \`state.debug\` is now always a non-null \`DebugConfig\` instance, so chained writes like \`state.debug.before = true\` work on a fresh state without a prior \`state.debug = {}\` setup step. The instance is sealed — typos like \`state.debug.bofore = true\` throw \`TypeError\` instead of silently creating a useless property. Type narrowed on the getter (\`DebugConfig | null\` → \`DebugConfig\`); setter still accepts \`null\` (now semantically "reset filters").

  Shipped in [#151](https://github.com/mellonis/turing-machine-js/pull/151).

## Peer-dep compatibility

Minor bump → no peer-dep widening required. The three dependent packages (\`builder\`, \`library-binary-numbers\`, \`library-binary-numbers-bare\`) already declare \`peerDependencies['@turing-machine-js/machine']: ^6.0.0\`, which includes \`6.1.0\`.

## Test plan

- [x] \`npm test\` — 413/413 passing.
- [x] \`npm run lint\` — clean.
- [x] \`npm run build\` — clean.