### PR TITLE
fix(State): nested `.wohs()` collapses inner overrides (#176)

### DIFF
--- a/packages/machine/src/classes/State.spec.ts
+++ b/packages/machine/src/classes/State.spec.ts
@@ -188,22 +188,52 @@ describe('State.withOverriddenHaltState', () => {
     expect(wrapped.name).toBe('inner(outer)');
   });
 
-  test('paren-naming distinguishes nestings that flat `>` notation would collide', () => {
+  test('paren-naming distinguishes wrapping where the override is itself wrapped', () => {
     const A = new State({[ifOtherSymbol]: {}}, 'A');
     const B = new State({[ifOtherSymbol]: {}}, 'B');
 
-    // Construction 1: bare=A, override=(B with override A)
+    // bare=A, override=(B with override A) — outer1 = A.wohs(B.wohs(A))
+    // Under #176, only `this` is unwrapped; the override (B.wohs(A)) is preserved as-is.
     const inner1 = B.withOverriddenHaltState(A);
     const outer1 = A.withOverriddenHaltState(inner1);
 
-    // Construction 2: bare=(A with override B), override=A
-    const inner2 = A.withOverriddenHaltState(B);
-    const outer2 = inner2.withOverriddenHaltState(A);
-
-    // Old `>` notation would collide both at "A>B>A". Paren notation keeps them distinct.
     expect(outer1.name).toBe('A(B(A))');
-    expect(outer2.name).toBe('A(B)(A)');
-    expect(outer1.name).not.toBe(outer2.name);
+    expect(outer1.overriddenHaltState).toBe(inner1);
+  });
+
+  test('nested `.wohs()` chain collapses inner overrides (#176)', () => {
+    // `A.wohs(t1).wohs(t2)` is equivalent to `A.wohs(t2)` — t1 is dead at
+    // runtime (only the outermost wohs's override is pushed onto the stack
+    // when the wrapper is entered; verified empirically by probe). The
+    // composite name reflects the runtime behavior, not construction history.
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const t1 = new State({[ifOtherSymbol]: {}}, 't1');
+    const t2 = new State({[ifOtherSymbol]: {}}, 't2');
+
+    const W1 = A.withOverriddenHaltState(t1);
+    const W2 = W1.withOverriddenHaltState(t2);
+
+    // Composite name: outer override only, inner ('t1') dropped.
+    expect(W2.name).toBe('A(t2)');
+    expect(W2.overriddenHaltState).toBe(t2);
+
+    // Structurally equivalent to direct construction.
+    const W2direct = A.withOverriddenHaltState(t2);
+
+    expect(W2.name).toBe(W2direct.name);
+    expect(W2.overriddenHaltState).toBe(W2direct.overriddenHaltState);
+  });
+
+  test('3-deep `.wohs()` chain collapses to outermost override (#176)', () => {
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const t1 = new State({[ifOtherSymbol]: {}}, 't1');
+    const t2 = new State({[ifOtherSymbol]: {}}, 't2');
+    const t3 = new State({[ifOtherSymbol]: {}}, 't3');
+
+    const W = A.withOverriddenHaltState(t1).withOverriddenHaltState(t2).withOverriddenHaltState(t3);
+
+    expect(W.name).toBe('A(t3)');
+    expect(W.overriddenHaltState).toBe(t3);
   });
 });
 

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -280,11 +280,17 @@ export default class State {
     // private-field access (legal within the same class).
     const state = new State();
 
-    state.#name = `${this.name}(${overriddenHaltState.name})`;
-    state.#symbolToDataMap = this.#symbolToDataMap;
+    // Unwrap `this` if it's itself a wrapper — the chain's inner overrides
+    // are dead at runtime anyway (only the outermost `.wohs()`'s override is
+    // pushed onto the halt-stack on entry; verified empirically). Composite
+    // name reflects runtime behavior, not construction history. See #176.
+    const bare = this.#bareState ?? this;
+
+    state.#name = `${bare.name}(${overriddenHaltState.name})`;
+    state.#symbolToDataMap = bare.#symbolToDataMap;
     state.#overriddenHaltState = overriddenHaltState;
-    state.#debugRef = this.#debugRef;
-    state.#bareState = this;
+    state.#debugRef = bare.#debugRef;
+    state.#bareState = bare;
 
     return state;
   }


### PR DESCRIPTION
## Summary

\`A.wohs(t1).wohs(t2)\` now produces a wrapper named \`A(t2)\` with bare = A (instead of the old \`A(t1)(t2)\` with bare = W1). The chain's inner overrides are dead at runtime — only the outermost \`.wohs()\`'s override is pushed onto the halt-stack on entry (verified empirically by probe in the design discussion). The composite name now reflects runtime behavior, not construction history.

Closes #176.

## Implementation

Single-line change in \`State#withOverriddenHaltState\`: unwrap \`this\` to its bare before composing the new wrapper.

\`\`\`diff
   withOverriddenHaltState(overriddenHaltState: State) {
     const state = new State();

+    // Unwrap \`this\` if it's itself a wrapper — see #176.
+    const bare = this.#bareState ?? this;
+
-    state.#name = \`\${this.name}(\${overriddenHaltState.name})\`;
+    state.#name = \`\${bare.name}(\${overriddenHaltState.name})\`;
-    state.#symbolToDataMap = this.#symbolToDataMap;
+    state.#symbolToDataMap = bare.#symbolToDataMap;
     state.#overriddenHaltState = overriddenHaltState;
-    state.#debugRef = this.#debugRef;
+    state.#debugRef = bare.#debugRef;
-    state.#bareState = this;
+    state.#bareState = bare;
\`\`\`

## Tests

- New: \`A.wohs(t1).wohs(t2).name === 'A(t2)'\` + structural equivalence to \`A.wohs(t2)\` (same name + same override target).
- New: 3-deep chain \`A.wohs(t1).wohs(t2).wohs(t3) → 'A(t3)'\`.
- Updated: the existing \"paren-naming distinguishes nestings\" test now exercises only override-side wrapping (\`A.wohs(B.wohs(A))\`), since \`this\`-side chain construction collapses under the new rule.

Full suite: 433/433 passing (was 431 baseline + 2 new tests). Coverage 99.14% / 96.72% / 100% / 99.21% — above floors.

## Doesn't apply to

- **Sibling wrappers around the same bare** — \`A.wohs(t1)\` and \`A.wohs(t2)\` constructed separately produce two distinct wrappers with names \`A(t1)\` and \`A(t2)\`. The fix only affects chains where \`this\` is already a wrapper.
- **Wrapping a wrapper as override target** — \`A.wohs(W2)\` where \`W2\` is a wrapper. The override side is preserved as-is; only \`this\` is unwrapped.

## Effect on existing artifacts

- \`packages/library-binary-numbers*/states.md\` — regenerated, **no diff**. Those compositions use independent wrappers (each \`bare.wohs(target)\` where bare is non-wrapped), so no chain collapse happens.
- \`round-trip.spec.ts\` — passes unchanged.

## Composes with

- **#175** (memoization). With both shipped: \`A.wohs(t1).wohs(t2) === A.wohs(t2)\` (literal reference equality via cache lookup of \`(A, t2)\`). Implementation order works either way; this PR's change defines the equivalence, #175's cache then deduplicates on it.
- **#174** (callable-subtree visualization). The composite name in the wrapper's \`[[…]]\` node becomes shorter and more accurate.

## Test plan

- [x] \`npm test\` — 433/433 passing
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` (\`tsc --noEmit -p packages/machine/tsconfig.json\`) — clean
- [x] \`npm run test:coverage\` — above floors
- [x] \`npm run docs:states\` — no diff for binary-numbers libraries