### PR TITLE
test: raise v7 coverage to clear PR #167's Coveralls failure

### DIFF
--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -1203,6 +1203,46 @@ describe('Mermaid label escaping (#194)', () => {
     expect((subgraphLine!.match(/"/g) ?? []).length).toBe(2);
   });
 
+  test('carriage return in alphabet symbol encodes as &#13;', () => {
+    // Sibling of the `\n` test above — pins the second statement-terminator
+    // branch in escapeMermaidLabel so coverage doesn't drift if someone
+    // adds another escape category and forgets the `\r` case.
+    const alphabet = new Alphabet([' ', 'a', '\r']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const s = new State({
+      [tapeBlock.symbol(['a'])]: {
+        command: [{symbol: '\r', movement: movements.right}],
+        nextState: haltState,
+      },
+    }, 's');
+
+    const mermaid = toMermaid(State.toGraph(s, tapeBlock));
+    expect(mermaid).toContain('&#13;');
+
+    const reparsed = fromMermaid(mermaid);
+    expect(reparsed.nodes[s.id].transitions[0].command[0].symbol).toBe("'\r'");
+  });
+
+  test('hex numeric entity `&#xHH;` decodes (hand-edited Mermaid support)', () => {
+    // `toMermaid` only emits decimal numeric entities (`&#NN;`), but
+    // `fromMermaid` accepts hex too for hand-edited `.mmd` files where a
+    // user might write `&#x22;` instead of `&quot;`. Pin the hex-decode
+    // branch in unescapeMermaidLabel by constructing a minimal Mermaid
+    // graph that uses a hex entity in a node name.
+    const mermaid = [
+      'flowchart TD',
+      '%% alphabets: [[" ","0"]]',
+      '  s0(((halt)))',
+      '  s1["a&#x22;b"]',
+      '  idle([idle])',
+      '  idle -. enter .-> s1',
+      '  s1 -- "[\'0\'] → [K]/[S]" --> s0',
+    ].join('\n');
+
+    const graph = fromMermaid(mermaid);
+    expect(graph.nodes[1].name).toBe('a"b');
+  });
+
   test('ambiguous `&amp;quot;` decodes once, not twice', () => {
     // User content that looks like a doubly-encoded entity. Single-pass
     // decode should give back the literal `&quot;` text, not `"`.

--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -115,6 +115,8 @@ function unescapeMermaidLabel(s: string): string {
           const n = Number.parseInt(hex, 16);
           return n <= 0xFFFF ? String.fromCharCode(n) : String.fromCodePoint(n);
         }
+        /* c8 ignore next 2 — defensive: the regex shape guarantees one of
+           named / dec / hex is always set, so this fallback is unreachable. */
         return match;
       }
     }

--- a/packages/machine/src/utilities/stateGraph.ts
+++ b/packages/machine/src/utilities/stateGraph.ts
@@ -187,6 +187,9 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
       // `nodes[id]` is always populated for `id` that the BFS reached, so
       // a defensive `!node` check would be dead. `isHalt` / `isWrapper`
       // are real boundaries — both stop reach-set expansion.
+      /* c8 ignore next 3 — defensive: the push site below already filters
+         halt/wrapper targets, and the initial push is always a bare, so
+         this branch is unreachable in practice. */
       if (node.isHalt || node.isWrapper) {
         continue;
       }


### PR DESCRIPTION
[PR #167](https://github.com/mellonis/turing-machine-js/pull/167)'s `coverage/coveralls` status reports `Coverage decreased (-0.5%) to 97.805%` against master at 98.291%. This PR closes the gap by exercising the two genuinely-testable v7-new branches and annotating two unreachable branches.

## Before / after

| Metric | Before (v7 tip) | After |
|---|---|---|
| Statements | 98.84% | **99.33%** |
| Branches | 95.72% | **96.49%** |
| Functions | 100% | 100% |
| Lines | 98.95% | **99.47%** |

All four climb above master (98.291% per the most recent push) and above the 97/90/95/97 floors.

## Changes

1. **`\r` escape test** (`graph.spec.ts`). Pins the carriage-return case in `escapeMermaidLabel`. The existing `\n` test only covered one of the two statement-terminator cases.
2. **Hex numeric entity decode test** (`graph.spec.ts`). `toMermaid` only emits decimal entities (`&#NN;`), but `fromMermaid` accepts hex (`&#xHH;`) for hand-edited `.mmd` files. Exercised by a constructed-Mermaid-input test rather than a round-trip (since we never EMIT hex).
3. **`c8 ignore` on two unreachable branches**:
   - `graphFormats.ts` `return match;` fallback in `unescapeMermaidLabel`'s switch — the regex guarantees one of `named` / `dec` / `hex` is always set; the default is dead.
   - `stateGraph.ts` `if (node.isHalt || node.isWrapper) continue;` in `computeReach` — the push site below already filters halt/wrapper targets, and the initial push is always a bare. (Same branch was uncovered on master pre-#180, where it lived in State.ts; not a v7-introduced gap.)

## Test plan
- [x] `npm test` — 488 → 490 passing.
- [x] `npm run lint` clean.
- [x] `npm run test:coverage` — shows the metrics above.