### PR TITLE
feat(state): first-class tags on State + GraphNode + Mermaid emit (#186)

### DIFF
--- a/packages/machine/src/classes/State.spec.ts
+++ b/packages/machine/src/classes/State.spec.ts
@@ -332,6 +332,95 @@ describe('State.toGraph — unbound Reference', () => {
   });
 });
 
+describe('State tags (#186)', () => {
+  test('a fresh State has an empty tags array', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    expect(s.tags).toEqual([]);
+  });
+
+  test('tag() adds tags and is chainable', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    const ret = s.tag('hot', 'sampled');
+
+    expect(ret).toBe(s);
+    expect(s.tags).toEqual(['hot', 'sampled']);
+  });
+
+  test('tag() de-duplicates repeated tags', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    s.tag('hot');
+    s.tag('hot', 'cold');
+
+    expect(s.tags).toEqual(['hot', 'cold']);
+  });
+
+  test('untag() removes tags and is chainable', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    s.tag('hot', 'sampled', 'cold');
+    const ret = s.untag('hot');
+
+    expect(ret).toBe(s);
+    expect(s.tags).toEqual(['sampled', 'cold']);
+  });
+
+  test('untag() of a non-present tag is a no-op', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    s.tag('a');
+    s.untag('not-present');
+
+    expect(s.tags).toEqual(['a']);
+  });
+
+  test('tags getter returns a frozen snapshot — caller cannot mutate', () => {
+    const s = new State({[ifOtherSymbol]: {nextState: haltState}});
+
+    s.tag('a');
+    const snapshot = s.tags;
+
+    expect(() => {
+      (snapshot as unknown as string[]).push('b');
+    }).toThrow();
+
+    expect(s.tags).toEqual(['a']);
+  });
+
+  test('tags are scoped to the wrapper instance, not the shared bare (#175 sharing)', () => {
+    // Engine #175 memoization means `A.wohs(t1)` and `A.wohs(t2)` produce
+    // distinct wrapper instances even though they share the same `#symbolToDataMap`.
+    // Tags must live on the wrapper instance — tagging one wrapper must NOT
+    // propagate to siblings sharing the same bare.
+    const A = new State({[ifOtherSymbol]: {nextState: haltState}}, 'A');
+    const t1 = new State({[ifOtherSymbol]: {nextState: haltState}}, 't1');
+    const t2 = new State({[ifOtherSymbol]: {nextState: haltState}}, 't2');
+
+    const W1 = A.withOverriddenHaltState(t1);
+    const W2 = A.withOverriddenHaltState(t2);
+
+    W1.tag('hot');
+
+    expect(W1.tags).toEqual(['hot']);
+    expect(W2.tags).toEqual([]); // no leak across wrappers sharing a bare
+    expect(A.tags).toEqual([]);  // no leak to the bare either
+  });
+
+  test('haltState is not specially excluded from tagging', () => {
+    // No reason to forbid tagging haltState. Engine doesn't impose a tag
+    // semantic, so tagging the halt singleton is the consumer's call.
+    haltState.tag('halt-debug-marker');
+
+    expect(haltState.tags).toContain('halt-debug-marker');
+
+    // Cleanup so other tests don't see the residue.
+    haltState.untag('halt-debug-marker');
+    expect(haltState.tags).not.toContain('halt-debug-marker');
+  });
+});
+
 describe('State.fromGraph — cyclic override-halt chain', () => {
   test('throws when the override-halt graph has a cycle', () => {
     // Under the v7 callable-subtree model, override-halt chains live on
@@ -343,10 +432,10 @@ describe('State.fromGraph — cyclic override-halt chain', () => {
       initialId: 1,
       alphabets: [[' ', '0', '1']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        1: {id: 1, name: 'wA', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: true, bareStateId: 3, frameId: null},
-        2: {id: 2, name: 'wB', isHalt: false, transitions: [], overriddenHaltStateId: 1, isHaltMarker: false, isWrapper: true, bareStateId: 3, frameId: null},
-        3: {id: 3, name: 'shared', isHalt: false, transitions: [dummyTransition], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        1: {id: 1, name: 'wA', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: true, bareStateId: 3, frameId: null, tags: []},
+        2: {id: 2, name: 'wB', isHalt: false, transitions: [], overriddenHaltStateId: 1, isHaltMarker: false, isWrapper: true, bareStateId: 3, frameId: null, tags: []},
+        3: {id: 3, name: 'shared', isHalt: false, transitions: [dummyTransition], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
       },
     };
 

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -102,6 +102,15 @@ export default class State {
   // a runtime concern, not part of the structural graph.
   #debugRef: { current: DebugConfig | null } = {current: null};
 
+  // Out-of-band tags applied to this State (#186). Tags are visualization
+  // and debugger-tooling metadata — they don't affect runtime transition
+  // lookup or `equivalentOn` comparisons. Stored as a Set for de-duplication;
+  // exposed via the `tags` getter as a frozen array snapshot. Lives on the
+  // State INSTANCE so wrappers (from `withOverriddenHaltState`) carry tags
+  // independently of their bare's tag set — see the #175 sharing test in
+  // State.spec.ts.
+  #tags: Set<string> = new Set();
+
   constructor(stateDefinition: Record<string | symbol, {
     command?: Command | ConstructorParameters<typeof TapeCommand>[0] | ConstructorParameters<typeof TapeCommand>[0][],
     nextState?: State | Reference,
@@ -214,6 +223,41 @@ export default class State {
     }
 
     this.#debugRef.current = new DebugConfig(this, value);
+  }
+
+  /**
+   * Add one or more tags to this State (#186). Tags are out-of-band metadata
+   * used by visualization (`toMermaid` emits `classDef`/`class` lines) and
+   * debugger tooling — they don't affect runtime transition lookup,
+   * `equivalentOn` comparisons, or any structural identity. Chainable.
+   */
+  tag(...tags: string[]): this {
+    for (const t of tags) {
+      this.#tags.add(t);
+    }
+
+    return this;
+  }
+
+  /**
+   * Remove one or more tags from this State (#186). Untagging a tag the
+   * State doesn't carry is a no-op. Chainable.
+   */
+  untag(...tags: string[]): this {
+    for (const t of tags) {
+      this.#tags.delete(t);
+    }
+
+    return this;
+  }
+
+  /**
+   * Frozen snapshot of this State's current tags (#186). The returned array
+   * is `Object.freeze`d — mutating it throws in strict mode (which TS-emitted
+   * code uses). Order matches insertion order of the underlying Set.
+   */
+  get tags(): readonly string[] {
+    return Object.freeze([...this.#tags]);
   }
 
   /** @internal — invoked by DebugConfig setters via module-private symbol. */
@@ -429,6 +473,7 @@ export default class State {
             frameId: null,
             transitions: [],
             overriddenHaltStateId: null,
+            tags: [...state.#tags],
           };
         }
 
@@ -450,6 +495,7 @@ export default class State {
           frameId: null,
           transitions: [],
           overriddenHaltStateId: overrideTarget.#id,
+          tags: [...state.#tags],
         };
 
         bareIds.add(bareState.#id);
@@ -470,6 +516,7 @@ export default class State {
         frameId: null,
         transitions: [],
         overriddenHaltStateId: null,
+        tags: [...state.#tags],
       };
 
       nodes[state.#id] = node;
@@ -515,6 +562,7 @@ export default class State {
         frameId: null,
         transitions: [],
         overriddenHaltStateId: null,
+        tags: [...haltState.#tags],
       };
     }
 
@@ -672,6 +720,7 @@ export default class State {
         frameId,
         transitions: [],
         overriddenHaltStateId: null,
+        tags: [],
       };
     }
 
@@ -764,6 +813,11 @@ export default class State {
       const bare = new State(stateDefinition);
 
       bare.#name = node.name;
+
+      if (node.tags.length > 0) {
+        bare.tag(...node.tags);
+      }
+
       bareStates[nodeId] = bare;
     }
 
@@ -799,6 +853,14 @@ export default class State {
         const override = getFinal(node.overriddenHaltStateId!);
 
         state = bare.withOverriddenHaltState(override);
+
+        // Apply wrapper-scoped tags (#186). Tags don't leak across wrappers
+        // sharing a bare — the wrapper instance owns its own tag set, and
+        // engine #175 memoization returns the same instance for the same
+        // (bare, override) pair, so this is idempotent across rebuilds.
+        if (node.tags.length > 0) {
+          state.tag(...node.tags);
+        }
       } else {
         state = bareStates[nodeId];
       }

--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -118,9 +118,9 @@ describe('toMermaid', () => {
       initialId: 1,
       alphabets: [[' ', '0', '1']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
         1: {
-          id: 1, name: 'entry', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null,
+          id: 1, name: 'entry', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: [],
           transitions: [
             {pattern: "'0'", command: [{symbol: 'K', movement: 'R'}], nextStateId: 1, id: "test-edge"},
             {pattern: "'1'", command: [{symbol: 'K', movement: 'S'}], nextStateId: 0, id: "test-edge"},
@@ -147,8 +147,8 @@ describe('toMermaid', () => {
       initialId: 1,
       alphabets: [[' ', '0']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        1: {id: 1, name: 'wrapper', isHalt: false, transitions: [], overriddenHaltStateId: 0, isHaltMarker: false, isWrapper: true, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        1: {id: 1, name: 'wrapper', isHalt: false, transitions: [], overriddenHaltStateId: 0, isHaltMarker: false, isWrapper: true, bareStateId: null, frameId: null, tags: []},
       },
     });
 
@@ -161,9 +161,9 @@ describe('toMermaid', () => {
       initialId: 1,
       alphabets: [[' ', '0']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        1: {id: 1, name: 'entry', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        2: {id: 2, name: 'helper', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        1: {id: 1, name: 'entry', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        2: {id: 2, name: 'helper', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
       },
     });
 
@@ -175,9 +175,9 @@ describe('toMermaid', () => {
       initialId: 1,
       alphabets: [[' ', '0'], [' ', 'a']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
         1: {
-          id: 1, name: 'entry', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null,
+          id: 1, name: 'entry', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: [],
           transitions: [{
             pattern: "'0','a'",
             command: [{symbol: "'0'", movement: 'R'}, {symbol: "'a'", movement: 'L'}],
@@ -905,5 +905,101 @@ describe('spec doc: worked union shapes are real engine emit', () => {
     ].join('\n');
 
     expect(stripIds(out)).toBe(expected);
+  });
+});
+
+describe('toMermaid: tags (#186)', () => {
+  test('no tags → no classDef / class lines', () => {
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 'plain');
+
+    const out = toMermaid(State.toGraph(s, tapeBlock));
+
+    expect(out).not.toContain('classDef');
+    expect(out).not.toContain('class ');
+  });
+
+  test('one tag → one classDef + matching class assignment', () => {
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 'tagged').tag('hot');
+
+    const out = toMermaid(State.toGraph(s, tapeBlock));
+
+    expect(out).toMatch(/classDef tag_hot /);
+    expect(out).toMatch(/class s\d+ tag_hot/);
+  });
+
+  test('multiple states sharing a tag → one classDef, comma-joined ids in class', () => {
+    const alphabet = new Alphabet([' ', '0', '1']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+    const b = new State({
+      [symbol(['1'])]: {nextState: haltState},
+    }, 'b').tag('hot');
+    const a = new State({
+      [symbol(['0'])]: {nextState: b},
+    }, 'a').tag('hot');
+
+    const out = toMermaid(State.toGraph(a, tapeBlock));
+
+    expect((out.match(/classDef tag_hot /g) ?? []).length).toBe(1);
+    // Two states share the tag — emitted on one `class` line with
+    // comma-joined ids.
+    expect(out).toMatch(/class s\d+,s\d+ tag_hot/);
+  });
+
+  test('multiple tags on one state → one class line per tag', () => {
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 'tagged').tag('hot', 'sampled');
+
+    const out = toMermaid(State.toGraph(s, tapeBlock));
+
+    expect(out).toMatch(/classDef tag_hot /);
+    expect(out).toMatch(/classDef tag_sampled /);
+    expect(out).toMatch(/class s\d+ tag_hot/);
+    expect(out).toMatch(/class s\d+ tag_sampled/);
+  });
+});
+
+describe('fromMermaid: tags (#186)', () => {
+  test('parses classDef + class lines back into GraphNode.tags', () => {
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","0"]]',
+      '  s0(((halt)))',
+      '  s1["a"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      "  s1 -- \"['0'] → [K]/[S]\" --> s0",
+      '  classDef tag_hot fill:#fef3c7',
+      '  class s1 tag_hot',
+    ].join('\n');
+
+    const graph = fromMermaid(mermaid);
+
+    expect(graph.nodes[1].tags).toEqual(['hot']);
+    expect(graph.nodes[0].tags).toEqual([]);
+  });
+
+  test('multi-tag round-trip preserves order', () => {
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 'rt').tag('alpha', 'beta');
+
+    const emitted = toMermaid(State.toGraph(s, tapeBlock));
+    const reparsed = fromMermaid(emitted);
+
+    expect(reparsed.nodes[s.id].tags).toEqual(['alpha', 'beta']);
   });
 });

--- a/packages/machine/src/utilities/graph.ts
+++ b/packages/machine/src/utilities/graph.ts
@@ -49,6 +49,11 @@ export type GraphNode = {
   // `haltState`. Halt marker id = `-frameId` (sits in disjoint negative-id
   // range from real node ids).
   isHaltMarker: boolean;
+  // Out-of-band tags applied to this State (#186). Empty array if untagged.
+  // Survives `toGraph`/`fromGraph` round-trip and renders in `toMermaid` as
+  // `classDef tag_<name>` + `class sN tag_<name>` lines. Doesn't affect
+  // runtime semantics — purely a visualization/debugger-tooling channel.
+  tags: string[];
 };
 
 export type Graph = {

--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -83,6 +83,17 @@ export function toMermaid(graph: Graph): string {
     }
   }
 
+  // Build the visible-label string for a node — name plus, if tagged, a
+  // `<br>tag1, tag2, ...` suffix so the rendered Mermaid shows both. Tags
+  // are the source of truth on the GraphNode; `<br>` is the universal
+  // Mermaid line-break that works across renderers without `classDef`-
+  // pseudo-element hacks (#186).
+  const labelOf = (node: GraphNode): string => {
+    if (node.tags.length === 0) return node.name;
+
+    return `${node.name}<br>${node.tags.join(', ')}`;
+  };
+
   // 1. Emit top-level nodes (real halt, non-wrapper regulars outside any frame).
   for (const node of topLevelNodes) {
     const mid = mermaidIdFor(node.id);
@@ -90,13 +101,13 @@ export function toMermaid(graph: Graph): string {
     if (node.isHalt) {
       lines.push(`  ${mid}(((halt)))`);
     } else {
-      lines.push(`  ${mid}["${node.name}"]`);
+      lines.push(`  ${mid}["${labelOf(node)}"]`);
     }
   }
 
   // 2. Emit wrappers at top level.
   for (const wrapper of wrapperNodes) {
-    lines.push(`  ${mermaidIdFor(wrapper.id)}[["${wrapper.name}"]]`);
+    lines.push(`  ${mermaidIdFor(wrapper.id)}[["${labelOf(wrapper)}"]]`);
   }
 
   // 3. `idle` sentinel.
@@ -121,7 +132,7 @@ export function toMermaid(graph: Graph): string {
 
     // Inner nodes — sort by id for determinism.
     for (const node of (nodesByFrame.get(frameId) ?? []).slice().sort((a, b) => a.id - b.id)) {
-      lines.push(`    ${mermaidIdFor(node.id)}["${node.name}"]`);
+      lines.push(`    ${mermaidIdFor(node.id)}["${labelOf(node)}"]`);
     }
 
     const haltMarker = haltMarkerByFrame.get(frameId);
@@ -249,7 +260,81 @@ export function toMermaid(graph: Graph): string {
     }
   }
 
+  // 10. Tags (#186) — emit one `classDef tag_<name> fill:#...` per unique
+  //     tag across all nodes, then one `class <ids> tag_<name>` line per
+  //     tag listing every node that carries it (comma-joined for compact
+  //     emit). Tag-name → CSS-class identifier sanitization replaces any
+  //     char outside `[A-Za-z0-9_-]` with `_`; tag-name uniqueness in the
+  //     emit assumes user tags are already distinct after sanitization
+  //     (collisions are user error).
+  emitTagAnnotations(lines, nodes);
+
   return lines.join('\n');
+}
+
+// Default Mermaid `classDef` palette — 6 visually distinct fill+stroke pairs,
+// selected by tag-name hash so multi-tag diagrams look readable out of the
+// box without user configuration. Users who want different colors can edit
+// the emitted Mermaid before rendering or override post-emit.
+const TAG_PALETTE: ReadonlyArray<readonly [string, string]> = [
+  ['#fef3c7', '#92400e'], // amber
+  ['#dbeafe', '#1e40af'], // blue
+  ['#dcfce7', '#166534'], // green
+  ['#fce7f3', '#9d174d'], // pink
+  ['#ede9fe', '#5b21b6'], // violet
+  ['#fee2e2', '#991b1b'], // red
+];
+
+function sanitizeTagName(tag: string): string {
+  return tag.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+function tagColor(tag: string): readonly [string, string] {
+  // Cheap deterministic hash — sum of char codes mod palette length. Stable
+  // across runs; same tag name always picks the same color.
+  let h = 0;
+
+  for (let i = 0; i < tag.length; i += 1) {
+    h = (h + tag.charCodeAt(i)) % TAG_PALETTE.length;
+  }
+
+  return TAG_PALETTE[h];
+}
+
+function emitTagAnnotations(lines: string[], nodes: GraphNode[]): void {
+  // Collect nodes per tag in node-id order so output is deterministic.
+  const nodesByTag = new Map<string, number[]>();
+
+  for (const node of nodes) {
+    for (const tag of node.tags) {
+      let list = nodesByTag.get(tag);
+
+      if (!list) {
+        list = [];
+        nodesByTag.set(tag, list);
+      }
+
+      list.push(node.id);
+    }
+  }
+
+  if (nodesByTag.size === 0) return;
+
+  const sortedTags = [...nodesByTag.keys()].sort();
+
+  for (const tag of sortedTags) {
+    const sanitized = sanitizeTagName(tag);
+    const [fill, stroke] = tagColor(tag);
+
+    lines.push(`  classDef tag_${sanitized} fill:${fill},stroke:${stroke}`);
+  }
+
+  for (const tag of sortedTags) {
+    const sanitized = sanitizeTagName(tag);
+    const ids = nodesByTag.get(tag)!.map((id) => mermaidIdFor(id)).join(',');
+
+    lines.push(`  class ${ids} tag_${sanitized}`);
+  }
 }
 
 // Helper: identify "the bare states" that anchor a frame's name. A bare is a
@@ -301,6 +386,32 @@ const haltArrowRegex = /^w_(\d+)\s+-\.\s+"halt"\s+\.->\s+s0$/;
 // First capture char anchored as \S to avoid polynomial backtracking between
 // the preceding \s* and a permissive (.+); see CodeQL js/polynomial-redos.
 const alphabetsRegex = /^%%\s*alphabets:\s*(\S.*)$/;
+// Tag annotation lines (#186). Matches both `classDef tag_<sanitized>` and
+// `class <id-list> tag_<sanitized>`. ClassDef declarations are decorative
+// (palette) and discarded on parse — toMermaid will regenerate them from
+// the tag set on re-emit. `class` lines carry the actual graph-node
+// assignments; we strip the `tag_` prefix and assign each tag to each
+// listed node's `tags` array.
+const classDefTagRegex = /^classDef\s+tag_([A-Za-z0-9_-]+)\s+.+$/;
+const classAssignTagRegex = /^class\s+([sc]\d+(?:,[sc]\d+)*)\s+tag_([A-Za-z0-9_-]+)$/;
+
+// Splits a node label like `"A<br>hot, sampled"` into its name and tags (#186).
+// Labels without `<br>` have no tags. Tags are comma-joined; trimmed of
+// whitespace. The `<br>` is the single source of truth for tag-name parsing —
+// `class` lines are decorative-only and not consulted here.
+function splitLabelTags(label: string): {name: string; tags: string[]} {
+  const brIx = label.indexOf('<br>');
+
+  if (brIx < 0) {
+    return {name: label, tags: []};
+  }
+
+  const name = label.slice(0, brIx);
+  const tagsStr = label.slice(brIx + '<br>'.length);
+  const tags = tagsStr.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+
+  return {name, tags};
+}
 
 export function fromMermaid(text: string): Graph {
   const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
@@ -319,6 +430,7 @@ export function fromMermaid(text: string): Graph {
       isWrapper?: boolean;
       bareStateId?: number | null;
       frameId?: number | null;
+      tags?: string[];
     } = {},
   ): GraphNode => {
     if (!nodes[id]) {
@@ -332,6 +444,7 @@ export function fromMermaid(text: string): Graph {
         frameId: opts.frameId ?? null,
         transitions: [],
         overriddenHaltStateId: null,
+        tags: opts.tags ? [...opts.tags] : [],
       };
     } else {
       if (opts.name !== undefined) nodes[id].name = opts.name;
@@ -340,6 +453,11 @@ export function fromMermaid(text: string): Graph {
       if (opts.isWrapper !== undefined) nodes[id].isWrapper = opts.isWrapper;
       if (opts.bareStateId !== undefined) nodes[id].bareStateId = opts.bareStateId;
       if (opts.frameId !== undefined) nodes[id].frameId = opts.frameId;
+      if (opts.tags !== undefined) {
+        for (const t of opts.tags) {
+          if (!nodes[id].tags.includes(t)) nodes[id].tags.push(t);
+        }
+      }
     }
 
     return nodes[id];
@@ -355,6 +473,11 @@ export function fromMermaid(text: string): Graph {
       alphabets = JSON.parse(am[1]);
       continue;
     }
+
+    // Tag annotations (#186) — classDef lines are decorative and skipped;
+    // `class` lines are parsed in the edge pass since they reference nodes
+    // by id and need those nodes already created in the first pass.
+    if (classDefTagRegex.test(line)) continue;
 
     const sgStart = line.match(subgraphStartRegex);
 
@@ -389,9 +512,12 @@ export function fromMermaid(text: string): Graph {
     const wm = line.match(wrappedNodeRegex);
 
     if (wm) {
+      const {name, tags} = splitLabelTags(wm[2]);
+
       ensureNode(parseMermaidId(wm[1]), {
-        name: wm[2],
+        name,
         isWrapper: true,
+        tags,
       });
 
       continue;
@@ -400,9 +526,12 @@ export function fromMermaid(text: string): Graph {
     const rm = line.match(regularNodeRegex);
 
     if (rm) {
+      const {name, tags} = splitLabelTags(rm[2]);
+
       ensureNode(parseMermaidId(rm[1]), {
-        name: rm[2],
+        name,
         frameId: currentFrameId,
+        tags,
       });
 
       continue;
@@ -421,6 +550,23 @@ export function fromMermaid(text: string): Graph {
     // Return/halt arrows are derivable from frame structure at the next
     // toMermaid emit; consume but don't persist as graph data.
     if (returnArrowRegex.test(line) || haltArrowRegex.test(line)) {
+      continue;
+    }
+
+    // Tag class-assignment line (#186): `class s1,s5 tag_hot` — adds
+    // the tag to each listed node. Tag-name preserved as written
+    // (sanitization on emit is lossy in principle; on parse we don't
+    // un-sanitize, since the original could have any characters).
+    const tagMatch = line.match(classAssignTagRegex);
+
+    if (tagMatch) {
+      const ids = tagMatch[1].split(',');
+      const tagName = tagMatch[2];
+
+      for (const idStr of ids) {
+        ensureNode(parseMermaidId(idStr), {tags: [tagName]});
+      }
+
       continue;
     }
 

--- a/packages/machine/src/utilities/introspection.spec.ts
+++ b/packages/machine/src/utilities/introspection.spec.ts
@@ -7,9 +7,9 @@ describe('summarizeGraph', () => {
       initialId: 1,
       alphabets: [[' ', '0', '1']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
         1: {
-          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null,
+          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: [],
           transitions: [
             {pattern: '0', command: [{symbol: 'K', movement: 'R'}], nextStateId: 1, id: "test-edge"},
             {pattern: '1', command: [{symbol: 'K', movement: 'S'}], nextStateId: 0, id: "test-edge"},
@@ -31,9 +31,9 @@ describe('summarizeGraph', () => {
       initialId: 1,
       alphabets: [[' ', '0']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
         1: {
-          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null,
+          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: [],
           transitions: [
             {pattern: '0', command: [{symbol: 'K', movement: 'R'}], nextStateId: 1, id: "test-edge"},
           ],
@@ -52,9 +52,9 @@ describe('summarizeGraph', () => {
       initialId: 1,
       alphabets: [[' ', '0']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
         1: {
-          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null,
+          id: 1, name: 'a', isHalt: false, overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: [],
           transitions: [{pattern: '0', command: [{symbol: 'K', movement: 'S'}], nextStateId: 0, id: "test-edge"}],
         },
       },
@@ -72,10 +72,10 @@ describe('summarizeGraph', () => {
       initialId: 1,
       alphabets: [[' ']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        2: {id: 2, name: 'b', isHalt: false, transitions: [], overriddenHaltStateId: 3, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        3: {id: 3, name: 'c', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        2: {id: 2, name: 'b', isHalt: false, transitions: [], overriddenHaltStateId: 3, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        3: {id: 3, name: 'c', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
       },
     };
 
@@ -90,8 +90,8 @@ describe('summarizeGraph', () => {
       initialId: 1,
       alphabets: [[' ']],
       nodes: {
-        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        0: {id: 0, name: 'halt', isHalt: true, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: null, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
       },
     };
 
@@ -197,8 +197,8 @@ describe('summarizeGraph defensive guards', () => {
       initialId: 1,
       alphabets: [[' ', '0']],
       nodes: {
-        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
-        2: {id: 2, name: 'b', isHalt: false, transitions: [], overriddenHaltStateId: 1, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null},
+        1: {id: 1, name: 'a', isHalt: false, transitions: [], overriddenHaltStateId: 2, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
+        2: {id: 2, name: 'b', isHalt: false, transitions: [], overriddenHaltStateId: 1, isHaltMarker: false, isWrapper: false, bareStateId: null, frameId: null, tags: []},
       },
     };
 


### PR DESCRIPTION
Closes #186. Adds `state.tag(...)` / `.untag(...)` / `.tags` API on State, `GraphNode.tags: string[]` field, `<br>`-embedded label emit in toMermaid for visible tag names, `classDef` + `class` lines for color grouping, fromMermaid label-split for parse. Tags live on the State INSTANCE (not on the shared symbolToDataMap), so engine #175 memoization doesn't leak tags across wrappers sharing a bare. 456/456 tests pass, coverage above floors. Driven by post-machine-js#86.