### PR TITLE
fix(fromMermaid): tighten classDef/class tag regexes to clear CodeQL polynomial-ReDoS flag

### DIFF
--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -392,8 +392,13 @@ const alphabetsRegex = /^%%\s*alphabets:\s*(\S.*)$/;
 // the tag set on re-emit. `class` lines carry the actual graph-node
 // assignments; we strip the `tag_` prefix and assign each tag to each
 // listed node's `tags` array.
-const classDefTagRegex = /^classDef\s+tag_([A-Za-z0-9_-]+)\s+.+$/;
-const classAssignTagRegex = /^class\s+([sc]\d+(?:,[sc]\d+)*)\s+tag_([A-Za-z0-9_-]+)$/;
+//
+// Inter-token gaps are fixed at single literal spaces (matching toMermaid's
+// canonical emit) rather than `\s+`. This avoids the polynomial-ReDoS
+// pattern CodeQL flags when `\s+` surrounds a content group (see also
+// `callArrowRegex` / `returnArrowRegex` tightening in PR #182).
+const classDefTagRegex = /^classDef tag_([A-Za-z0-9_-]+) .+$/;
+const classAssignTagRegex = /^class ([sc]\d+(?:,[sc]\d+)*) tag_([A-Za-z0-9_-]+)$/;
 
 // Splits a node label like `"A<br>hot, sampled"` into its name and tags (#186).
 // Labels without `<br>` have no tags. Tags are comma-joined; trimmed of


### PR DESCRIPTION
Same shape as #182 — `\s+...\s+` around a content group with `-` in the character class triggers CodeQL's polynomial-ReDoS detector. `toMermaid` emits these tag lines with exactly single literal spaces, so tightening to literals is loss-free. 456/456 tests pass, lint clean. CodeQL annotation: https://github.com/mellonis/turing-machine-js/pull/167#discussion_r3282035002. Once this lands, alpha.3 release PR #188 needs a rebase to pick it up before publishing.