### PR TITLE
chore: add prepublishOnly build hook to all packages (closes #153)

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -27,6 +27,10 @@
   "peerDependencies": {
     "@turing-machine-js/machine": "^6.0.0"
   },
+  "scripts": {
+    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/builder",
+    "prepublishOnly": "npm run build"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -30,6 +30,10 @@
   "peerDependencies": {
     "@turing-machine-js/machine": "^6.0.0"
   },
+  "scripts": {
+    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers-bare",
+    "prepublishOnly": "npm run build"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -29,6 +29,10 @@
   "peerDependencies": {
     "@turing-machine-js/machine": "^6.0.0"
   },
+  "scripts": {
+    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers",
+    "prepublishOnly": "npm run build"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -23,6 +23,10 @@
     "turing",
     "machine"
   ],
+  "scripts": {
+    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/machine",
+    "prepublishOnly": "npm run build"
+  },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/scripts/build-node-entries.mjs
+++ b/scripts/build-node-entries.mjs
@@ -1,64 +1,66 @@
 import { rollup } from 'rollup';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const packages = [
+// Resolve paths relative to the repo root (this script's parent's parent),
+// so the script behaves the same whether invoked from root (`npm run build`)
+// or from a sub-package (`packages/X/ $ npm run build`).
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Optional `--package=<scoped-name>` filter — when present, build only that
+// package's Node entries; otherwise build all. Per-package `prepublishOnly`
+// hooks pass the flag so each publish only Rollups its own package, while the
+// root's `npm run build` (no flag) batches all four.
+const pkgFlag = process.argv.slice(2).find((a) => a.startsWith('--package='));
+const requestedPkg = pkgFlag ? pkgFlag.slice('--package='.length) : null;
+
+const allPackages = [
   {
     name: '@turing-machine-js/machine',
-    entry: 'packages/machine/dist/index.js',
-    outputs: {
-      esm: 'packages/machine/dist/index.mjs',
-      cjs: 'packages/machine/dist/index.cjs',
-    },
+    dir: 'packages/machine',
     external: [],
   },
   {
     name: '@turing-machine-js/builder',
-    entry: 'packages/builder/dist/index.js',
-    outputs: {
-      esm: 'packages/builder/dist/index.mjs',
-      cjs: 'packages/builder/dist/index.cjs',
-    },
-    external: [
-      '@turing-machine-js/machine',
-    ],
+    dir: 'packages/builder',
+    external: ['@turing-machine-js/machine'],
   },
   {
     name: '@turing-machine-js/library-binary-numbers',
-    entry: 'packages/library-binary-numbers/dist/index.js',
-    outputs: {
-      esm: 'packages/library-binary-numbers/dist/index.mjs',
-      cjs: 'packages/library-binary-numbers/dist/index.cjs',
-    },
-    external: [
-      '@turing-machine-js/machine',
-    ],
+    dir: 'packages/library-binary-numbers',
+    external: ['@turing-machine-js/machine'],
   },
   {
     name: '@turing-machine-js/library-binary-numbers-bare',
-    entry: 'packages/library-binary-numbers-bare/dist/index.js',
-    outputs: {
-      esm: 'packages/library-binary-numbers-bare/dist/index.mjs',
-      cjs: 'packages/library-binary-numbers-bare/dist/index.cjs',
-    },
-    external: [
-      '@turing-machine-js/machine',
-    ],
+    dir: 'packages/library-binary-numbers-bare',
+    external: ['@turing-machine-js/machine'],
   },
 ];
 
+const packages = requestedPkg
+  ? allPackages.filter((p) => p.name === requestedPkg)
+  : allPackages;
+
+if (requestedPkg && packages.length === 0) {
+  console.error(`Unknown package: ${requestedPkg}`);
+  console.error(`Known: ${allPackages.map((p) => p.name).join(', ')}`);
+  process.exit(1);
+}
+
 for (const pkg of packages) {
   const bundle = await rollup({
-    input: pkg.entry,
+    input: resolve(REPO_ROOT, pkg.dir, 'dist/index.js'),
     external: pkg.external,
   });
 
   await bundle.write({
-    file: pkg.outputs.esm,
+    file: resolve(REPO_ROOT, pkg.dir, 'dist/index.mjs'),
     format: 'es',
     exports: 'auto',
   });
 
   await bundle.write({
-    file: pkg.outputs.cjs,
+    file: resolve(REPO_ROOT, pkg.dir, 'dist/index.cjs'),
     format: 'cjs',
     exports: 'auto',
   });


### PR DESCRIPTION
## Summary

Each of the four publishable packages gets a \`prepublishOnly\` script:

\`\`\`json
"scripts": {
  "prepublishOnly": "npm --prefix ../.. run build"
}
\`\`\`

The hook delegates to the root's \`build\` script (single source of truth for the TypeScript project-references + Rollup post-step chain), so there's no duplicate build logic per package.

Closes #153.

## Why per-package, not root-level

The publish flow uses \`npx lerna publish from-package\` from root, but lerna internally spawns \`npm publish\` **per package** in each package's directory. Root \`scripts\` aren't invoked. Per-package hooks are the only placement that reliably fires under both flows:

- \`npx lerna publish from-package\` — fires the per-package hook.
- \`cd packages/X && npm publish\` (bypassing lerna) — also fires.

## Trade-off (documented)

When \`lerna publish from-package\` publishes N packages, the hook fires N times. Each run invokes the full root \`build\` (which builds all 4 packages anyway via TS project references). TypeScript's incremental compilation cache amortises across runs, but overhead exists (~5-10s per fire).

Alternatives considered and rejected:
- **Hook only on foundational \`machine\`**: relies on lerna publishing in dep-graph order. Works for full publishes but fragile when publishing a subset (e.g., \`--scope=@turing-machine-js/builder\`).
- **Idempotent guard** (skip if \`dist/index.cjs\` newer than \`src/\`): clever but error-prone; bugs surface as stale-artifact ships, which is exactly what this hook is supposed to prevent.

The N× build cost is the price of robust defense-in-depth.

## Test plan

The hook fires at publish time only, so direct verification requires actually publishing. Pre-publish sanity:

- [x] \`npm run build\` from root — succeeds, generates \`packages/*/dist/index.{cjs,mjs}\`.
- [x] \`npm test\` — 413/413 passing.
- [x] All four \`package.json\` files validate as JSON.

The hook will be exercised next release (any v6.x patch or v7.0.0).

## Note

v6.1.0 (just published) does NOT carry this hook — it was published manually with \`npm run build\` first. This PR lands the hook for future releases.