### PR TITLE
fix(coverage): cover patternKinds defensive paths; drop dead typeof check

### DIFF
--- a/packages/machine/src/classes/TapeBlock.spec.ts
+++ b/packages/machine/src/classes/TapeBlock.spec.ts
@@ -418,3 +418,51 @@ describe('TapeBlock.clone', () => {
     expect(clonedSymbol).toBe(original);
   });
 });
+
+describe('TapeBlock.patternKinds (#205)', () => {
+  // Public method (used internally by TuringMachine.runStepByStep to populate
+  // `MachineState.matchedTransition.matchKinds`). Engine-internal callers
+  // always pass a registered symbol whose patternList matches the current
+  // head; the two defensive fallbacks below exist so external callers
+  // (debugger tools, custom dispatchers) get safe "all literal" results
+  // for unrecognized symbols / no-match cases instead of crashing.
+
+  test('ifOtherSymbol returns all `wildcard` (length = tape count)', () => {
+    const a = new Alphabet([' ', 'a', 'b']);
+    const tb = TapeBlock.fromAlphabets([a, a]);
+    expect(tb.patternKinds(ifOtherSymbol)).toEqual(['wildcard', 'wildcard']);
+  });
+
+  test('registered specific-symbol pattern returns per-position kinds', () => {
+    const a = new Alphabet([' ', 'a', 'b']);
+    const tape1 = new Tape({alphabet: a, symbols: ['a']});
+    const tape2 = new Tape({alphabet: a, symbols: ['b']});
+    const tb = TapeBlock.fromTapes([tape1, tape2]);
+    // Mixed-kind pattern: position 0 wildcard, position 1 literal.
+    const sym = tb.symbol([ifOtherSymbol, 'b']);
+    expect(tb.patternKinds(sym)).toEqual(['wildcard', 'literal']);
+  });
+
+  test('unregistered symbol falls back to all `literal`', () => {
+    // Defensive: an alien symbol that was never interned via tb.symbol(...)
+    // should not crash patternKinds — engine-internal callers never pass
+    // such a symbol, but external API callers might.
+    const a = new Alphabet([' ', 'a']);
+    const tb = TapeBlock.fromAlphabets([a, a]);
+    const alien = Symbol('alien');
+    expect(tb.patternKinds(alien)).toEqual(['literal', 'literal']);
+  });
+
+  test('registered symbol with no matching pattern falls back to all `literal`', () => {
+    // Defensive: pass a registered symbol whose pattern doesn't match the
+    // supplied currentSymbols. Pattern is `['a', 'a']`; head is `['b', 'b']`.
+    // Internally unreachable (engine fires the pattern only when head matches),
+    // but exposed via the public method's `currentSymbols` parameter.
+    const a = new Alphabet([' ', 'a', 'b']);
+    const tape1 = new Tape({alphabet: a, symbols: ['a']});
+    const tape2 = new Tape({alphabet: a, symbols: ['a']});
+    const tb = TapeBlock.fromTapes([tape1, tape2]);
+    const sym = tb.symbol(['a', 'a']);
+    expect(tb.patternKinds(sym, ['b', 'b'])).toEqual(['literal', 'literal']);
+  });
+});

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -225,10 +225,13 @@ export default class TuringMachine {
           // happen. Now the pause anchors post-step (after the iter's own
           // after-pause if armed), so consumers see the just-fired halt-
           // bound transition + diagram cursor still on the triggering state.
-          const debug = state.debug;
-          const stateDebugConfig = typeof debug === 'boolean' ? null : debug;
-          const beforeMatch = matchFilter(stateDebugConfig?.before, symbol);
-          const afterMatch = matchFilter(stateDebugConfig?.after, symbol)
+          //
+          // `state` here is always non-halt (halt is terminal — the run
+          // loop never iterates with state === haltState), so `state.debug`
+          // is always `DebugConfig` at runtime. The public getter's return
+          // type matches that.
+          const beforeMatch = matchFilter(state.debug?.before, symbol);
+          const afterMatch = matchFilter(state.debug?.after, symbol)
             || (nextState === haltState && haltState.debug);
 
           const nextStateForYield = nextState.isHalt && stack.length


### PR DESCRIPTION
Two coverage gaps surfaced by Coveralls on [PR #167](https://github.com/mellonis/turing-machine-js/pull/167) (the v7 → master release tracker), both introduced incidentally by #205 + #207.

## What's uncovered (before this PR)

| File | Lines | Why uncovered |
|---|---|---|
| `TapeBlock.patternKinds` (#205) | 192–194, 203–205 | Two `[…literal]` defensive fallbacks for \`patternList === undefined\` (alien symbol) and \`winning === undefined\` (no pattern matches head). Engine-internal callers always pass a registered symbol whose pattern matches, but these are public-API entry points reachable from external callers (debugger tools, custom dispatchers). |
| `TuringMachine.runStepByStep` (#207) | 229 (branch) | The \`typeof debug === 'boolean'\` check was added defensively while #207 widened \`State.debug\`'s return-type contract. Unreachable at runtime — the run loop's iter state is always non-halt (halt is terminal, doesn't iterate), so \`state.debug\` is always \`DebugConfig\`. The public getter's return type already matches that. |

## Fix shape

- **`patternKinds`** — added 4 focused tests in `TapeBlock.spec.ts` covering all paths (ifOtherSymbol, registered specific pattern, alien symbol fallback, no-match-on-head fallback). Method moves from 95% statement coverage to 100%.
- **`runStepByStep`** — dropped the dead typeof check. \`const beforeMatch = matchFilter(state.debug?.before, symbol);\` works because the runtime guarantees \`state.debug\` is \`DebugConfig\` in the loop.

## Coverage delta

| Metric | Before | After |
|---|---|---|
| Statements | 99.03 | 99.35 |
| Branches | 96.13 | 96.58 |
| Functions | 99.05 | 100 |
| Lines | 99.31 | 99.48 |

Tests: 501 → 505. Lint + typecheck clean. Remaining uncovered lines are all pre-existing defensive throws / WeakRef-GC-dependent paths unrelated to this v7 trajectory.

## Why now

PR #167 is BLOCKED on Coveralls. This unblocks the cross-branch merge check so when v7 is ready to ship stable (after #102 lands), the master merge isn't gated on already-fixed regressions. Lands ahead of the upcoming `chore/release-7.0.0-alpha.5` PR so the alpha.5 release picks it up automatically.