### PR TITLE
fix: await onStep in TuringMachine.run (closes #158)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: '24'
       - run: npm ci
       - run: npm run lint
+      - run: npm run typecheck
       - run: npm run test:coverage
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "docs:states": "node ./scripts/build-states-md.mjs",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p packages/machine/tsconfig.json && tsc --noEmit -p packages/builder/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers-bare/tsconfig.json"
   },
   "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "workspaces": [

--- a/packages/builder/tsconfig.build.json
+++ b/packages/builder/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "composite": true
   },
   "references": [

--- a/packages/builder/tsconfig.json
+++ b/packages/builder/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "..",
     "outDir": "dist",
     "paths": {
-      "@turing-machine-js/*": ["./packages/*"]
+      "@turing-machine-js/*": ["../*/src/index"]
     }
   }
 }

--- a/packages/library-binary-numbers-bare/tsconfig.build.json
+++ b/packages/library-binary-numbers-bare/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "composite": true
   },
   "references": [

--- a/packages/library-binary-numbers-bare/tsconfig.json
+++ b/packages/library-binary-numbers-bare/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "..",
     "outDir": "dist",
     "paths": {
-      "@turing-machine-js/*": ["./packages/*"]
+      "@turing-machine-js/*": ["../*/src/index"]
     }
   }
 }

--- a/packages/library-binary-numbers/tsconfig.build.json
+++ b/packages/library-binary-numbers/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "composite": true
   },
   "references": [

--- a/packages/library-binary-numbers/tsconfig.json
+++ b/packages/library-binary-numbers/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "..",
     "outDir": "dist",
     "paths": {
-      "@turing-machine-js/*": ["./packages/*"]
+      "@turing-machine-js/*": ["../*/src/index"]
     }
   }
 }

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -42,7 +42,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     const {machine, state} = buildMachine();
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -55,7 +55,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     state.debug = {before: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -69,7 +69,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     state.debug = {before: [symA]};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     const aVisits = steps.filter((s) => s.currentSymbols[0] === 'A');
     const nonAVisits = steps.filter((s) => s.currentSymbols[0] !== 'A');
@@ -85,7 +85,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     state.debug = {before: []};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -98,7 +98,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     state.debug = {before: [ifOtherSymbol]};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     const blankVisits = steps.filter((s) => s.currentSymbols[0] === alphabet.blankSymbol);
     const nonBlankVisits = steps.filter((s) => s.currentSymbols[0] !== alphabet.blankSymbol);
@@ -119,7 +119,7 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     state.debug = {after: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -132,7 +132,7 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     state.debug = {before: true, after: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -146,7 +146,7 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     state.debug = {after: [symA]};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     const aHits = steps.filter((s) => s.currentSymbols[0] === 'A');
@@ -169,7 +169,7 @@ describe('TuringMachine — haltState.debug.before', () => {
     haltState.debug = {before: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     // Only the visit that transitions to halt (the trailing blank) carries
@@ -212,7 +212,7 @@ describe('TuringMachine — haltState.debug.before', () => {
     haltState.debug = {before: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: wrapped, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: wrapped, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(3);
 
@@ -237,7 +237,7 @@ describe('TuringMachine — haltState.debug.before', () => {
     haltState.debug = {before: [symA]};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     // Halt has no head symbol; list filter cannot match. No debug break should fire
@@ -263,7 +263,7 @@ describe('TuringMachine — run() with onPause', () => {
     state.debug = {before: true};
     const steps: MachineState[] = [];
 
-    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => { steps.push(s); }});
 
     // Trajectory unaffected — onStep sees same number of yields as without debug.
     expect(steps).toHaveLength(VISIT_COUNT);

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -38,11 +38,11 @@ const buildMachine = () => {
 };
 
 describe('TuringMachine — debug.before filter (loop yields)', () => {
-  test('without debug, no debugBreak field on yields', () => {
+  test('without debug, no debugBreak field on yields', async () => {
     const {machine, state} = buildMachine();
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -50,12 +50,12 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     }
   });
 
-  test('debug.before = true tags every visit with debugBreak.before', () => {
+  test('debug.before = true tags every visit with debugBreak.before', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -63,13 +63,13 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     }
   });
 
-  test('debug.before with symbol list matches only listed symbols', () => {
+  test('debug.before with symbol list matches only listed symbols', async () => {
     const {machine, state, symbol} = buildMachine();
     const symA = symbol(['A']);
     state.debug = {before: [symA]};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     const aVisits = steps.filter((s) => s.currentSymbols[0] === 'A');
     const nonAVisits = steps.filter((s) => s.currentSymbols[0] !== 'A');
@@ -80,12 +80,12 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     for (const v of nonAVisits) expect(v).not.toHaveProperty('debugBreak');
   });
 
-  test('debug.before with empty list never matches', () => {
+  test('debug.before with empty list never matches', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: []};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -93,12 +93,12 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
     }
   });
 
-  test('debug.before with [ifOtherSymbol] matches only the catch-all visit', () => {
+  test('debug.before with [ifOtherSymbol] matches only the catch-all visit', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: [ifOtherSymbol]};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     const blankVisits = steps.filter((s) => s.currentSymbols[0] === alphabet.blankSymbol);
     const nonBlankVisits = steps.filter((s) => s.currentSymbols[0] !== alphabet.blankSymbol);
@@ -114,12 +114,12 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
   // on the same yield. Previously `after` was on the NEXT yield with a
   // substituted source-state payload — see #109/#119 for the rationale.
 
-  test('debug.after = true tags every yield with debugBreak.after', () => {
+  test('debug.after = true tags every yield with debugBreak.after', async () => {
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -127,12 +127,12 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     }
   });
 
-  test('before AND after on same visit produce both flags on every yield', () => {
+  test('before AND after on same visit produce both flags on every yield', async () => {
     const {machine, state} = buildMachine();
     state.debug = {before: true, after: true};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     for (const step of steps) {
@@ -140,13 +140,13 @@ describe('TuringMachine — debug.after filter (loop yields)', () => {
     }
   });
 
-  test('after with symbol list matches only listed symbols', () => {
+  test('after with symbol list matches only listed symbols', async () => {
     const {machine, state, symbol} = buildMachine();
     const symA = symbol(['A']);
     state.debug = {after: [symA]};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     const aHits = steps.filter((s) => s.currentSymbols[0] === 'A');
@@ -164,12 +164,12 @@ describe('TuringMachine — haltState.debug.before', () => {
     haltState.debug = null;
   });
 
-  test('haltState.debug.before = true fires on program halt (last visit only)', () => {
+  test('haltState.debug.before = true fires on program halt (last visit only)', async () => {
     const {machine, state} = buildMachine();
     haltState.debug = {before: true};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     // Only the visit that transitions to halt (the trailing blank) carries
@@ -183,7 +183,7 @@ describe('TuringMachine — haltState.debug.before', () => {
     expect(last.debugBreak).toEqual({before: true});
   });
 
-  test('haltState.debug.before fires on subroutine return (halt-pop)', () => {
+  test('haltState.debug.before fires on subroutine return (halt-pop)', async () => {
     // Custom 1-cell tape + nested-state setup. Trajectory:
     //   visit 1: head 'A', state=wrapped → erase+right, transition to inner
     //   visit 2: head blank, state=inner → ifOtherSymbol → would halt;
@@ -212,7 +212,7 @@ describe('TuringMachine — haltState.debug.before', () => {
     haltState.debug = {before: true};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: wrapped, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: wrapped, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(3);
 
@@ -231,13 +231,13 @@ describe('TuringMachine — haltState.debug.before', () => {
     expect(steps[2].debugBreak).toEqual({before: true});
   });
 
-  test('haltState.debug.before with symbol list NEVER matches (no head symbol at halt)', () => {
+  test('haltState.debug.before with symbol list NEVER matches (no head symbol at halt)', async () => {
     const {machine, state, symbol} = buildMachine();
     const symA = symbol(['A']);
     haltState.debug = {before: [symA]};
     const steps: MachineState[] = [];
 
-    machine.run({initialState: state, onStep: (s) => steps.push(s)});
+    await machine.run({initialState: state, onStep: (s) => steps.push(s)});
 
     expect(steps).toHaveLength(VISIT_COUNT);
     // Halt has no head symbol; list filter cannot match. No debug break should fire

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -155,6 +155,32 @@ describe('run tests', () => {
     }).toThrow('some exception');
     expect(generator.next().done).toBe(true);
   });
+
+  test('async onStep is awaited between iters (#158)', async () => {
+    const order: string[] = [];
+    const yieldToMicrotask = () => new Promise<void>((r) => queueMicrotask(r));
+
+    await machine.run({
+      initialState,
+      stepsLimit: 1e5,
+      onStep: async (m) => {
+        order.push(`pre-${m.step}`);
+        await yieldToMicrotask();
+        order.push(`post-${m.step}`);
+      },
+    });
+
+    // pre-N and post-N must always be adjacent — never interleaved like
+    // `pre-0, pre-1, post-0, post-1` — because the engine awaits each call
+    // before yielding the next MachineState. Pre/post pairs are emitted in
+    // strictly increasing `step` order.
+    expect(order.length).toBeGreaterThan(0);
+    for (let i = 0; i < order.length; i += 2) {
+      const stepN = order[i].slice(4);
+      expect(order[i]).toBe(`pre-${stepN}`);
+      expect(order[i + 1]).toBe(`post-${stepN}`);
+    }
+  });
 });
 
 describe('properties', () => {

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -84,7 +84,7 @@ describe('run tests', () => {
   test('run', async () => {
     const steps: MachineState[] = [];
 
-    await machine.run({initialState, stepsLimit: 1e5, onStep: (step) => steps.push(step)});
+    await machine.run({initialState, stepsLimit: 1e5, onStep: (step) => { steps.push(step); }});
 
     expect(steps)
       .toEqual(expectedSteps);

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -62,11 +62,17 @@ export default class TuringMachine {
     debug = true,
   }: RunParameter & {
     /**
-     * Sync, ~free hook fired on every iteration. Use for logging/tracing —
-     * the hot loop runs this without a microtask boundary, so it must not
-     * be async.
+     * Hook fired on every iteration. Use for logging/tracing — and for
+     * yield-style coordination: returning a Promise suspends the run loop
+     * until it resolves, so a consumer can throttle the per-iter cadence
+     * (e.g. an interactive debugger awaiting a `setTimeout`-Promise between
+     * iters) without owning the loop. A sync `void` return adds one microtask
+     * boundary per iter (the engine awaits a non-Promise to keep the dispatch
+     * shape uniform); negligible for typical loops, but noted for tight ones.
+     *
+     * Awaited inline since v6.2.0 ([#158](https://github.com/mellonis/turing-machine-js/issues/158)).
      */
-    onStep?: (machineState: MachineState) => void;
+    onStep?: (machineState: MachineState) => void | Promise<void>;
     /**
      * Async hook fired when `state.debug[when]` matches at the current
      * iteration. The promise is awaited inline, so the consumer can suspend
@@ -104,7 +110,7 @@ export default class TuringMachine {
       }
 
       if (onStep instanceof Function) {
-        onStep(machineState);
+        await onStep(machineState);
       }
 
       if (debug && machineState.debugBreak?.after && onPause) {


### PR DESCRIPTION
## Summary

- `onStep` is now awaited inline in `TuringMachine.run`, so consumers returning a Promise can suspend the run loop between iters. Discovered in [`mellonis/machines-demo#43`](https://github.com/mellonis/machines-demo/issues/43): the demo's new RUNNING_AUTO path wraps `onStep` with `setTimeout` to throttle the per-iter cadence, and the throttle didn't fire because the engine ignored the returned Promise.
- Type widened: `(m: MachineState) => void` → `(m: MachineState) => void | Promise<void>`.
- 11 tests in `TuringMachine.debug.spec.ts` that called `machine.run(...)` fire-and-forget now properly `await`. Those tests relied on the sync execution that's now gone — the proper shape was always `await machine.run(...)` since `run()` became `Promise<void>` in v4.

## Backward-compat note

Sync consumers pay one microtask boundary per iter (the engine awaits a non-Promise to keep dispatch uniform). For consumers that fire-and-forget `machine.run(...)` without awaiting the returned Promise, side effects of `onStep` no longer complete before the next sync statement — they yield microtasks. Warrants a CHANGELOG entry under v6.2.0; not a major bump (the public Promise-typed contract was unchanged since v4).

## Companion PR

`@post-machine-js/machine` has the same shape internally: its run-wrapping `onStep` doesn't await the user's `onStep`. Companion PR opens alongside this one.

## Test plan
- [x] \`npm test\` — 414/414 pass (1 new test \`async onStep is awaited between iters\` asserting pre/post-N pairs are never interleaved across iters)
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean
- [ ] Manual: pull the demo's RUNNING_AUTO path against this engine, verify per-iter throttle honors the configured interval