### PR TITLE
feat(State): memoize withOverriddenHaltState (#175)

### DIFF
--- a/packages/machine/src/classes/State.spec.ts
+++ b/packages/machine/src/classes/State.spec.ts
@@ -224,6 +224,60 @@ describe('State.withOverriddenHaltState', () => {
     expect(W2.overriddenHaltState).toBe(W2direct.overriddenHaltState);
   });
 
+  test('memoization: same (bare, override) pair returns the same wrapper instance (#175)', () => {
+    // `withOverriddenHaltState` interns its results keyed by (bare, override).
+    // Two calls with the same arguments — even with chained construction —
+    // return the literally same JS object.
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const t = new State({[ifOtherSymbol]: {}}, 't');
+
+    const W1 = A.withOverriddenHaltState(t);
+    const W2 = A.withOverriddenHaltState(t);
+
+    expect(W1).toBe(W2);
+    expect(W1.id).toBe(W2.id);
+    expect(W1.name).toBe('A(t)');
+  });
+
+  test('memoization composes with chain collapse: A.wohs(t1).wohs(t2) === A.wohs(t2) (#175 + #176)', () => {
+    // After #176 collapses the chain to (A, t2), the cache hit on (A, t2)
+    // returns the same instance as the direct call.
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const t1 = new State({[ifOtherSymbol]: {}}, 't1');
+    const t2 = new State({[ifOtherSymbol]: {}}, 't2');
+
+    const Wdirect = A.withOverriddenHaltState(t2);
+    const Wchained = A.withOverriddenHaltState(t1).withOverriddenHaltState(t2);
+
+    expect(Wchained).toBe(Wdirect);
+  });
+
+  test('memoization is per-(bare, override) pair: different override → different instance (#175)', () => {
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const t1 = new State({[ifOtherSymbol]: {}}, 't1');
+    const t2 = new State({[ifOtherSymbol]: {}}, 't2');
+
+    const W1 = A.withOverriddenHaltState(t1);
+    const W2 = A.withOverriddenHaltState(t2);
+
+    expect(W1).not.toBe(W2);
+    expect(W1.name).toBe('A(t1)');
+    expect(W2.name).toBe('A(t2)');
+  });
+
+  test('memoization is per-(bare, override) pair: different bare → different instance (#175)', () => {
+    const A = new State({[ifOtherSymbol]: {}}, 'A');
+    const B = new State({[ifOtherSymbol]: {}}, 'B');
+    const t = new State({[ifOtherSymbol]: {}}, 't');
+
+    const W_A = A.withOverriddenHaltState(t);
+    const W_B = B.withOverriddenHaltState(t);
+
+    expect(W_A).not.toBe(W_B);
+    expect(W_A.name).toBe('A(t)');
+    expect(W_B.name).toBe('B(t)');
+  });
+
   test('3-deep `.wohs()` chain collapses to outermost override (#176)', () => {
     const A = new State({[ifOtherSymbol]: {}}, 'A');
     const t1 = new State({[ifOtherSymbol]: {}}, 't1');

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -72,6 +72,13 @@ export class DebugConfig {
 }
 
 export default class State {
+  // Memoization cache for `withOverriddenHaltState`. Keyed by
+  // (bare, override) — same args return the same wrapper instance (#175).
+  // Two-level WeakMap so the outer entry is GC'd when the bare is collected;
+  // WeakRef values let wrappers themselves be GC'd when nothing else holds
+  // them, with cache misses simply reconstructing fresh wrappers.
+  static #wrapperCache = new WeakMap<State, WeakMap<State, WeakRef<State>>>();
+
   readonly #id: number = id(this);
 
   // Not `readonly` because `withOverriddenHaltState` and `fromGraph` set the
@@ -274,23 +281,46 @@ export default class State {
   }
 
   withOverriddenHaltState(overriddenHaltState: State) {
-    // Construct with no name, then overwrite #name directly — the composed
-    // name contains `(` and `)` by design, which the constructor's user-facing
-    // validation would reject. Internal composition bypasses validation via
-    // private-field access (legal within the same class).
-    const state = new State();
-
     // Unwrap `this` if it's itself a wrapper — the chain's inner overrides
     // are dead at runtime anyway (only the outermost `.wohs()`'s override is
     // pushed onto the halt-stack on entry; verified empirically). Composite
     // name reflects runtime behavior, not construction history. See #176.
     const bare = this.#bareState ?? this;
 
+    // Memoize by (bare, override) so identical args return the same instance
+    // (#175). The cache uses WeakMaps + WeakRefs so cached wrappers can be
+    // GC'd when nothing else holds them. Compounds with the chain-collapse
+    // above: `A.wohs(t1).wohs(t2)` keys as (A, t2) after the unwrap, hitting
+    // the same cache slot as a direct `A.wohs(t2)`.
+    let innerCache = State.#wrapperCache.get(bare);
+
+    if (innerCache !== undefined) {
+      const ref = innerCache.get(overriddenHaltState);
+
+      if (ref !== undefined) {
+        const cached = ref.deref();
+
+        if (cached !== undefined) {
+          return cached;
+        }
+      }
+    } else {
+      innerCache = new WeakMap();
+      State.#wrapperCache.set(bare, innerCache);
+    }
+
+    // Cache miss — construct with no name, then overwrite #name directly
+    // (composed names contain `(` and `)` which the constructor's user-facing
+    // validation would reject; private-field access bypasses that).
+    const state = new State();
+
     state.#name = `${bare.name}(${overriddenHaltState.name})`;
     state.#symbolToDataMap = bare.#symbolToDataMap;
     state.#overriddenHaltState = overriddenHaltState;
     state.#debugRef = bare.#debugRef;
     state.#bareState = bare;
+
+    innerCache.set(overriddenHaltState, new WeakRef(state));
 
     return state;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
+    "lib": ["ES2021"],
     "declaration": true,
     "strict": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary

Cache \`(bare, override) → wrapper\` so identical arguments return the same JS instance. \`A.wohs(t) === A.wohs(t)\` — referential equality holds for repeated wrap calls.

Closes #175.

## Composes with #178 (#176)

> ⚠️ **This PR is stacked on #178.** Branch \`feat/wohs-memoization-175\` is based on \`feat/nested-wohs-collapse-176\`. The PR currently shows the combined diff; once #178 merges to \`v7\`, this PR's diff reduces to just the memoization changes.

The composition (with #178 merged):
- #178 (#176) unwraps \`this\` to its bare on each \`.wohs()\` call.
- This cache then keys by \`(bare, override)\`.
- Result: \`A.wohs(t1).wohs(t2) === A.wohs(t2)\` — chained construction hits the same cache slot as direct construction.

Without #178, the cache still works for the simple case \`A.wohs(t) === A.wohs(t)\`. Chained calls produce different cache slots (since \`this\` would be a wrapper, not the bare). #178 is the prerequisite for full algebraic identity across chains.

## Implementation

- Static private cache: \`State.#wrapperCache: WeakMap<State, WeakMap<State, WeakRef<State>>>\`
- Two-level WeakMap structure:
  - Outer keyed by \`bare\` — auto-prunes when the bare is GC'd.
  - Inner keyed by \`override\` — auto-prunes when the override is GC'd.
  - WeakRef values let wrappers be GC'd when nothing else holds them; subsequent identical calls reconstruct fresh wrappers (cache misses are silent).
- Cache lookup happens BEFORE constructing a new wrapper; cache miss falls through to the existing construction path.

\`\`\`diff
+  // Memoization cache for \`withOverriddenHaltState\`. Keyed by (bare, override).
+  static #wrapperCache = new WeakMap<State, WeakMap<State, WeakRef<State>>>();

   withOverriddenHaltState(overriddenHaltState: State) {
     const bare = this.#bareState ?? this;

+    // Cache lookup
+    let innerCache = State.#wrapperCache.get(bare);
+    if (innerCache !== undefined) {
+      const ref = innerCache.get(overriddenHaltState);
+      if (ref !== undefined) {
+        const cached = ref.deref();
+        if (cached !== undefined) return cached;
+      }
+    } else {
+      innerCache = new WeakMap();
+      State.#wrapperCache.set(bare, innerCache);
+    }
+
     const state = new State();
     // ... construct fresh wrapper ...
+    innerCache.set(overriddenHaltState, new WeakRef(state));

     return state;
   }
\`\`\`

## Tooling

Bumped \`lib\` from default-implied \`ES2020\` to \`ES2021\` in the root \`tsconfig.json\` — \`WeakRef\` is an ES2021 type. \`target\` stays \`ES2020\`, so emit is unchanged. Runtime requires \`WeakRef\` support (Node 14.6+, all modern browsers; CI runs Node 24 per CLAUDE.md).

## Tests

4 new tests:

- \`A.wohs(t) === A.wohs(t)\` — same instance + same id + correct name.
- \`A.wohs(t1).wohs(t2) === A.wohs(t2)\` — composes with #176 (this test passes once #178 is merged; without #178 it would still pass because chained construction would key as \`(W1, t2)\` separately, but the test relies on the cache + unwrap together).
- Different override → different instance (cache key sanity).
- Different bare → different instance (cache key sanity).

Full suite: 437/437 (was 433 + 4 new tests). Coverage 99.15/96.57/100/99.22 — above floors. Typecheck + lint clean.

## Out of scope

- **Aggressive collapse** like \`A.wohs(t).wohs(t) → A.wohs(t)\` (idempotent self-rewrap). With #178 unwrapping \`this\` first, \`A.wohs(t).wohs(t)\` already hits the same cache key as \`A.wohs(t)\`, so it works correctly — but as a side effect of #178, not a separate mechanism in this PR.
- **Symmetry rewrites** like \`A.wohs(B).wohs(A) → A.wohs(B)\`. The engine doesn't introspect override-target relationships.

## Test plan

- [x] \`npm test\` — 437/437
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --noEmit -p packages/machine/tsconfig.json\` — clean
- [x] \`npm run test:coverage\` — above floors

## Merge order

Recommend: merge #178 first, then this. The diff of this PR against v7 will then be just the memoization changes (~80 lines). GitHub will auto-update the diff after #178 merges.