### PR TITLE
fix(release): restore sync onStep contract; bump to v6.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.2.0",
+  "version": "6.3.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,7 +10656,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10667,7 +10667,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10678,7 +10678,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10689,7 +10689,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -364,7 +364,7 @@ Both APIs are first-class — `run()` is built on top of `runStepByStep()` (see 
 
 **Rule of thumb.** If your consumer reads `state.debug` and expects the engine to act on it (pause, fire callbacks), use `run()`. If you want pull-based iteration with full control over timing, use `runStepByStep()` — the `debugBreak` field is still on every yield, so you can inspect breakpoint metadata yourself.
 
-**Don't split one logical flow across both APIs.** A consumer that wants stepwise UI *and* hook-driven breakpoints should use `run({ onStep, onPause, debug })` exclusively, implementing "wait between steps" by awaiting a resolvable Promise inside `onStep`. Routing some operations through `runStepByStep()` and others through `run()` means `state.debug` only flows through one of the two paths — a subtle footgun where breakpoints silently disappear on whichever code path uses the generator directly.
+**Don't split one logical flow across both APIs.** A consumer that wants stepwise UI *and* hook-driven breakpoints should use `run({ onStep, onPause, debug })` exclusively. Routing some operations through `runStepByStep()` and others through `run()` means `state.debug` only flows through one of the two paths — a subtle footgun where breakpoints silently disappear on whichever code path uses the generator directly. For per-iter throttle / "wait between steps" UIs, see [Throttle pattern](#throttle-pattern).
 
 ## Subroutine composition with `withOverrodeHaltState`
 
@@ -516,6 +516,37 @@ If `onPause` is not provided, breaks fire-and-resume invisibly — the trajector
 
 **Caveat:** `haltState` is a module-level singleton. Setting `haltState.debug` affects every machine in the process; clear in `afterEach` / `finally` for test isolation.
 
+### Throttle pattern
+
+For per-iter throttle / animation / "wait between steps" UIs, do the await inside `onPause`, not `onStep` — `onPause` is the engine's awaited callback. To make it fire on every iter (no user-set breakpoints needed), arm `.after = true` on the initial state and rearm `m.nextState.debug.after = true` inside the callback. The chain is self-propagating:
+
+```ts
+initialState.debug.after = true; // first pause-point
+
+await machine.run({
+  initialState,
+  debug: true,
+  onPause: async (m) => {
+    // m.debugBreak.after is true here on every iter.
+    await new Promise((r) => setTimeout(r, intervalMs)); // throttle
+
+    // Rearm for the next iter (engine processes m.nextState next).
+    // `state.debug` is shared across `withOverrodeHaltState` wrappers — a
+    // single arm reaches all of them.
+    if (!m.nextState.isHalt) m.nextState.debug.after = true;
+  },
+});
+```
+
+A few details:
+
+- **Halting iter**: `m.nextState === haltState` on the last user iter. The example skips the rearm there. The halting iter's own `.after` already fired this callback (engine v5+ fixed [#108](https://github.com/mellonis/turing-machine-js/issues/108) part 1).
+- **`haltState.debug.after`**: throws on assignment (#108 part 2). Don't try to rearm onto haltState itself — pause for halt by checking `m.nextState.isHalt` in the callback before the rearm step.
+- **Coexists with user-authored breaks**: if a user state also has `.before = true` set by the consumer's own code, `onPause` fires twice on that iter (before + after). Tell them apart with `m.debugBreak`.
+- **Click-pause** during throttling: keep a flag set from the outside; check it inside `onPause` before the `setTimeout` and surface a "real" pause (await a resolvable Promise the UI controls) instead of the throttle one. The engine doesn't need to know — it just sees a longer awaited `onPause`.
+
+(v6.2.0 briefly widened `onStep` to async to enable a throttle-in-onStep pattern. That was a mistake — restored to sync in v6.3.0. The rearm-via-`onPause` pattern above is the engine-native shape.)
+
 ## Special objects
 
 ### haltState
@@ -590,6 +621,8 @@ API surface changes since v3, in past tense so the timing of each piece is expli
 - **v5** — `onDebugBreak` renamed to `onPause`. New `run({ debug: boolean })` master switch suppresses all `onPause` dispatches without unsetting `state.debug` assignments. Assigning a truthy `.after` to `haltState.debug` now throws at write time (halt is terminal — no iteration-after-halt to anchor on).
 - **v6** — Per-iter lifecycle reordered to `before → step → after`, all firing on the same yield. Previously `after` fired on iter K+1's tick with a `prevYield` substitution dance; that substitution is gone. The `MachineState.debugBreak` field shape is unchanged across all three versions.
 - **v6.1** — `state.debug` ergonomics: the field is now always a non-null `DebugConfig` instance (lazy-initialized on first read), so chained field writes like `state.debug.before = true` work on a fresh state without a prior whole-object assignment. The `DebugConfig` instance is `Object.seal`-ed, so typos like `state.debug.bofore = true` throw `TypeError` at write time instead of silently creating a useless property. `state.debug = null` continues to work but semantically means "reset filters" — the next read returns a fresh empty `DebugConfig` (#150).
+- **v6.2** *(superseded by v6.3.0)* — widened `onStep`'s signature to `(m) => void | Promise<void>` and added an inline `await onStep(...)` in the run loop, enabling throttle-in-`onStep` patterns. This overturned the docstring-stated contract that `onStep` is sync (microtask-free); the right place for per-iter throttling is `onPause` with self-rearm (see [Throttle pattern](#throttle-pattern)). Restored in v6.3.0.
+- **v6.3** — `onStep` reverted to its v6.0–v6.1 sync contract — `(m) => void`, called synchronously inside the run loop. The Throttle pattern section documents the engine-native shape for per-iter throttle / "wait between iters" UIs. No other API changes.
 
 For the full release history, see the [GitHub releases page](https://github.com/mellonis/turing-machine-js/releases).
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -156,31 +156,6 @@ describe('run tests', () => {
     expect(generator.next().done).toBe(true);
   });
 
-  test('async onStep is awaited between iters (#158)', async () => {
-    const order: string[] = [];
-    const yieldToMicrotask = () => new Promise<void>((r) => queueMicrotask(r));
-
-    await machine.run({
-      initialState,
-      stepsLimit: 1e5,
-      onStep: async (m) => {
-        order.push(`pre-${m.step}`);
-        await yieldToMicrotask();
-        order.push(`post-${m.step}`);
-      },
-    });
-
-    // pre-N and post-N must always be adjacent — never interleaved like
-    // `pre-0, pre-1, post-0, post-1` — because the engine awaits each call
-    // before yielding the next MachineState. Pre/post pairs are emitted in
-    // strictly increasing `step` order.
-    expect(order.length).toBeGreaterThan(0);
-    for (let i = 0; i < order.length; i += 2) {
-      const stepN = order[i].slice(4);
-      expect(order[i]).toBe(`pre-${stepN}`);
-      expect(order[i + 1]).toBe(`post-${stepN}`);
-    }
-  });
 });
 
 describe('properties', () => {

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -62,17 +62,22 @@ export default class TuringMachine {
     debug = true,
   }: RunParameter & {
     /**
-     * Hook fired on every iteration. Use for logging/tracing — and for
-     * yield-style coordination: returning a Promise suspends the run loop
-     * until it resolves, so a consumer can throttle the per-iter cadence
-     * (e.g. an interactive debugger awaiting a `setTimeout`-Promise between
-     * iters) without owning the loop. A sync `void` return adds one microtask
-     * boundary per iter (the engine awaits a non-Promise to keep the dispatch
-     * shape uniform); negligible for typical loops, but noted for tight ones.
+     * Sync, ~free hook fired on every iteration. Use for logging/tracing —
+     * the hot loop runs this without a microtask boundary, so it must not
+     * be async.
      *
-     * Awaited inline since v6.2.0 ([#158](https://github.com/mellonis/turing-machine-js/issues/158)).
+     * For per-iter throttle / coordination ("wait between iters" UIs):
+     * arm `state.debug.after = true` on each visited state and do the
+     * throttle inside `onPause` (which IS awaited). See the README's
+     * Throttle pattern section for a worked example.
+     *
+     * (v6.2.0 widened this to `void | Promise<void>` and added an inline
+     * `await`. That was a mistake — it drove the awaited contract into a
+     * hook that was deliberately documented as sync. Restored in v6.3.0;
+     * consumers needing per-iter await belong on the `onPause`-rearm
+     * pattern, not this hook.)
      */
-    onStep?: (machineState: MachineState) => void | Promise<void>;
+    onStep?: (machineState: MachineState) => void;
     /**
      * Async hook fired when `state.debug[when]` matches at the current
      * iteration. The promise is awaited inline, so the consumer can suspend
@@ -110,7 +115,7 @@ export default class TuringMachine {
       }
 
       if (onStep instanceof Function) {
-        await onStep(machineState);
+        onStep(machineState);
       }
 
       if (debug && machineState.debugBreak?.after && onPause) {


### PR DESCRIPTION
## Summary

[v6.2.0](https://github.com/mellonis/turing-machine-js/releases/tag/v6.2.0)'s \`await onStep(...)\` + \`(m) => void | Promise<void>\` widening overturned a deliberately documented sync contract:

> Sync, ~free hook fired on every iteration. Use for logging/tracing — the hot loop runs this without a microtask boundary, so it must not be async.

The throttle use case I justified the change with belongs on \`onPause\` — which is engine-awaited and has been since v4 — via a self-rearming pattern (\`state.debug.after = true\` on the initial state, throttle inside \`onPause\`, rearm \`m.nextState.debug.after = true\`, repeat). README's new **[Throttle pattern](packages/machine/README.md#throttle-pattern)** section walks through it.

## Reverted from v6.2.0

- \`TuringMachine.ts\`: \`await onStep(machineState)\` → \`onStep(machineState)\`; type narrowed back to \`(m: MachineState) => void\`; docstring restored with an explicit "v6.2.0 was a mistake" note pointing at the Throttle pattern section.
- \`TuringMachine.spec.ts\`: removed the "async onStep is awaited between iters (#158)" test.

## Kept from v6.2.0

These were independent goods and stay:

- Test callback bodies in block-body form (works fine under sync; no churn for the sake of churn).
- CI \`typecheck\` step ([previous PR section](https://github.com/mellonis/turing-machine-js/pull/159)).
- Dependent packages' \`tsconfig\` \`paths\` + \`rootDir\` fix.

## Released as v6.3.0

Lockstep bump across all 4 packages, peer-deps stay at \`^6.0.0\`. CHANGELOG / README versioning notes name v6.2.0 as superseded.

## Companion changes

- [\`mellonis/post-machine-js\`](https://github.com/mellonis/post-machine-js) gets a matching v6.3.0: revert its own \`await user onStep\` wrapper, close [#77](https://github.com/mellonis/post-machine-js/pull/77) unmerged. Will open shortly after this one merges + publishes.
- [\`mellonis/machines-demo#68\`](https://github.com/mellonis/machines-demo/pull/68) gets a worker redesign: drop the throttle-in-\`onStep\` code, implement RUNNING_AUTO via the \`onPause\` rearm pattern.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 413/413 (was 414 in v6.2.0; the deleted async-onStep test accounts for the difference)
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean