### PR TITLE
fix: declare inter-package TS references; per-package build uses local tsconfig (closes #155)

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -28,7 +28,7 @@
     "@turing-machine-js/machine": "^6.0.0"
   },
   "scripts": {
-    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/builder",
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/builder",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/index.cjs",

--- a/packages/builder/tsconfig.build.json
+++ b/packages/builder/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "../machine/tsconfig.build.json" }
+  ],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -31,7 +31,7 @@
     "@turing-machine-js/machine": "^6.0.0"
   },
   "scripts": {
-    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers-bare",
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers-bare",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/index.cjs",

--- a/packages/library-binary-numbers-bare/tsconfig.build.json
+++ b/packages/library-binary-numbers-bare/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "../machine/tsconfig.build.json" }
+  ],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -30,7 +30,7 @@
     "@turing-machine-js/machine": "^6.0.0"
   },
   "scripts": {
-    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers",
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/index.cjs",

--- a/packages/library-binary-numbers/tsconfig.build.json
+++ b/packages/library-binary-numbers/tsconfig.build.json
@@ -1,4 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    { "path": "../machine/tsconfig.build.json" }
+  ],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -24,7 +24,7 @@
     "machine"
   ],
   "scripts": {
-    "build": "tsc --build --verbose ../../tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/machine",
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/machine",
     "prepublishOnly": "npm run build"
   },
   "main": "dist/index.cjs",

--- a/packages/machine/tsconfig.build.json
+++ b/packages/machine/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true
   },
   "exclude": ["**/*.spec.ts", "dist"]
 }


### PR DESCRIPTION
## The bug (#155)

Clean \`npm run build\` (no existing \`dist/\` or \`*.tsbuildinfo\`) fails on first pass with \`TS2307: Cannot find module '@turing-machine-js/machine'\`. Workaround was running \`npm run build\` twice — first pass builds \`machine\` (the dependents fail), second pass succeeds because \`machine\`'s dist now exists.

Root cause: per-package \`tsconfig.build.json\` files did not declare inter-package references. Root config listed them alphabetically; tsc tried builder/library-binary-numbers/library-binary-numbers-bare BEFORE machine.

## Fix

Two coordinated changes:

1. **Each \`packages/*/tsconfig.build.json\` declares \`composite: true\`** (required by TS project-references mode).
2. **Three dependents declare \`references: [{path: "../machine/tsconfig.build.json"}]\`**. tsc now resolves topological order correctly.

## Bonus optimisation

Now that refs are correct, per-package \`build\` scripts (added in #154) switch from root tsconfig to local tsconfig:

\`\`\`diff
- "build": "tsc --build --verbose ../../tsconfig.build.json && ..."
+ "build": "tsc --build --verbose tsconfig.build.json && ..."
\`\`\`

When invoked via \`prepublishOnly\` from a sub-package, tsc only processes that package plus its transitive references (machine for dependents, nothing extra for machine itself) — not all four packages. For \`lerna publish from-package\` with the four-package lockstep release, this means **4 narrow tsc invocations instead of 4 root-wide ones**. Marginal but cleaner architecturally.

## Verification

- Clean state (\`find packages -name '*.tsbuildinfo' -delete && rm -rf packages/*/dist\`) then \`npm run build\` → **succeeds in one pass** (previously required two).
- Clean state then \`cd packages/builder && npm run build\` → tsc builds machine first via the new reference, then builder; Rollup runs only for builder.
- \`npm test\` — 413/413 passing.
- \`npm run lint\` — clean.