### PR TITLE
chore(release): v6.2.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.1.0",
+  "version": "6.2.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,7 +10656,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10667,7 +10667,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10678,7 +10678,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10689,7 +10689,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
## Summary

Lockstep version bump v6.1.0 → v6.2.0 across all 4 packages. Minor bump — peer-deps stay at \`^6.0.0\`.

## What's in v6.2.0

- **[#159](https://github.com/mellonis/turing-machine-js/pull/159) (closes [#158](https://github.com/mellonis/turing-machine-js/issues/158)): \`await onStep\` in \`TuringMachine.run\`.** Async \`onStep\` consumers can now suspend the run loop between iters (returning a Promise is awaited inline). Type widened: \`(m) => void\` → \`(m) => void | Promise<void>\`.
- **Soft-breaking timing change**: consumers calling \`machine.run(...)\` fire-and-forget (without awaiting the returned Promise) no longer see synchronous side effects of \`onStep\` — they yield microtasks between iters. Proper shape was always \`await machine.run(...)\` since v4.
- **CI hardening**: new \`typecheck\` script + step catches TS errors in test files (previously missed since the build config excludes \`*.spec.ts\` and vitest's esbuild doesn't type-check). Three dependent packages' tsconfigs fixed to resolve cross-package imports from source instead of the (CI-empty) \`dist/\`.

## Release plan after merge
- [ ] \`npm publish\` from each of \`packages/machine\`, \`packages/builder\`, \`packages/library-binary-numbers\`, \`packages/library-binary-numbers-bare\`
- [ ] \`gh release create v6.2.0\` with notes pointing to #159

## Companion release
[\`mellonis/post-machine-js#76\`](https://github.com/mellonis/post-machine-js/pull/76) ships the parallel \`await\` fix for PostMachine's internal \`onStep\` wrapper. Its tests can only honestly validate against engine v6.2.0 once published — so the post-machine-js release follows this one.