### PR TITLE
fix: HTML-entity-escape user content in Mermaid labels (#194)

### DIFF
--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -1053,3 +1053,167 @@ describe('fromMermaid: tags (#186)', () => {
     expect(reparsed.nodes[s.id].tags).toEqual(['alpha', 'beta']);
   });
 });
+
+describe('Mermaid label escaping (#194)', () => {
+  test('alphabet symbol containing literal " produces parseable output', () => {
+    // Repro from the issue: a write of `"` would land inside the
+    // `"..."`-wrapped edge label and terminate the string early on
+    // Mermaid's tokenizer.
+    const alphabet = new Alphabet([' ', 'a', '"']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['a'])]: {
+        command: [{symbol: '"', movement: movements.right}],
+        nextState: haltState,
+      },
+    }, 's');
+
+    const mermaid = toMermaid(State.toGraph(s, tapeBlock));
+
+    // No unescaped `"` inside the edge label between the outer wrappers.
+    expect(mermaid).toContain('&quot;');
+    expect(mermaid).not.toMatch(/-- "[^"]*"[^"]*"[^"]*" -->/);
+    // Round-trips back to a parseable graph that preserves the symbol.
+    const reparsed = fromMermaid(mermaid);
+    const reparsedTransitions = reparsed.nodes[s.id].transitions;
+    expect(reparsedTransitions).toHaveLength(1);
+    expect(reparsedTransitions[0].command[0].symbol).toBe("'\"'");
+  });
+
+  test('state name with grammar-significant chars survives round-trip', () => {
+    // <, >, &, " inside a State.name. Encoded as named entities; decoded
+    // verbatim on the way back.
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const name = 'A<&">B';
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, name);
+
+    const reparsed = fromMermaid(toMermaid(State.toGraph(s, tapeBlock)));
+    expect(reparsed.nodes[s.id].name).toBe(name);
+  });
+
+  test('tag name with grammar-significant chars survives round-trip', () => {
+    // Tag content is escaped per-fragment so a tag containing `<br>` or
+    // `,` doesn't get confused with the structural tag separators (which
+    // would split the tag wrong on the way back) or with HTML tag
+    // boundaries in the rendered SVG.
+    //
+    // The round-trip also picks up the `class tag_<sanitized>` line from
+    // the emit — that adds a second copy of each tag in its sanitized
+    // form (`has"quote` → `has_quote`). That's a known artifact of the
+    // #186 tag-emit design, not part of #194; this test only asserts
+    // that the ORIGINAL forms come back intact.
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 's').tag('a<br>b', 'has,comma', 'has"quote');
+
+    const reparsed = fromMermaid(toMermaid(State.toGraph(s, tapeBlock)));
+    expect(reparsed.nodes[s.id].tags).toEqual(
+      expect.arrayContaining(['a<br>b', 'has,comma', 'has"quote']),
+    );
+  });
+
+  test('newlines and C0 controls in alphabet symbols encode as numeric entities', () => {
+    const alphabet = new Alphabet([' ', 'a', '\n', '']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['a'])]: {
+        command: [{symbol: '\n', movement: movements.right}],
+        nextState: haltState,
+      },
+    }, 's');
+
+    const mermaid = toMermaid(State.toGraph(s, tapeBlock));
+
+    // No raw newline inside the emitted line (other than the inter-line
+    // separators between statements).
+    const transitionLine = mermaid
+      .split('\n')
+      .find((l) => l.includes('-- "') && l.includes('--> '));
+    expect(transitionLine).toBeDefined();
+    expect(transitionLine).toContain('&#10;');
+
+    const reparsed = fromMermaid(mermaid);
+    expect(reparsed.nodes[s.id].transitions[0].command[0].symbol).toBe("'\n'");
+  });
+
+  test('bidi control in state name encodes as numeric entity', () => {
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const name = 'left‮right';
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, name);
+
+    const mermaid = toMermaid(State.toGraph(s, tapeBlock));
+    expect(mermaid).toContain('&#8238;');
+    expect(mermaid).not.toContain('‮');
+
+    const reparsed = fromMermaid(mermaid);
+    expect(reparsed.nodes[s.id].name).toBe(name);
+  });
+
+  test('printable Unicode passes through unescaped (alphabet readability)', () => {
+    // Cyrillic + CJK glyphs in the alphabet and state name. Alphabet
+    // rejects multi-code-unit symbols (`.length === 1` check) so emoji
+    // outside the BMP can't be tested at this layer — that's fine,
+    // surrogate-pair handling is covered by the encoder's regex range
+    // and the round-trip decode-path tests above.
+    const alphabet = new Alphabet([' ', 'я', '中']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['я'])]: {
+        command: [{symbol: '中', movement: movements.right}],
+        nextState: haltState,
+      },
+    }, 'имя');
+
+    const mermaid = toMermaid(State.toGraph(s, tapeBlock));
+    expect(mermaid).toContain('имя');
+    expect(mermaid).toContain('я');
+    expect(mermaid).toContain('中');
+    // No spurious numeric entities for printable Unicode.
+    expect(mermaid).not.toMatch(/&#\d+;/);
+  });
+
+  test('callable-subtree frame label escapes the bare name', () => {
+    // The frame label `callable subtree of NAME` interpolates the bare
+    // state's name. Quotes in the bare name would break the
+    // `subgraph w_N["..."]` declaration.
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const bare = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, 'b"are');
+    const wrapper = bare.withOverriddenHaltState(haltState);
+
+    const mermaid = toMermaid(State.toGraph(wrapper, tapeBlock));
+    expect(mermaid).toContain('callable subtree of b&quot;are');
+    // The subgraph declaration line itself has exactly two `"`s: the
+    // outer label wrappers. Any additional one would mean an unescaped
+    // user `"` slipped through.
+    const subgraphLine = mermaid
+      .split('\n')
+      .find((l) => l.trimStart().startsWith('subgraph w_'));
+    expect(subgraphLine).toBeDefined();
+    expect((subgraphLine!.match(/"/g) ?? []).length).toBe(2);
+  });
+
+  test('ambiguous `&amp;quot;` decodes once, not twice', () => {
+    // User content that looks like a doubly-encoded entity. Single-pass
+    // decode should give back the literal `&quot;` text, not `"`.
+    const alphabet = new Alphabet([' ', '0']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const name = '&quot;literal&quot;';
+    const s = new State({
+      [tapeBlock.symbol(['0'])]: {nextState: haltState},
+    }, name);
+
+    const reparsed = fromMermaid(toMermaid(State.toGraph(s, tapeBlock)));
+    expect(reparsed.nodes[s.id].name).toBe(name);
+  });
+});

--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -46,6 +46,81 @@ function frameSubgraphId(frameId: number): string {
   return `w_${frameId}`;
 }
 
+// User-controlled content (state names, tag names, alphabet symbols inside
+// edge labels) is interpolated into Mermaid label strings (`"..."` wrappers
+// on nodes, wrappers, subgraphs, and edges). Mermaid's grammar terminates
+// the string on a literal `"`, and labels render via HTML/foreignObject so
+// `<`, `>`, `&` get interpreted as markup. Statement terminators (`\n`,
+// `\r`), C0 controls (except `\t`), DEL, bidi controls, and lone UTF-16
+// surrogates are encoded as numeric entities so they can't confuse the
+// tokenizer or flip text direction silently (#194).
+//
+// Printable Unicode (Cyrillic, CJK, emoji, accented Latin, etc.) passes
+// through unchanged — a tape alphabet of Cyrillic or Brainfuck glyphs
+// stays readable in the emitted `.mmd`.
+//
+// Escape is applied at the leaf — to each user-supplied fragment BEFORE
+// it's composed into a label. Structural pieces this module emits (`<br>`
+// tag separator, ` ∪ ` bare-name join, `[`, `]`, `,`, `|`, `/`, ` → `,
+// the `callable subtree of `/`callable scope: ` prefixes) are NOT escaped;
+// only user-controlled content is. fromMermaid mirrors with
+// `unescapeMermaidLabel` on each extracted leaf AFTER structural parsing,
+// so a literal `<br>` inside a state name (encoded as `&lt;br&gt;`)
+// survives the tag-split and decodes back at the leaf.
+const MERMAID_LABEL_ESCAPE_RE = /[&"<>\n\r\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u202A-\u202E\u2066-\u2069\uD800-\uDFFF]/g;
+function escapeMermaidLabel(s: string): string {
+  return s.replace(MERMAID_LABEL_ESCAPE_RE, (ch) => {
+    switch (ch) {
+      case '&': return '&amp;';
+      case '"': return '&quot;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '\n': return '&#10;';
+      case '\r': return '&#13;';
+      default: return `&#${ch.charCodeAt(0)};`;
+    }
+  });
+}
+
+// Inverse of escapeMermaidLabel. Decodes the four named entities the
+// encoder emits (`&amp;`, `&quot;`, `&lt;`, `&gt;`) plus arbitrary
+// numeric entities (`&#NN;`, `&#xHH;`) — the latter to round-trip the
+// control / bidi / lone-surrogate cases from encode. Other named entities
+// pass through unchanged: fromMermaid is strict to the dialect toMermaid
+// emits, and a future-proof full HTML-entity decoder would muddle that.
+//
+// Replacement is single-pass: each `&...;` match is consumed once with
+// no re-scanning of the substitution, so nested-looking inputs like
+// `&amp;quot;` (literal `&quot;` as user text) decode to `&quot;` not `"`.
+const MERMAID_LABEL_UNESCAPE_RE = /&(?:(amp|quot|lt|gt)|#(\d+)|#x([0-9a-fA-F]+));/g;
+function unescapeMermaidLabel(s: string): string {
+  return s.replace(MERMAID_LABEL_UNESCAPE_RE, (match, named, dec, hex) => {
+    switch (named) {
+      case 'amp': return '&';
+      case 'quot': return '"';
+      case 'lt': return '<';
+      case 'gt': return '>';
+      default: {
+        // Code units up to U+FFFF decode via fromCharCode so lone
+        // surrogates we encoded by UTF-16 code unit round-trip exactly.
+        // Hand-edited supplementary code points (`&#x1F600;`) use
+        // fromCodePoint to produce the right surrogate pair — but only
+        // when we didn't emit them ourselves, since encode runs per code
+        // unit.
+        if (dec !== undefined) {
+          const n = Number.parseInt(dec, 10);
+          return n <= 0xFFFF ? String.fromCharCode(n) : String.fromCodePoint(n);
+        }
+        if (hex !== undefined) {
+          const n = Number.parseInt(hex, 16);
+          return n <= 0xFFFF ? String.fromCharCode(n) : String.fromCodePoint(n);
+        }
+        return match;
+      }
+    }
+  });
+}
+
 export function toMermaid(graph: Graph): string {
   const lines: string[] = [
     'flowchart TD',
@@ -89,9 +164,17 @@ export function toMermaid(graph: Graph): string {
   // Mermaid line-break that works across renderers without `classDef`-
   // pseudo-element hacks (#186).
   const labelOf = (node: GraphNode): string => {
-    if (node.tags.length === 0) return node.name;
-
-    return `${node.name}<br>${node.tags.join(', ')}`;
+    const name = escapeMermaidLabel(node.name);
+    if (node.tags.length === 0) return name;
+    // Per-tag escape that ALSO encodes `,` — tags are joined with `, ` and
+    // split on `,` in `splitLabelTags`, so a literal comma in user tag
+    // content would be mistaken for a separator on the way back. `,` isn't
+    // in the base escape set because it's structural in edge labels
+    // (between per-tape cells in `writes`/`moves`), where the encode pass
+    // happens after composition — different context, different escape.
+    const tagFragments = node.tags
+      .map((t) => escapeMermaidLabel(t).replace(/,/g, '&#44;'));
+    return `${name}<br>${tagFragments.join(', ')}`;
   };
 
   // 1. Emit top-level nodes (real halt, non-wrapper regulars outside any frame).
@@ -123,7 +206,7 @@ export function toMermaid(graph: Graph): string {
     const frameBareNames = frameBares
       .slice()
       .sort((a, b) => a.id - b.id)
-      .map((n) => n.name);
+      .map((n) => escapeMermaidLabel(n.name));
     const label = frameBareNames.length > 1
       ? `callable scope: ${frameBareNames.join(' ∪ ')}`
       : `callable subtree of ${frameBareNames[0] ?? frameId}`;
@@ -255,7 +338,12 @@ export function toMermaid(graph: Graph): string {
       const reads = alternatives.map((alt) => `[${alt}]`).join('|');
       const writes = `[${t.command.map((c) => c.symbol).join(',')}]`;
       const moves = `[${t.command.map((c) => c.movement).join(',')}]`;
-      const label = `${reads} → ${writes}/${moves}`;
+      // Escape the WHOLE composed label — structural separators ([, ], ,,
+      // |, /, ' → ') are all in our safe ASCII set and pass through
+      // unchanged; only embedded user alphabet symbols inside `'...'` get
+      // entity-encoded. fromMermaid unescapes the captured label as the
+      // first step before structural parsing.
+      const label = escapeMermaidLabel(`${reads} → ${writes}/${moves}`);
 
       lines.push(
         `  ${mermaidIdFor(node.id)} -- "${label}" --> ${mermaidIdFor(t.nextStateId)}`,
@@ -409,16 +497,25 @@ const classAssignTagRegex = /^class ([sc]\d+(?:,[sc]\d+)*) tag_([A-Za-z0-9_-]+)$
 // Labels without `<br>` have no tags. Tags are comma-joined; trimmed of
 // whitespace. The `<br>` is the single source of truth for tag-name parsing —
 // `class` lines are decorative-only and not consulted here.
+//
+// Mermaid-label entities (`&lt;`, `&quot;`, etc., #194) are decoded AFTER
+// structural splitting: the `<br>` separator and `,` tag delimiter survive
+// encode unchanged, and a user state name / tag containing a literal `<br>`
+// or `,` was encoded leaf-side so it can't be confused with the structural
+// form. Decode at the leaves recovers the original characters.
 function splitLabelTags(label: string): {name: string; tags: string[]} {
   const brIx = label.indexOf('<br>');
 
   if (brIx < 0) {
-    return {name: label, tags: []};
+    return {name: unescapeMermaidLabel(label), tags: []};
   }
 
-  const name = label.slice(0, brIx);
+  const name = unescapeMermaidLabel(label.slice(0, brIx));
   const tagsStr = label.slice(brIx + '<br>'.length);
-  const tags = tagsStr.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+  const tags = tagsStr
+    .split(',')
+    .map((t) => unescapeMermaidLabel(t.trim()))
+    .filter((t) => t.length > 0);
 
   return {name, tags};
 }
@@ -619,7 +716,12 @@ export function fromMermaid(text: string): Graph {
 
     if (tm) {
       const fromId = parseMermaidId(tm[1]);
-      const label = tm[2];
+      // Decode the WHOLE captured label up front (#194). Structural
+      // separators (`[`, `]`, `,`, `|`, `/`, ` → `) are all safe ASCII
+      // outside the escape set and pass through encode unchanged, so it's
+      // safe to decode before structural parsing; only embedded alphabet
+      // symbols inside `'...'` get reconstituted.
+      const label = unescapeMermaidLabel(tm[2]);
       const toId = parseMermaidId(tm[3]);
 
       const arrowIx = label.indexOf(' → ');


### PR DESCRIPTION
Closes #194 *(carry to release PR — v7-branch merges don't auto-close)*

## Summary

Mermaid's flowchart parser terminates a `"..."` label on the first literal `"`. If any user-controlled fragment that lands inside a label contained `"` (or `<`, `>`, newline, etc.), the parser tripped and `mermaid.render()` threw. Discovered in machines-demo while trying to render a Brainfuck-style UTM whose data alphabet included printable ASCII 32–126.

Fix: HTML-entity escape user-controlled fragments at the leaf, applied to every place a user-supplied string is interpolated into a `"..."` label:

- alphabet symbols inside edge-label commands (`'X'`-wrapped literals)
- state names → node labels and wrapper composite names
- tag names → `<br>`-suffix of node labels (with an extra `,` → `&#44;` layer so the `, ` tag separator round-trips)
- bare names → `callable subtree of NAME` / `callable scope: A ∪ B` frame labels

Escape set:

| Category | Chars | Encoding |
|---|---|---|
| Grammar / HTML essentials | `&` `"` `<` `>` | named (`&amp;` `&quot;` `&lt;` `&gt;`) |
| Statement terminators | `\n` `\r` | numeric (`&#10;` `&#13;`) |
| C0 controls minus `\t` | U+0000–U+0008, U+000B–U+000C, U+000E–U+001F | numeric |
| DEL | U+007F | numeric |
| Bidi controls | U+202A–E, U+2066–9 | numeric |
| Lone UTF-16 surrogates | U+D800–U+DFFF | numeric |

Printable Unicode (Cyrillic, CJK, accented Latin, etc.) is intentionally NOT escaped — the emitted `.mmd` stays readable for non-ASCII alphabets.

`fromMermaid` mirrors with a single-pass entity decoder. Decode happens at the leaf AFTER structural parsing, so a literal `<br>` in a state name (encoded as `&lt;br&gt;`) survives the `<br>`-tag-split and decodes verbatim at the leaf.

Structural pieces this module emits (`<br>` tag separator, ` ∪ `, `[`, `,`, `|`, `/`, ` → `, the `callable subtree of` / `callable scope:` prefixes) are not escaped — only user-supplied fragments are.

## What this does NOT fix

Two pre-existing limitations remain (called out elsewhere in the `fromMermaid` docstring and now extended one item):

- Alphabet symbols containing `,`, `/`, or `→` still don't round-trip cleanly — those are structural separators in the edge-label grammar and the parser can't disambiguate. Doc-only follow-up.
- `class tag_<sanitized>` lines (from #186) still push their sanitized tag-name into the parsed node's tag set, so a tag like `has"quote` round-trips as both `has"quote` AND `has_quote`. That's a #186 design artifact (tag emit uses lossy sanitization, parse can't invert), not part of #194 — left as-is, with a note in the new test.

## Test plan
- [x] `npm test` — 465 → 473 tests passing, 8 new under `Mermaid label escaping (#194)`:
  - alphabet symbol containing `"` (the original repro)
  - state name with `<&">` round-trips
  - tag name with `<br>`, `,`, `"` round-trips (arrayContaining — class-line dupe accepted as pre-existing)
  - newlines in alphabet symbols encode as `&#10;`
  - bidi control in state name encodes as `&#8238;` (RLO)
  - printable Cyrillic + CJK pass through unchanged
  - callable-subtree frame label escapes the bare name
  - `&amp;quot;` (literal `&quot;` as user text) decodes once, not twice
- [x] `npm run lint` clean
- [x] `npm run build` clean (pre-existing `Lock.js` / circular-dep warnings unchanged)