### PR TITLE
fix: scope halt-stack to runStepByStep call (closes #196)

### DIFF
--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -300,3 +300,133 @@ describe('TuringMachine constructor', () => {
     expect(() => new TuringMachine({} as never)).toThrow(/invalid tapeBlock/);
   });
 });
+
+// Regression tests for #196 — the halt-stack used to be an instance field on
+// TuringMachine that wasn't reset between `runStepByStep` calls, so a caller
+// that peeked at iter 1 via the generator (then disposed it with
+// `generator.return()`) would leave the wrapper's override on the stack;
+// the next `run()` would push it a second time and produce one extra
+// iteration on its way out of the call. Builds a wrapper whose bare halts
+// on blank and whose override also halts immediately — the minimal shape
+// that surfaces the bug.
+describe('halt-stack reset between calls (regression for #196)', () => {
+  // Helper: build a fresh scenario per call so each subtest has independent
+  // State/Tape/TapeBlock instances (the engine's symbol patterns are
+  // tapeBlock-scoped — sharing across scenarios would throw "invalid symbol").
+  function buildWrapperOverWalkToBlank() {
+    const wAlphabet = new Alphabet([' ', 'a', 'b', '*']);
+    const tape = new Tape({alphabet: wAlphabet, symbols: ['a', 'b', 'a']});
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({tapeBlock});
+    const {symbol} = tapeBlock;
+    const walkToBlank = new State({
+      [symbol([wAlphabet.blankSymbol])]: {
+        command: [{movement: movements.stay}],
+        nextState: haltState,
+      },
+      [ifOtherSymbol]: {
+        command: [{movement: movements.right}],
+      },
+    }, 'walkToBlank');
+    const writeMarker = new State({
+      [ifOtherSymbol]: {
+        command: [{symbol: '*', movement: movements.stay}],
+        nextState: haltState,
+      },
+    }, 'writeMarker');
+    const initialState = walkToBlank.withOverriddenHaltState(writeMarker);
+    return {machine, initialState, tape};
+  }
+
+  test('runStepByStep peek + return + run produces no extra iterations', async () => {
+    const {machine, initialState, tape} = buildWrapperOverWalkToBlank();
+
+    // Caller peeks at iter 1 then disposes the generator without draining —
+    // pre-#196 this left the override on `#stack`.
+    const gen = machine.runStepByStep({initialState});
+    gen.next();
+    gen.return(undefined);
+
+    const iters: Array<{step: number; name: string}> = [];
+    await machine.run({
+      initialState,
+      onIter: (m) => {
+        iters.push({step: m.step, name: m.state.name ?? ''});
+      },
+    });
+
+    expect(iters).toEqual([
+      {step: 1, name: 'walkToBlank(writeMarker)'},
+      {step: 2, name: 'walkToBlank'},
+      {step: 3, name: 'walkToBlank'},
+      {step: 4, name: 'walkToBlank'},
+      {step: 5, name: 'writeMarker'},
+    ]);
+    expect(tape.symbols).toEqual(['a', 'b', 'a', '*']);
+  });
+
+  test('runStepByStep and run produce identical iter sequences', async () => {
+    const a = buildWrapperOverWalkToBlank();
+    const fromGen: Array<{step: number; name: string}> = [];
+    for (const m of a.machine.runStepByStep({initialState: a.initialState})) {
+      fromGen.push({step: m.step, name: m.state.name ?? ''});
+    }
+
+    const b = buildWrapperOverWalkToBlank();
+    const fromRun: Array<{step: number; name: string}> = [];
+    await b.machine.run({
+      initialState: b.initialState,
+      onIter: (m) => {
+        fromRun.push({step: m.step, name: m.state.name ?? ''});
+      },
+    });
+
+    expect(fromRun).toEqual(fromGen);
+  });
+
+  test('two consecutive runs on the same machine produce identical iter sequences', async () => {
+    // A self-loop-free machine — both runs traverse the same iter shape
+    // because the input alphabet is wide enough that the head moves off the
+    // initial cells and the post-run tape doesn't influence the next run.
+    // The point of this test is the #stack accumulation, not tape state.
+    const wAlphabet = new Alphabet([' ', 'a', 'b']);
+    const tape = new Tape({alphabet: wAlphabet, symbols: ['a']});
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({tapeBlock});
+    // A wrapper around a single-iter halt-on-anything bare. Each run pushes
+    // the override; if the pre-#196 leak existed, the second run would see
+    // a stale override and one extra iter.
+    const bare = new State({
+      [ifOtherSymbol]: {
+        command: [{movement: movements.stay}],
+        nextState: haltState,
+      },
+    }, 'bare');
+    const continuation = new State({
+      [ifOtherSymbol]: {
+        command: [{movement: movements.stay}],
+        nextState: haltState,
+      },
+    }, 'continuation');
+    const initialState = bare.withOverriddenHaltState(continuation);
+
+    const first: Array<{step: number; name: string}> = [];
+    await machine.run({
+      initialState,
+      onIter: (m) => {
+        first.push({step: m.step, name: m.state.name ?? ''});
+      },
+    });
+
+    const second: Array<{step: number; name: string}> = [];
+    await machine.run({
+      initialState,
+      onIter: (m) => {
+        second.push({step: m.step, name: m.state.name ?? ''});
+      },
+    });
+
+    expect(first.length).toBe(2); // wrapper-iter + continuation-iter
+    expect(second).toEqual(first);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -38,7 +38,6 @@ function matchFilter(filter: DebugConfig['before'], symbol: symbol): boolean {
 
 export default class TuringMachine {
   readonly #tapeBlock: TapeBlock;
-  readonly #stack: State[] = [];
 
   constructor({
                 tapeBlock,
@@ -148,7 +147,14 @@ export default class TuringMachine {
       this.#tapeBlock[lockSymbol].lock(executionSymbol);
 
 
-      const stack = this.#stack;
+      // Halt-stack is run-scoped, not machine-scoped (#196). Declaring it
+      // local makes that lifetime explicit and prevents leftover entries
+      // from a previous `runStepByStep` call (e.g. a build-time peek that
+      // never drained the generator) from being popped during a subsequent
+      // halt-bound transition. Before this change `#stack` was an instance
+      // field and accumulated one extra push per call when the same machine
+      // was reused.
+      const stack: State[] = [];
       let state = initialState;
 
       if (state.overriddenHaltState) {


### PR DESCRIPTION
Closes #196.

## Summary

- `TuringMachine.#stack` was an instance field, never reset between `runStepByStep` calls. Callers that started a generator, peeked at iter 1, then disposed it via `generator.return()` (the pattern `machines-demo`'s worker uses to populate `pendingCommand`) left the wrapper's `overriddenHaltState` on the stack. A subsequent `machine.run()` pushed the same override a second time; on its way out, an in-frame halt popped the leftover entry instead of exiting, producing one extra iteration.
- The stack is run-scoped, not machine-scoped — declared local inside `runStepByStep` so the lifetime is explicit and cross-call leakage is impossible.
- Three regression tests in `TuringMachine.spec.ts`:
  - `runStepByStep peek + return + run produces no extra iterations` — the minimal repro from the issue.
  - `runStepByStep and run produce identical iter sequences` — the broader invariant the bug violated.
  - `two consecutive runs on the same machine produce identical sequences` — defends against stack accumulation regressing in future.

## Memory-leak dimension

The iter-count bug was the visible symptom; the underlying defect was also a small reference leak. Each `runStepByStep` call pushed `state.overriddenHaltState` onto `#stack` at run start. That entry only gets popped when an in-flight iter hits `nextState.isHalt && stack.length`. If the generator is disposed before that pop fires — `.return()` mid-run, exception, or simply never driven past iter 1 (the demo's build-time peek) — the pushed `State` reference stayed on the instance.

Concretely:

1. **Per-call reference leak.** An abnormally-exited `runStepByStep` left one `State` reference on the instance's `#stack`. In the demo's specific pattern the leak was eventually consumed by the next call's ghost iter — i.e., the iter-count bug masked the leak. Had we fixed only the iter count (e.g., by guarding the second push), the leak would have become permanent on every peeked-and-disposed `runStepByStep`.
2. **Cross-call accumulation.** For a long-lived `TuringMachine` reused across many runs — the demo's worker reuses one `machine` for the lifetime of a Build — the stack grew by one entry per peeked-and-disposed call. Each entry is a `State` reference, which transitively pins its `#symbolToDataMap` and the reachable graph. Small per state, but the reachable subgraph can be substantial for non-toy machines.

A `finally`-block stack clear on the instance-field design would have addressed the iter count and the normal-exit leak path, but not the abandoned-generator leak path — that would still leak until the next generator drove its own cleanup. The local-scope fix matches lifetime to data semantics by construction: when the generator is collected, its stack goes with it.

## Test plan

- [x] `npm test` — 465 / 465 green (was 462 + 3 new). 14 / 14 in `TuringMachine.spec.ts` specifically.
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit -p packages/machine/tsconfig.json` — clean.
- [x] End-to-end repro against the demo (`machines-demo`'s "Callable subtree" example, step-by-step trace): pre-fix 6 paused events with a ghost iter at writeMarker; post-fix 5 paused events, ends at the expected halt.