### PR TITLE
test(coverage): exercise #174's union-find + halt-arrow + stripBrackets paths

### DIFF
--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -354,6 +354,24 @@ describe('fromMermaid error paths', () => {
     expect(() => fromMermaid(mermaid)).toThrow(/write-cells.*move-cells.*mismatch/);
   });
 
+  test('throws on a movement bracket that opens but never closes', () => {
+    // Targets `stripBrackets`'s own throw: writes are well-formed (`[K]`) so
+    // the `slashIx` guard accepts the label as `[…]/[…]`-shaped, but the
+    // movement segment `[S` opens without a closing `]`. `stripBrackets`
+    // catches this even though the earlier label-shape guard didn't.
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","0"]]',
+      '  s0(((halt)))',
+      '  s1["entry"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      "  s1 -- \"['0'] → [K]/[S\" --> s0", // moves part `[S` is missing the closing bracket
+    ].join('\n');
+
+    expect(() => fromMermaid(mermaid)).toThrow(/malformed bracketed list/);
+  });
+
   test('parses backslash-escaped chars inside a bracket (e.g. literal `|` as `\\|`)', () => {
     // `stripBrackets` walks the inner content character-by-character; when it
     // hits `\`, it skips the next char (so `\|` is a literal pipe, not the
@@ -555,5 +573,81 @@ describe('README diagrams: engine-generated outputs', () => {
     // Retired keywords — must NOT appear under the new convention.
     expect(output).not.toContain('onHalt');
     expect(output).not.toContain('halt frame');
+  });
+});
+
+// Spec Example 6 "Shared body state" + worked example 2 (direct entry into the
+// union frame): two wrappers W1, W2 with bares A, B whose reach sets overlap
+// on a shared body state X, plus a dispatcher with a direct entry to X (a
+// non-wrapper transition into the frame).
+//
+// Exercises:
+//   - union-find on overlapping reach sets (State.ts ufFind multi-step walk +
+//     path compression + ufUnion)
+//   - `callable scope: A ∪ B` subgraph label (graphFormats frameBareNames sort)
+//   - `-. "halt" .->` demand-emit arrow (graphFormats hasNonWrapperEntry path)
+describe('callable-subtree: shared body state forces a union frame', () => {
+  test('two bares sharing a body state merge into one frame; non-wrapper entry triggers halt arrow', () => {
+    const alphabet = new Alphabet([' ', '1', '2', '3', 'X']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+
+    // Shared body state X — halts on any symbol.
+    const X = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'X');
+
+    // Bare A — transitions to X.
+    const A = new State({
+      [ifOtherSymbol]: {command: {movement: movements.right}, nextState: X},
+    }, 'A');
+
+    // Bare B — also transitions to X (so reach(A) ∩ reach(B) ⊇ {X}, union triggers).
+    const B = new State({
+      [ifOtherSymbol]: {command: {movement: movements.right}, nextState: X},
+    }, 'B');
+
+    // Targets for the wrappers.
+    const target1 = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 't1');
+    const target2 = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 't2');
+
+    const W1 = A.withOverriddenHaltState(target1);
+    const W2 = B.withOverriddenHaltState(target2);
+
+    // Dispatcher chooses path by symbol: '1' → W1, '2' → W2, '3' → X (direct
+    // entry into the union frame, the non-wrapper entry path that triggers
+    // the `-. "halt" .->` arrow).
+    const dispatcher = new State({
+      [symbol(['1'])]: {command: {movement: movements.stay}, nextState: W1},
+      [symbol(['2'])]: {command: {movement: movements.stay}, nextState: W2},
+      [symbol(['3'])]: {command: {movement: movements.stay}, nextState: X},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+
+    // A and B should share a frameId (union-find merged them).
+    const nodeA = graph.nodes[A.id];
+    const nodeB = graph.nodes[B.id];
+    const nodeX = graph.nodes[X.id];
+
+    expect(nodeA.frameId).not.toBeNull();
+    expect(nodeA.frameId).toBe(nodeB.frameId);
+    expect(nodeX.frameId).toBe(nodeA.frameId);
+
+    // Frame id = smallest bare-id in the component (deterministic canonical).
+    expect(nodeA.frameId).toBe(Math.min(A.id, B.id));
+
+    // Emit: one union frame with `callable scope: A ∪ B` label, halt arrow
+    // present (cross-subgraph dispatcher → X entry).
+    const out = toMermaid(graph);
+
+    expect(out).toContain('callable scope: A ∪ B');
+    expect(out).toMatch(/w_\d+ -\. "halt" \.-> s0/);
+    // Both wrappers call their respective bares.
+    expect(out).toMatch(/s\d+ == "call" ==> s\d+/g);
   });
 });


### PR DESCRIPTION
## Summary

Recovers the `-1.8pp` Coveralls drop that PR #167's integration check flagged after [#174](https://github.com/mellonis/turing-machine-js/issues/174) merged to v7. The new callable-subtree code added branches that the existing test suite doesn't exercise:

- **Union-find** in `State.toGraph` never fires for any binary-numbers algorithm — their bares all transition to wrappers, not directly between each other's bodies, so reach sets never overlap.
- **`hasNonWrapperEntry`** in `toMermaid` (which gates the `-. "halt" .->` arrow) requires a cross-subgraph entry from a non-wrapper into a frame state — no existing test sets that up.
- **`stripBrackets`'s own throw** was unreachable from prior tests because the earlier `]/[` shape guard caught everything before it could fire.

## What this PR adds

Two targeted tests in `packages/machine/src/utilities/graph.spec.ts`:

1. **Shared body state forces a union frame** (spec Example 6 worked example 2). Dispatcher with `['1'] → W1`, `['2'] → W2`, `['3'] → X` where `X` is a body state shared between bares `A` (in W1) and `B` (in W2). Drives:
   - `ufFind` multi-step root walk + path compression
   - `ufUnion` merging two bares into one component
   - The multi-element `frameBareNames.sort` + `callable scope: A ∪ B` subgraph label
   - `hasNonWrapperEntry` flipping ON for the union frame, emitting `-. "halt" .->`

2. **Movement bracket malformed** — label `['0'] → [K]/[S` passes the `]/[` shape guard, but `stripBrackets` rejects the move part because it opens without a closing `]`. Targets the previously unreachable `stripBrackets` throw branch (`graphFormats.ts:475`).

## Coverage delta (local v8)

| Metric | Before | After | Δ |
|---|---|---|---|
| Statements | 97.49% | 98.51% | +1.02 |
| Branches | 94.04% | 95.23% | +1.19 |
| Functions | 98.85% | 100% | +1.15 |
| Lines | 97.83% | 98.91% | +1.08 |

Comfortably above the Coveralls baseline that flagged `Coverage decreased (-1.8%)` on #167. Once this lands on v7, the v7→master integration check on #167 should go green.

## Test plan

- [x] `npm test` — 439/439 pass (437 prior + 2 new)
- [x] `npm run lint` — clean
- [x] `npm run test:coverage` — above all floors with margin