### PR TITLE
test(graphFormats): cover fromMermaid parser error paths

### DIFF
--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -292,6 +292,51 @@ describe('fromMermaid error paths', () => {
 
     expect(() => fromMermaid(mermaid)).toThrow(/compact in-bracket alternation/);
   });
+
+  test('throws when the read label has no bracketed list', () => {
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","0","1"]]',
+      '  s0(((halt)))',
+      '  s1["entry"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      '  s1 -- "X → [K]/[S]" --> s0', // no `[…]` in the read part at all
+    ].join('\n');
+
+    expect(() => fromMermaid(mermaid)).toThrow(/no bracketed read-list/);
+  });
+
+  test('throws on write/move cell-count mismatch', () => {
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","0","1"]]',
+      '  s0(((halt)))',
+      '  s1["entry"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      "  s1 -- \"['0'] → [K,K]/[R]\" --> s0", // 2 writes, 1 move
+    ].join('\n');
+
+    expect(() => fromMermaid(mermaid)).toThrow(/write-cells.*move-cells.*mismatch/);
+  });
+
+  test('parses backslash-escaped chars inside a bracket (e.g. literal `|` as `\\|`)', () => {
+    // `stripBrackets` walks the inner content character-by-character; when it
+    // hits `\`, it skips the next char (so `\|` is a literal pipe, not the
+    // alternation separator). Exercises the escape branch in stripBrackets.
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","|"]]',
+      '  s0(((halt)))',
+      '  s1["x"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      "  s1 -- \"['\\|'] → [K]/[S]\" --> s0", // pattern reads `'\|'` (literal pipe)
+    ].join('\n');
+
+    expect(() => fromMermaid(mermaid)).not.toThrow();
+  });
 });
 
 describe('fromMermaid ensureNode update branches', () => {


### PR DESCRIPTION
## Summary

Three new tests in the existing `fromMermaid error paths` describe block, covering parser-error branches added during the v7 emit overhaul that were never exercised:

- Read label with no bracketed list (`graphFormats.ts:379`)
- Write/move cell-count mismatch (`graphFormats.ts:396`)
- Backslash-escape branch in `stripBrackets` (`graphFormats.ts:355-356`)

## Why

Coveralls reported a coverage drop on PR #167 (v7 → master draft) after v7-alpha.1's emit overhaul landed. The new parser error paths were live but untested — locally clean (above the 97/90/95/97 floors in `vitest.config.ts`), but enough of a delta vs. master that Coveralls' no-drop check failed.

## Coverage delta

| Metric | Before | After | Δ |
|---|---|---|---|
| Statements | 98.29% | 98.72% | +0.43 |
| Branches | 95.35% | 96.13% | +0.78 |
| Functions | 100% | 100% | — |
| `graphFormats.ts` stmts | 96.42% | 98.8% | +2.38 |
| `graphFormats.ts` branches | 90.62% | 94.79% | +4.17 |

## What's NOT covered

Remaining uncovered branches in v7 code are defensive fallbacks not worth synthetic tests:

- `graph.ts:173, 209` — fallback returns in `parsePatternString` / `parseWriteSymbolLabel` for malformed inputs
- `State.ts:463-464` — catch for unbound `Reference.ref` throw during `toGraph` walk
- `introspection.ts:121` — `if (node)` guard in cycle detection

## Test plan

- [x] `npm test` — all tests pass (425/425, +3)
- [x] `npm run test:coverage` — numbers above
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean