### PR TITLE
fix(fromMermaid): tighten `&` ribbon regex to clear CodeQL polynomial-ReDoS flag

### DIFF
--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -290,9 +290,12 @@ const labeledTransitionRegex = /^([sc]\d+)\s+--\s+"(.*)"\s+-->\s+([sc]\d+)$/;
 // Wrapper → override (unlabeled solid `-->`).
 const wrapperOverrideRegex = /^(s\d+)\s+-->\s+([sc]\d+)$/;
 // Call arrow (bold `==>`), with optional `&`-joined source ribbon.
-const callArrowRegex = /^(s\d+(?:\s+&\s+s\d+)*)\s+==\s+"call"\s+==>\s+(s\d+)$/;
+// Ribbon separator is fixed at " & " (single spaces around &) — toMermaid
+// emits exactly that form, so the parser is strict to it. The literal-space
+// form avoids CodeQL's polynomial-ReDoS flag on a `\s+&\s+` shape.
+const callArrowRegex = /^(s\d+(?: & s\d+)*)\s+==\s+"call"\s+==>\s+(s\d+)$/;
 // Return arrow (`w_N -. return .-> s_W` with optional `&` target ribbon).
-const returnArrowRegex = /^w_(\d+)\s+-\.\s+"return"\s+\.->\s+(s\d+(?:\s+&\s+s\d+)*)$/;
+const returnArrowRegex = /^w_(\d+)\s+-\.\s+"return"\s+\.->\s+(s\d+(?: & s\d+)*)$/;
 // Halt arrow (`w_N -. halt .-> s0`).
 const haltArrowRegex = /^w_(\d+)\s+-\.\s+"halt"\s+\.->\s+s0$/;
 // First capture char anchored as \S to avoid polynomial backtracking between
@@ -425,7 +428,7 @@ export function fromMermaid(text: string): Graph {
     const cm = line.match(callArrowRegex);
 
     if (cm) {
-      const sources = cm[1].split(/\s+&\s+/);
+      const sources = cm[1].split(' & ');
       const bareId = parseMermaidId(cm[2]);
 
       for (const src of sources) {


### PR DESCRIPTION
## Summary

Tightens the two `&`-ribbon regexes in `fromMermaid` (`callArrowRegex`, `returnArrowRegex`) so CodeQL stops flagging them as polynomial-ReDoS shapes. Surfaced on PR #167's integration build for commit 1dde21d (post-#174-merge to v7).

## What CodeQL flagged

`packages/machine/src/utilities/graphFormats.ts:428` — `/\s+&\s+/` in the `.split(...)` call (and the matching `(?:\s+&\s+s\d+)*` repeat inside `callArrowRegex` / `returnArrowRegex`). The `\s+...\s+` shape around a single literal char is CodeQL's classic polynomial-ReDoS pattern.

## Fix

`toMermaid` emits ribbon members with exactly ` & ` (single space on each side). The parser is documented as strict to the dialect `toMermaid` emits, so tightening to literals is loss-free for any round-trip use:

- Regex repeat group: `(?:\s+&\s+s\d+)*` → `(?: & s\d+)*`
- Split: `.split(/\s+&\s+/)` → `.split(' & ')`

The outer `\s+` between major tokens (`==`, `==>`, `-.`, `.->`) stay as `\s+` — they're not in a repeat group and CodeQL doesn't flag them.

## Test plan

- [x] `npm test` — 437/437 pass (round-trip, README example, library-binary-numbers all still parse the ribbon)
- [x] `npm run lint` — clean