### PR TITLE
docs(spec) + test: worked union shapes (A∪B, A∪B∪C, transitive) + invariant/snapshot tests

### DIFF
--- a/docs/superpowers/specs/2026-05-21-halt-frame-transitive-closure.md
+++ b/docs/superpowers/specs/2026-05-21-halt-frame-transitive-closure.md
@@ -568,6 +568,158 @@ Cross-subgraph entry `s_disp -- ['3'] --> s_X` triggers the `halt` arrow to emit
 
 The union model degrades gracefully — adding direct entry to a state inside the union just flips the `halt` arrow on. No new structural concept needed.
 
+### Worked union shapes — engine-emitted Mermaid
+
+Real `toMermaid` output (post-#174) for three increasingly merged union shapes. Each test machine has a dispatcher routing by tape symbol into per-bare wrappers `W = bare.withOverriddenHaltState(target)`. The bares' transitions land on shared body states that drive the union-find merge.
+
+#### Case 1: `A ∪ B` (two bares, one shared state)
+
+```text
+reach(A) = {A, X}
+reach(B) = {B, X}
+A ∩ B = {X} → union(A, B)
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","1","2"]]
+  s0(((halt)))
+  s4["t1"]
+  s5["t2"]
+  s8["dispatcher"]
+  s6[["A(t1)"]]
+  s7[["B(t2)"]]
+  idle([idle])
+  subgraph w_2["callable scope: A ∪ B"]
+    s1["X"]
+    s2["A"]
+    s3["B"]
+    c2(((halt)))
+  end
+  idle -. enter .-> s8
+  s6 == "call" ==> s2
+  s7 == "call" ==> s3
+  w_2 -. "return" .-> s6 & s7
+  s6 --> s4
+  s7 --> s5
+  s1 -- "[*] → [K]/[S]" --> c2
+  s2 -- "[*] → [K]/[R]" --> s1
+  s3 -- "[*] → [K]/[R]" --> s1
+  s4 -- "[*] → [K]/[S]" --> s0
+  s5 -- "[*] → [K]/[S]" --> s0
+  s8 -- "['1'] → [K]/[S]" --> s6
+  s8 -- "['2'] → [K]/[S]" --> s7
+```
+
+Two `==> call` arrows into the same frame; one `& `-joined `return` ribbon back to both wrappers.
+
+#### Case 2: `A ∪ B ∪ C` (three bares, all share X directly)
+
+```text
+reach(A) = {A, X}
+reach(B) = {B, X}
+reach(C) = {C, X}
+Every pair intersects on X → all merge.
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","1","2","3"]]
+  s0(((halt)))
+  s13["t1"]
+  s14["t2"]
+  s15["t3"]
+  s19["dispatcher"]
+  s16[["A(t1)"]]
+  s17[["B(t2)"]]
+  s18[["C(t3)"]]
+  idle([idle])
+  subgraph w_10["callable scope: A ∪ B ∪ C"]
+    s9["X"]
+    s10["A"]
+    s11["B"]
+    s12["C"]
+    c10(((halt)))
+  end
+  idle -. enter .-> s19
+  s16 == "call" ==> s10
+  s17 == "call" ==> s11
+  s18 == "call" ==> s12
+  w_10 -. "return" .-> s16 & s17 & s18
+  s16 --> s13
+  s17 --> s14
+  s18 --> s15
+  s9 -- "[*] → [K]/[S]" --> c10
+  s10 -- "[*] → [K]/[R]" --> s9
+  s11 -- "[*] → [K]/[R]" --> s9
+  s12 -- "[*] → [K]/[R]" --> s9
+  s13 -- "[*] → [K]/[S]" --> s0
+  s14 -- "[*] → [K]/[S]" --> s0
+  s15 -- "[*] → [K]/[S]" --> s0
+  s19 -- "['1'] → [K]/[S]" --> s16
+  s19 -- "['2'] → [K]/[S]" --> s17
+  s19 -- "['3'] → [K]/[S]" --> s18
+```
+
+Three `call` arrows, one three-way `& `-joined `return` ribbon. Same frame, one halt marker.
+
+#### Case 3: `(A ∪ B) ∪ C` — transitive (B and C don't share anything direct)
+
+```text
+reach(A) = {A, X, Y}
+reach(B) = {B, X}
+reach(C) = {C, Y}
+A ∩ B = {X}   → union(A, B)
+A ∩ C = {Y}   → union(A, C)  ← C joins {A, B} via A
+B ∩ C = ∅     ← but they end up in the same frame anyway, transitively
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","1","2","3"]]
+  s0(((halt)))
+  s25["t1"]
+  s26["t2"]
+  s27["t3"]
+  s31["dispatcher"]
+  s28[["A(t1)"]]
+  s29[["B(t2)"]]
+  s30[["C(t3)"]]
+  idle([idle])
+  subgraph w_22["callable scope: A ∪ B ∪ C"]
+    s20["X"]
+    s21["Y"]
+    s22["A"]
+    s23["B"]
+    s24["C"]
+    c22(((halt)))
+  end
+  idle -. enter .-> s31
+  s28 == "call" ==> s22
+  s29 == "call" ==> s23
+  s30 == "call" ==> s24
+  w_22 -. "return" .-> s28 & s29 & s30
+  s28 --> s25
+  s29 --> s26
+  s30 --> s27
+  s20 -- "[*] → [K]/[S]" --> c22
+  s21 -- "[*] → [K]/[S]" --> c22
+  s22 -- "['1'] → [K]/[R]" --> s20
+  s22 -- "['2'] → [K]/[R]" --> s21
+  s23 -- "[*] → [K]/[R]" --> s20
+  s24 -- "[*] → [K]/[R]" --> s21
+  s25 -- "[*] → [K]/[S]" --> s0
+  s26 -- "[*] → [K]/[S]" --> s0
+  s27 -- "[*] → [K]/[S]" --> s0
+  s31 -- "['1'] → [K]/[S]" --> s28
+  s31 -- "['2'] → [K]/[S]" --> s29
+  s31 -- "['3'] → [K]/[S]" --> s30
+```
+
+Two shared body states (X, Y). B reaches X only; C reaches Y only. They never see each other directly — yet they live in the same frame because A bridges them. The union-find transitive-closure step is what bundles them.
+
+**Reading rule encoded in the emit:** one subgraph = one union component. The label tells you how many bares share the scope. `& `-joined `call` / `return` arrows tell you how many wrappers are in play (always one per wrapper; the union collapses bares, never wrappers).
+
 ## Data model changes
 
 The callable-subtree model **un-collapses what v7 alpha.1 collapsed**. In alpha.1, each `withOverriddenHaltState` wrapper produces ONE `GraphNode` representing both the wrapper and its bare (the bare is "collapsed onto" the wrapper's id, with `isWrapped: true`). Under the new model, **wrappers and bares are separate `GraphNode` instances**:

--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -651,3 +651,259 @@ describe('callable-subtree: shared body state forces a union frame', () => {
     expect(out).toMatch(/s\d+ == "call" ==> s\d+/g);
   });
 });
+
+// Spec-doc invariants + snapshots for the three worked union shapes in
+// `docs/superpowers/specs/2026-05-21-halt-frame-transitive-closure.md`'s
+// "Worked union shapes — engine-emitted Mermaid" section.
+//
+// The spec doc claims its Mermaid blocks are real engine emit (not
+// hand-drawn). These tests enforce that claim two ways:
+//   1. Invariant tests assert the structural rules the model promises
+//      (frame merging, ribbon collapse, demand-emit arrows). Named tests
+//      → failures point at the broken rule, not at a byte diff.
+//   2. Snapshot tests (with id normalization, same shape as the
+//      round-trip test) pin the cosmetic emit. Failures here catch drift
+//      between the doc and the engine — either rerun the probe + update
+//      the doc, or revert the unintended emit change.
+//
+// Normalize all `s\d+`, `c\d+`, `w_\d+` to `sX`/`cX`/`w_X` since global
+// State.#id is shared across tests and isn't stable across test-ordering
+// changes. Same normalization used by `test/round-trip.spec.ts`.
+function stripIds(mermaid: string): string {
+  return mermaid
+    .replace(/\bs\d+\b/g, 'sX')
+    .replace(/\bc\d+\b/g, 'cX')
+    .replace(/\bw_\d+\b/g, 'w_X');
+}
+
+describe('spec doc: worked union shapes are real engine emit', () => {
+  // Reusable target factory — each test needs N small halting States as
+  // wrapper targets. Inlining the State construction directly would clutter
+  // each test.
+  const haltingTarget = (name: string) => new State({
+    [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+  }, name);
+
+  test('Case 1: A ∪ B (two bares, one shared body state X)', () => {
+    const alphabet = new Alphabet([' ', '1', '2']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+
+    const X = haltingTarget('X');
+    const A = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'A');
+    const B = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'B');
+    const W1 = A.withOverriddenHaltState(haltingTarget('t1'));
+    const W2 = B.withOverriddenHaltState(haltingTarget('t2'));
+    const dispatcher = new State({
+      [symbol(['1'])]: {command: {movement: movements.stay}, nextState: W1},
+      [symbol(['2'])]: {command: {movement: movements.stay}, nextState: W2},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+    const out = toMermaid(graph);
+
+    // Invariants — A, B distinct bares so call arrows are NOT ribbon-collapsed
+    // (the `& ` ribbon on calls collapses only wrappers SHARING a bare).
+    expect(graph.nodes[A.id].frameId).toBe(graph.nodes[B.id].frameId);
+    expect(graph.nodes[X.id].frameId).toBe(graph.nodes[A.id].frameId);
+    expect(out).toContain('"callable scope: A ∪ B"');
+    expect(out.match(/== "call" ==>/g)).toHaveLength(2); // one per wrapper
+    expect(out).toMatch(/w_\d+ -\. "return" \.-> s\d+ & s\d+/); // ribbon on return side
+    expect(out).not.toMatch(/-\. "halt" \.->/); // no non-wrapper entry to frame
+
+    // Snapshot (id-normalized). Doubles as the cosmetic-drift detector for
+    // the matching block in the spec doc.
+    const expected = [
+      'flowchart TD',
+      '%% alphabets: [[" ","1","2"]]',
+      '  sX(((halt)))',
+      '  sX["t1"]',
+      '  sX["t2"]',
+      '  sX["dispatcher"]',
+      '  sX[["A(t1)"]]',
+      '  sX[["B(t2)"]]',
+      '  idle([idle])',
+      '  subgraph w_X["callable scope: A ∪ B"]',
+      '    sX["X"]',
+      '    sX["A"]',
+      '    sX["B"]',
+      '    cX(((halt)))',
+      '  end',
+      '  idle -. enter .-> sX',
+      '  sX == "call" ==> sX',
+      '  sX == "call" ==> sX',
+      '  w_X -. "return" .-> sX & sX',
+      '  sX --> sX',
+      '  sX --> sX',
+      '  sX -- "[*] → [K]/[S]" --> cX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      "  sX -- \"['1'] → [K]/[S]\" --> sX",
+      "  sX -- \"['2'] → [K]/[S]\" --> sX",
+    ].join('\n');
+
+    expect(stripIds(out)).toBe(expected);
+  });
+
+  test('Case 2: A ∪ B ∪ C (three bares, all share X directly)', () => {
+    const alphabet = new Alphabet([' ', '1', '2', '3']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+
+    const X = haltingTarget('X');
+    const A = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'A');
+    const B = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'B');
+    const C = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'C');
+    const W1 = A.withOverriddenHaltState(haltingTarget('t1'));
+    const W2 = B.withOverriddenHaltState(haltingTarget('t2'));
+    const W3 = C.withOverriddenHaltState(haltingTarget('t3'));
+    const dispatcher = new State({
+      [symbol(['1'])]: {command: {movement: movements.stay}, nextState: W1},
+      [symbol(['2'])]: {command: {movement: movements.stay}, nextState: W2},
+      [symbol(['3'])]: {command: {movement: movements.stay}, nextState: W3},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+    const out = toMermaid(graph);
+
+    // Invariants
+    const frameA = graph.nodes[A.id].frameId;
+
+    expect(frameA).not.toBeNull();
+    expect(graph.nodes[B.id].frameId).toBe(frameA);
+    expect(graph.nodes[C.id].frameId).toBe(frameA);
+    expect(graph.nodes[X.id].frameId).toBe(frameA);
+    expect(out).toContain('"callable scope: A ∪ B ∪ C"');
+    expect(out.match(/== "call" ==>/g)).toHaveLength(3); // one per wrapper, no ribbon
+    expect(out).toMatch(/w_\d+ -\. "return" \.-> s\d+ & s\d+ & s\d+/);
+    expect(out).not.toMatch(/-\. "halt" \.->/);
+
+    const expected = [
+      'flowchart TD',
+      '%% alphabets: [[" ","1","2","3"]]',
+      '  sX(((halt)))',
+      '  sX["t1"]',
+      '  sX["t2"]',
+      '  sX["t3"]',
+      '  sX["dispatcher"]',
+      '  sX[["A(t1)"]]',
+      '  sX[["B(t2)"]]',
+      '  sX[["C(t3)"]]',
+      '  idle([idle])',
+      '  subgraph w_X["callable scope: A ∪ B ∪ C"]',
+      '    sX["X"]',
+      '    sX["A"]',
+      '    sX["B"]',
+      '    sX["C"]',
+      '    cX(((halt)))',
+      '  end',
+      '  idle -. enter .-> sX',
+      '  sX == "call" ==> sX',
+      '  sX == "call" ==> sX',
+      '  sX == "call" ==> sX',
+      '  w_X -. "return" .-> sX & sX & sX',
+      '  sX --> sX',
+      '  sX --> sX',
+      '  sX --> sX',
+      '  sX -- "[*] → [K]/[S]" --> cX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      "  sX -- \"['1'] → [K]/[S]\" --> sX",
+      "  sX -- \"['2'] → [K]/[S]\" --> sX",
+      "  sX -- \"['3'] → [K]/[S]\" --> sX",
+    ].join('\n');
+
+    expect(stripIds(out)).toBe(expected);
+  });
+
+  test('Case 3: (A ∪ B) ∪ C — transitive (A bridges B and C via X and Y)', () => {
+    const alphabet = new Alphabet([' ', '1', '2', '3']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+
+    const X = haltingTarget('X');
+    const Y = haltingTarget('Y');
+    // A has TWO transitions — one to X (overlapping B's reach), one to Y
+    // (overlapping C's reach). B and C share nothing directly.
+    const A = new State({
+      [symbol(['1'])]: {command: {movement: movements.right}, nextState: X},
+      [symbol(['2'])]: {command: {movement: movements.right}, nextState: Y},
+    }, 'A');
+    const B = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: X}}, 'B');
+    const C = new State({[ifOtherSymbol]: {command: {movement: movements.right}, nextState: Y}}, 'C');
+    const W1 = A.withOverriddenHaltState(haltingTarget('t1'));
+    const W2 = B.withOverriddenHaltState(haltingTarget('t2'));
+    const W3 = C.withOverriddenHaltState(haltingTarget('t3'));
+    const dispatcher = new State({
+      [symbol(['1'])]: {command: {movement: movements.stay}, nextState: W1},
+      [symbol(['2'])]: {command: {movement: movements.stay}, nextState: W2},
+      [symbol(['3'])]: {command: {movement: movements.stay}, nextState: W3},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+    const out = toMermaid(graph);
+
+    // Invariants — transitive merge is the load-bearing rule.
+    const frameA = graph.nodes[A.id].frameId;
+
+    expect(frameA).not.toBeNull();
+    expect(graph.nodes[B.id].frameId).toBe(frameA);
+    expect(graph.nodes[C.id].frameId).toBe(frameA);
+    expect(graph.nodes[X.id].frameId).toBe(frameA);
+    expect(graph.nodes[Y.id].frameId).toBe(frameA); // critical: B-C don't share directly
+    expect(out).toContain('"callable scope: A ∪ B ∪ C"');
+    expect(out.match(/== "call" ==>/g)).toHaveLength(3);
+    expect(out).toMatch(/w_\d+ -\. "return" \.-> s\d+ & s\d+ & s\d+/);
+    expect(out).not.toMatch(/-\. "halt" \.->/);
+
+    const expected = [
+      'flowchart TD',
+      '%% alphabets: [[" ","1","2","3"]]',
+      '  sX(((halt)))',
+      '  sX["t1"]',
+      '  sX["t2"]',
+      '  sX["t3"]',
+      '  sX["dispatcher"]',
+      '  sX[["A(t1)"]]',
+      '  sX[["B(t2)"]]',
+      '  sX[["C(t3)"]]',
+      '  idle([idle])',
+      '  subgraph w_X["callable scope: A ∪ B ∪ C"]',
+      '    sX["X"]',
+      '    sX["Y"]',
+      '    sX["A"]',
+      '    sX["B"]',
+      '    sX["C"]',
+      '    cX(((halt)))',
+      '  end',
+      '  idle -. enter .-> sX',
+      '  sX == "call" ==> sX',
+      '  sX == "call" ==> sX',
+      '  sX == "call" ==> sX',
+      '  w_X -. "return" .-> sX & sX & sX',
+      '  sX --> sX',
+      '  sX --> sX',
+      '  sX --> sX',
+      '  sX -- "[*] → [K]/[S]" --> cX',
+      '  sX -- "[*] → [K]/[S]" --> cX',
+      "  sX -- \"['1'] → [K]/[R]\" --> sX",
+      "  sX -- \"['2'] → [K]/[R]\" --> sX",
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[R]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      '  sX -- "[*] → [K]/[S]" --> sX',
+      "  sX -- \"['1'] → [K]/[S]\" --> sX",
+      "  sX -- \"['2'] → [K]/[S]\" --> sX",
+      "  sX -- \"['3'] → [K]/[S]\" --> sX",
+    ].join('\n');
+
+    expect(stripIds(out)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

Appends three engine-emitted Mermaid examples to the "Shared body state" edge-case section of the callable-subtree spec doc (\`docs/superpowers/specs/2026-05-21-halt-frame-transitive-closure.md\`), **plus invariant + snapshot tests that enforce the doc's "real engine emit" claim against future drift**.

### Spec doc additions

- **Case 1: \`A ∪ B\`** — two bares, one shared body state. Two separate \`== "call" ==>\` arrows; one \`& \`-joined \`return\` ribbon. No \`halt\` arrow (no non-wrapper entry to frame).
- **Case 2: \`A ∪ B ∪ C\`** — three bares, all share X directly. Three separate \`call\` arrows; one three-way \`return\` ribbon.
- **Case 3: \`(A ∪ B) ∪ C\`** (transitive) — A shares X with B, A shares Y with C, B and C share nothing direct. Union-find's transitive-closure step bundles all three into one scope.

### Tests added (\`graph.spec.ts > spec doc: worked union shapes are real engine emit\`)

Per case, **invariant + snapshot** — two layers that catch different failure modes:

**Invariant assertions** (model-level rules; failure points at the broken contract):
- All bares in a case share one \`frameId\`.
- Frame-label string matches (\`"callable scope: A ∪ B"\` etc.).
- Number of \`== "call" ==>\` arrows equals number of wrappers (each wrapper has its own bare → no call-side ribbon collapse).
- Return arrow is one \`& \`-joined ribbon over all calling wrappers.
- No \`-. "halt" .->\` arrow (no non-wrapper entry to the frame).

**Snapshot assertions** (cosmetic emit; pins the doc's "real engine emit" claim):
- Full \`toMermaid\` output, with state IDs normalized via \`stripIds\` (\`s\d+\` → \`sX\`, \`c\d+\` → \`cX\`, \`w_\d+\` → \`w_X\` — same approach as \`test/round-trip.spec.ts\`).
- A snapshot failure means either the engine's emit drifted (re-pin) or the spec doc was edited out-of-sync (regenerate from probe).

### Why both layers

- **Invariant alone** misses cosmetic drift — the doc could go stale without the contract breaking.
- **Snapshot alone** fails opaquely on rule breaks (\`"strings differ"\`) without naming the broken rule.
- **Together**: when invariant fails, the failure NAMES the broken rule. When snapshot fails but invariants pass, drift is purely cosmetic.

## Test plan

- [x] \`npm test\` — 442/442 pass (439 prior + 3 new)
- [x] \`npm run lint\` — clean

## Commits

1. \`231729f\` — docs(spec): worked union shapes (A∪B, A∪B∪C, transitive)
2. \`401b80a\` — test(spec): invariant + snapshot tests for the worked union shapes