### PR TITLE
chore(release): 7.0.0-alpha.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10656,40 +10656,40 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "7.0.0-alpha.4",
+      "version": "7.0.0-alpha.5",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       }
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "7.0.0-alpha.4",
+      "version": "7.0.0-alpha.5",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       }
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "7.0.0-alpha.4",
+      "version": "7.0.0-alpha.5",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       }
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "7.0.0-alpha.4",
+      "version": "7.0.0-alpha.5",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.5] - 2026-05-25
+
+Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.5 — adds per-iter `MachineState.matchedTransition` + renames `GraphTransition.id` separator `-` → `.` ([#205](https://github.com/mellonis/turing-machine-js/issues/205)), collapses `haltState.debug` to a `boolean` with halt-imminent pause on the AFTER side of the halt-triggering iter ([#207](https://github.com/mellonis/turing-machine-js/issues/207)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.4` → `^7.0.0-alpha.5`.
+
 ## [7.0.0-alpha.4] - 2026-05-23
 
 Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.4 — adds `State.collectStates` ([#195](https://github.com/mellonis/turing-machine-js/issues/195)), extracts graph serialization into `utilities/stateGraph.ts` ([#180](https://github.com/mellonis/turing-machine-js/issues/180)), fixes `toMermaid` label escape ([#194](https://github.com/mellonis/turing-machine-js/issues/194)) and `runStepByStep` halt-stack scope ([#196](https://github.com/mellonis/turing-machine-js/issues/196)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.3` → `^7.0.0-alpha.4`.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "builder"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.4"
+    "@turing-machine-js/machine": "^7.0.0-alpha.5"
   },
   "scripts": {
     "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/builder",

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.5] - 2026-05-25
+
+Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.5 — adds per-iter `MachineState.matchedTransition` + renames `GraphTransition.id` separator `-` → `.` ([#205](https://github.com/mellonis/turing-machine-js/issues/205)), collapses `haltState.debug` to a `boolean` with halt-imminent pause on the AFTER side of the halt-triggering iter ([#207](https://github.com/mellonis/turing-machine-js/issues/207)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.4` → `^7.0.0-alpha.5`.
+
 ## [7.0.0-alpha.4] - 2026-05-23
 
 Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.4 — adds `State.collectStates` ([#195](https://github.com/mellonis/turing-machine-js/issues/195)), extracts graph serialization into `utilities/stateGraph.ts` ([#180](https://github.com/mellonis/turing-machine-js/issues/180)), fixes `toMermaid` label escape ([#194](https://github.com/mellonis/turing-machine-js/issues/194)) and `runStepByStep` halt-stack scope ([#196](https://github.com/mellonis/turing-machine-js/issues/196)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.3` → `^7.0.0-alpha.4`.

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,7 +28,7 @@
     "teaching"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.4"
+    "@turing-machine-js/machine": "^7.0.0-alpha.5"
   },
   "scripts": {
     "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers-bare",

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.5] - 2026-05-25
+
+Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.5 — adds per-iter `MachineState.matchedTransition` + renames `GraphTransition.id` separator `-` → `.` ([#205](https://github.com/mellonis/turing-machine-js/issues/205)), collapses `haltState.debug` to a `boolean` with halt-imminent pause on the AFTER side of the halt-triggering iter ([#207](https://github.com/mellonis/turing-machine-js/issues/207)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.4` → `^7.0.0-alpha.5`.
+
 ## [7.0.0-alpha.4] - 2026-05-23
 
 Released in lockstep with `@turing-machine-js/machine` 7.0.0-alpha.4 — adds `State.collectStates` ([#195](https://github.com/mellonis/turing-machine-js/issues/195)), extracts graph serialization into `utilities/stateGraph.ts` ([#180](https://github.com/mellonis/turing-machine-js/issues/180)), fixes `toMermaid` label escape ([#194](https://github.com/mellonis/turing-machine-js/issues/194)) and `runStepByStep` halt-stack scope ([#196](https://github.com/mellonis/turing-machine-js/issues/196)). No source or behavior changes in this package. Peer dep `@turing-machine-js/machine` widened `^7.0.0-alpha.3` → `^7.0.0-alpha.4`.

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"
@@ -27,7 +27,7 @@
     "numbers"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.4"
+    "@turing-machine-js/machine": "^7.0.0-alpha.5"
   },
   "scripts": {
     "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/library-binary-numbers",

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.5] - 2026-05-25
+
+Fifth v7 pre-release. Adds per-iter `matchedTransition` to `MachineState` so consumers can resolve the firing transition by graph id without re-deriving from `(source, nextState)` ambiguous pairs ([#205](https://github.com/mellonis/turing-machine-js/issues/205)), collapses `haltState.debug` to a `boolean` and moves the halt-imminent pause to the AFTER side of the halt-triggering iter so the wording + diagram cursor agree with the just-fired transition ([#207](https://github.com/mellonis/turing-machine-js/issues/207)), and renames the `GraphTransition.id` separator from `-` to `.` for parser-friendly splitting. Published under the `next` dist-tag: `npm install @turing-machine-js/machine@next`.
+
+**Pre-release — the API surface may still shift before stable v7.0.0.** Pin to a specific alpha for reproducibility: `@turing-machine-js/machine@7.0.0-alpha.5`.
+
+### Added
+
+- **`MachineState.matchedTransition`** ([#205](https://github.com/mellonis/turing-machine-js/issues/205)) — every yielded `MachineState` from `run` / `runStepByStep` now carries `{ id: string, matchKinds: ('wildcard' | 'literal')[] }`. `id` is `${stateId}.${transitionIx}` and resolves directly in `toGraph`'s output via `graph.nodes[stateId].transitions.find(t => t.id === ...)`. For wrapper-entry iters, `id` references the BARE's transition (wrappers delegate via `bareState`). `matchKinds` is per-tape, length = tape count; `'wildcard'` iff the winning alternative held `ifOtherSymbol` at that position. Eliminates `(source, nextState)` resolution ambiguity for tools doing exact-edge highlighting, per-transition coverage maps, or wildcard-aware log formatting.
+
+- **`State.getMatchedTransition(symbol)`** ([#205](https://github.com/mellonis/turing-machine-js/issues/205)) — public method returning `{ nextState, matchedSymbol, ix }` for the symbol's transition. Same lookup `getNextState` does, plus the index — exposes the K used by `MachineState.matchedTransition.id` so callers needing both don't pay for the lookup twice.
+
+- **`TapeBlock.patternKinds(symbol, currentSymbols?)`** ([#205](https://github.com/mellonis/turing-machine-js/issues/205)) — public method returning per-tape `'wildcard' | 'literal'` for the matched alternative's selector. The engine uses it internally to populate `matchedTransition.matchKinds`; exposed for consumers wiring custom dispatch.
+
+- **`HaltState` typed alias** ([#207](https://github.com/mellonis/turing-machine-js/issues/207)) — the exported `haltState` singleton now carries a narrower TypeScript type (`State & { debug: boolean; ... }`) so `haltState.debug = true` is type-safe at the call site. Generic `State` references still see `DebugConfig` — runtime branches on `this.isHalt`.
+
+### Changed
+
+- **`GraphTransition.id` separator: `-` → `.`** ([#205](https://github.com/mellonis/turing-machine-js/issues/205)). Was `${stateId}-${patternIx}`, now `${stateId}.${patternIx}`. Aligns with `matchedTransition.id` and makes the id splittable without colliding with user-defined state names that may contain `-`. **Breaking** for any consumer parsing the old separator; alpha-channel only.
+
+- **`haltState.debug` is `boolean`** ([#207](https://github.com/mellonis/turing-machine-js/issues/207)). Was `DebugConfig` with per-side `{ before?, after? }` filters; under v7 it's a single `boolean` flag. `haltState.debug = true` enables; `false` / `null` disables. **Object-shaped writes throw** (`{ before: true }`, `{ after: true }`, etc.). The pause fires on the AFTER side of the iter whose transition leads to halt — `m.state` is the triggering state (not haltState), `m.debugBreak.after === true`. Diagram + log narratives read naturally: the halt-bound transition has fired when the pause lands, and halt is the next thing. **Breaking** — pre-alpha.5 consumers using `haltState.debug = { before: true }` must switch to `haltState.debug = true`.
+
+  ⚠️ **Chained-form `haltState.debug.before = true` silently no-ops in non-strict mode.** The getter returns the boolean; assigning `.before` to a primitive is a JS no-op outside strict mode (`TypeError` in strict). The engine setter never sees the write. Use the whole-object form (`haltState.debug = true` / `= false` / `= null`).
+
+- **`State` internal: single `#getEntry` helper for `getCommand` / `getNextState` / `getMatchedTransition`** ([#206](https://github.com/mellonis/turing-machine-js/pull/206)). Internal refactor — no public API change. All three accessors now share one `.get()` lookup + unified throw message (`"No transition for symbol at state named ..."` — was per-method messages).
+
+- **Internal: dead-code typeof check on `state.debug` in `runStepByStep` removed; `patternKinds` defensive paths now have dedicated test coverage** ([#210](https://github.com/mellonis/turing-machine-js/pull/210)). Engine-internal cleanup that bumps overall coverage to 99.35% statements / 96.58% branches / 100% functions / 99.48% lines.
+
+### Docs
+
+- ⚠️ **README + CLAUDE.md** ([#209](https://github.com/mellonis/turing-machine-js/pull/209)) — warn that chained-form `haltState.debug.before = true` silently no-ops in non-strict mode (`new Function(...)`, `<script>` without `"use strict"`). Engine can't intercept (the write happens on a primitive after the getter returned); doc steers users to the whole-object form.
+
 ## [7.0.0-alpha.4] - 2026-05-23
 
 Fourth v7 pre-release. Adds an id-keyed lookup helper for the State graph ([#195](https://github.com/mellonis/turing-machine-js/issues/195)), fixes two upstream issues surfaced while wiring the new helper into downstream tooling — a `toMermaid` label-grammar bug ([#194](https://github.com/mellonis/turing-machine-js/issues/194)) and a halt-stack lifetime bug in `runStepByStep` ([#196](https://github.com/mellonis/turing-machine-js/issues/196)) — and extracts graph serialization into its own module without API change ([#180](https://github.com/mellonis/turing-machine-js/issues/180)). Published under the `next` dist-tag: `npm install @turing-machine-js/machine@next`.

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
Fifth v7 pre-release. Lockstep bump across all 4 packages.

## What's in alpha.5

- **[#205](https://github.com/mellonis/turing-machine-js/issues/205)** — \`MachineState.matchedTransition\` ([PR #206](https://github.com/mellonis/turing-machine-js/pull/206)). Every yielded MachineState carries \`{ id, matchKinds }\` so consumers resolve the firing transition by graph id without re-deriving from \`(source, nextState)\` ambiguous pairs. Also renames \`GraphTransition.id\` separator from \`-\` to \`.\` for parser-friendly splitting.
- **[#207](https://github.com/mellonis/turing-machine-js/issues/207)** — \`haltState.debug\` collapsed to \`boolean\` ([PR #208](https://github.com/mellonis/turing-machine-js/pull/208)). The per-side \`{ before, after }\` shape never modeled anything for the halt singleton; under v7 it's a single flag. Halt-imminent pause moved to the AFTER side of the halt-triggering iter — diagram cursor + log wording agree with the just-fired transition.
- **[#209](https://github.com/mellonis/turing-machine-js/pull/209)** — docs: chained-form \`haltState.debug.before = true\` silently no-ops in non-strict mode.
- **[#210](https://github.com/mellonis/turing-machine-js/pull/210)** — coverage cleanup: \`patternKinds\` defensive paths + drop dead typeof check.

## Breaking inside the alpha line

- \`GraphTransition.id\` separator change (\`-\` → \`.\`). Any consumer parsing the old separator must update.
- \`haltState.debug\` is \`boolean\`. Pre-alpha.5 callers using \`haltState.debug = { before: true }\` must switch to \`haltState.debug = true\` (object writes throw).

## Quality

- 505 tests pass, lint + typecheck clean
- Coverage 99.35% statements / 96.58% branches / 100% functions / 99.48% lines (above 97/90/95/97 floors)
- \`npm publish --dry-run\` clean (verified by lerna's prepublishOnly auto-build hook)

## Release flow (post-merge)

1. \`npx lerna publish from-package --yes\` from repo root
2. \`gh release create v7.0.0-alpha.5 --target master --title v7.0.0-alpha.5 --notes-file <path>\` — wait, this targets \`master\` per the script, but alpha tags are usually on \`v7\`. Verify the script's target arg or cut from \`v7\`. (Alpha releases are pre-releases — pass \`--prerelease\` if cutting via gh.)