### PR TITLE
docs: trim historical bloat + fix stale GraphTransition.id format

### DIFF
--- a/packages/builder/src/builder.spec.ts
+++ b/packages/builder/src/builder.spec.ts
@@ -124,7 +124,7 @@ describe('buildMachine — debug config (#101)', () => {
 
   test('debug.after symbol-list fires on the halting iter\'s own yield', async () => {
     // 'B' triggers the halting transition; the after-fire for B reaches
-    // onPause on B's own yield (post-#119 dispatch model).
+    // onPause on B's own yield.
     const [machine, init] = buildLoopMachine({Q0: {after: ['B']}});
     machine.tapeBlock.replaceTape(new Tape({
       alphabet: machine.tapeBlock.alphabets[0],

--- a/packages/library-binary-numbers/src/graphs.spec.ts
+++ b/packages/library-binary-numbers/src/graphs.spec.ts
@@ -2,27 +2,20 @@ import {State, fromMermaid, summarizeGraph, toMermaid} from '@turing-machine-js/
 import binaryNumbers from './index';
 
 // Per-state counts pinned from the source comments above each declaration in
-// `index.ts`. These are runtime state counts (per `summarize().stateCount`),
-// which exclude the `isHaltMarker` visualization sentinels v7 synthesizes
-// inside each `halt frame` subgraph. The states.md per-algorithm header uses
-// the same definition, so all three sources agree by construction.
-// v7 callable-subtree counts (#174). Under the new model, each
-// `withOverriddenHaltState` emits a SEPARATE wrapper node (in addition to the
-// bare's node) — so wrapper-bearing algorithms gain 1 node per wrapper, minus
-// any savings from de-duplicating shared bares (no per-context duplication
-// anymore). `goToNumber`, `goToNextNumber`, `goToPreviousNumber`,
-// `goToNumbersStart`, `plusOne` have no wrappers and are unchanged.
+// `index.ts`. Runtime state counts (per `summarize().stateCount`) — excludes
+// `isHaltMarker` visualization sentinels synthesized inside `halt frame`
+// subgraphs. Matches the states.md per-algorithm header by construction.
 const expectedNodeCount: Record<keyof typeof binaryNumbers['states'], number> = {
   goToNumber: 2,
   goToNextNumber: 3,
   goToPreviousNumber: 3,
   goToNumbersStart: 2,
-  deleteNumber: 5, // alpha.1: 4 (one wohs); +1 wrapper node
-  invertNumber: 5, // alpha.1: 4 (one wohs); +1 wrapper node
-  normalizeNumber: 7, // alpha.1: 6 (one wohs); +1 wrapper node
+  deleteNumber: 5,
+  invertNumber: 5,
+  normalizeNumber: 7,
   plusOne: 5,
-  minusOne: 18, // alpha.1: 15; +3 for wrapper-vs-bare separation minus shared-bare dedup
-  minusOneFast: 10, // alpha.1: 8; +2 wrapper nodes
+  minusOne: 18,
+  minusOneFast: 10,
 };
 
 const stateNames = Object.keys(expectedNodeCount) as Array<keyof typeof expectedNodeCount>;

--- a/packages/machine/src/classes/Reference.spec.ts
+++ b/packages/machine/src/classes/Reference.spec.ts
@@ -48,10 +48,8 @@ describe('Reference', () => {
     });
 
     test('second bind() returns the EXISTING binding, not the passed argument', () => {
-      // This was the subtle case the previous "Reference bind return the passed
-      // parameter" test under-asserted. The first bind happens to satisfy that
-      // claim, but it's not the contract — the contract is "return the current
-      // binding."
+      // Contract: bind() returns the current binding (set by first bind), not
+      // whatever is passed to subsequent calls.
       const reference = new Reference();
       const first = new State();
       const second = new State();

--- a/packages/machine/src/classes/State.spec.ts
+++ b/packages/machine/src/classes/State.spec.ts
@@ -105,10 +105,7 @@ describe('State constructor — invalid inputs', () => {
 
 describe('State.getCommand / .getNextState / .getMatchedTransition — error paths', () => {
   // Default-constructed State has an empty symbolToDataMap; any lookup throws.
-  // #206 unified the message across all three methods: the prior per-method
-  // wording ("No command for…" / "No nextState for…") conveyed the same root
-  // cause ("no transition for this symbol") and the public methods now share
-  // a single `#getEntry` helper.
+  // All three accessors share `#getEntry` and so share the unified message.
 
   test('getCommand on an unmapped symbol throws "No transition for symbol at state named …"', () => {
     expect(() => new State().getCommand(ifOtherSymbol))
@@ -140,8 +137,7 @@ describe('State.getSymbol — head resolution', () => {
 
 describe('State.withOverriddenHaltState', () => {
   // The wrapper shares the original's symbolToDataMap and debugRef but adds
-  // an overriddenHaltState. Audit-flagged: the previous test only checked the
-  // name pattern; these tests pin the actual wrapping contract.
+  // an overriddenHaltState. These tests pin the wrapping contract.
 
   test('wrapper exposes the override target', () => {
     const original = new State({[ifOtherSymbol]: {nextState: haltState}});

--- a/packages/machine/src/classes/State.ts
+++ b/packages/machine/src/classes/State.ts
@@ -8,10 +8,9 @@ import {
   decodeMovement,
   decodeWriteSymbol,
 } from '../utilities/graph';
-// Delegate targets for `State.toGraph` / `State.fromGraph` (#180). The
-// import cycle with stateGraph.ts is resolved by ESM live bindings — see
-// the bottom-of-file note in that module. Aliased so the delegating
-// static methods can keep their canonical names without clashing.
+// Aliased so the delegating static methods can keep their canonical names
+// without clashing. The import cycle with stateGraph.ts is resolved by
+// ESM live bindings — see the bottom-of-file note in that module.
 import {
   type StateMap,
   collectStates as collectStatesImpl,
@@ -117,8 +116,8 @@ export default class State {
 
   // For wrapper states (produced by `withOverriddenHaltState`), points at the
   // State whose transition map was wrapped. `null` on bare/atomic states.
-  // Used by `toGraph` to collapse the wrapper-and-its-bare pair into a single
-  // "wrapped bare" graph node — see the v7 emit redesign for #138.
+  // `toGraph` reads this to render wrapper and bare as separate nodes linked
+  // by a `==> call` arrow.
   #bareState: State | null = null;
 
   #symbolToDataMap = new Map<symbol, { command: Command, nextState: State | Reference }>();
@@ -347,9 +346,8 @@ export default class State {
   }
 
   /** @internal — invoked by DebugConfig setters via module-private symbol.
-   *  Per #207, haltState no longer flows through DebugConfig (its `debug`
-   *  setter rejects object writes before construction), so the validator
-   *  only sees non-halt states here. */
+   *  haltState's `debug` setter rejects object writes before reaching
+   *  DebugConfig, so this validator only sees non-halt states. */
   [validateDebugFilter](
     fieldName: 'before' | 'after',
     filter: readonly symbol[] | true | undefined,
@@ -384,9 +382,7 @@ export default class State {
   // Single lookup + throw site shared by `getCommand`, `getNextState`, and
   // `getMatchedTransition`. Returns the symbol's entry `{command, nextState}`
   // (one map-get, no `.has()` pre-check); throws a unified message when no
-  // entry exists. Before #206, each public method did its own `.has() + .get()!`
-  // double-lookup with a slightly different error string — same root cause
-  // ("no transition for this symbol"), so the message is unified.
+  // entry exists.
   #getEntry(symbol: symbol) {
     const entry = this.#symbolToDataMap.get(symbol);
 

--- a/packages/machine/src/classes/Tape.spec.ts
+++ b/packages/machine/src/classes/Tape.spec.ts
@@ -10,7 +10,6 @@ describe('Tape constructor', () => {
   });
 
   test('honors the position parameter', () => {
-    // Pinned position (was Math.random — non-deterministic).
     const alphabet = new Alphabet(['0', '1']);
     const tape = new Tape({alphabet, position: 42});
 

--- a/packages/machine/src/classes/TuringMachine.debug.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.debug.spec.ts
@@ -110,9 +110,7 @@ describe('TuringMachine — debug.before filter (loop yields)', () => {
 });
 
 describe('TuringMachine — debug.after filter (loop yields)', () => {
-  // v6.0.0 (#119): both `before` and `after` refer to THIS iter, dispatched
-  // on the same yield. Previously `after` was on the NEXT yield with a
-  // substituted source-state payload — see #109/#119 for the rationale.
+  // Both `before` and `after` refer to THIS iter, dispatched on the same yield.
 
   test('debug.after = true tags every yield with debugBreak.after', async () => {
     const {machine, state} = buildMachine();
@@ -181,9 +179,9 @@ describe('TuringMachine — haltState.debug (boolean, #207)', () => {
     }
     const last = steps[VISIT_COUNT - 1];
     expect(last.nextState).toBe(haltState);
-    // #207 timing: fires on AFTER side (post-iter, before halt processing) —
-    // not BEFORE as the v6 API did. `m.state` is the TRIGGERING state (the
-    // one whose transition leads to halt), not haltState itself.
+    // #207 spec: fires on AFTER side (post-iter, before halt processing).
+    // `m.state` is the TRIGGERING state (whose transition leads to halt),
+    // not haltState itself.
     expect(last.state).toBe(state);
     expect(last.debugBreak).toEqual({after: true});
   });
@@ -315,9 +313,8 @@ describe('TuringMachine — run() with onPause', () => {
     });
 
     expect(seen).toHaveLength(VISIT_COUNT);
-    // v6.0.0: the after-call's `m.state` is the iter that armed the after
-    // (no substitution dance — `before` and `after` for the SAME iter both
-    // fire on that iter's own yield).
+    // The after-call's `m.state` is the iter that armed the after; `before`
+    // and `after` for the SAME iter both fire on that iter's own yield.
     for (const entry of seen) {
       expect(entry.state).toBe(state);
       expect(entry.debugBreak).toEqual({after: true});
@@ -337,9 +334,8 @@ describe('TuringMachine — run() with onPause', () => {
       },
     });
 
-    // v6.0.0 per-iter lifecycle: before → step → after. Every yield (including
-    // the first) dispatches both hooks in this order.
-    // For VISIT_COUNT visits, expect: [before, after, before, after, …]
+    // Per-iter lifecycle: before → step → after. Every yield dispatches both
+    // hooks in this order. For VISIT_COUNT visits: [before, after, before, …]
     expect(calls).toHaveLength(VISIT_COUNT * 2);
     for (let i = 0; i < calls.length; i++) {
       expect(calls[i]).toBe(i % 2 === 0 ? 'before' : 'after');
@@ -389,10 +385,8 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
   afterEach(() => { haltState.debug = null; });
 
   test('halting iter still fires its after (#108 part 1)', async () => {
-    // debug.after = true matches every visit. v6.0.0 (#119) dispatches the
-    // halting iter's after directly on its own yield, so all VISIT_COUNT
-    // visits fire (previously only VISIT_COUNT - 1 because the halting iter's
-    // after had no anchor yield).
+    // debug.after = true matches every visit. The halting iter's after
+    // dispatches on its own yield, so all VISIT_COUNT visits fire.
     const {machine, state} = buildMachine();
     state.debug = {after: true};
     const after: MachineState[] = [];
@@ -418,7 +412,6 @@ describe('TuringMachine — halt semantics for after-fire (#108)', () => {
   });
 
   test('haltState.debug = {before: true} throws — boolean-only API (#207)', () => {
-    // The v6 API; under #207 this throws so callers migrate to `= true`.
     expect(() => {
       // @ts-expect-error — see comment above.
       haltState.debug = {before: true};

--- a/packages/machine/src/classes/TuringMachine.spec.ts
+++ b/packages/machine/src/classes/TuringMachine.spec.ts
@@ -320,14 +320,10 @@ describe('TuringMachine constructor', () => {
   });
 });
 
-// Regression tests for #196 — the halt-stack used to be an instance field on
-// TuringMachine that wasn't reset between `runStepByStep` calls, so a caller
-// that peeked at iter 1 via the generator (then disposed it with
-// `generator.return()`) would leave the wrapper's override on the stack;
-// the next `run()` would push it a second time and produce one extra
-// iteration on its way out of the call. Builds a wrapper whose bare halts
-// on blank and whose override also halts immediately — the minimal shape
-// that surfaces the bug.
+// Regression for #196: halt-stack must be run-scoped, not machine-scoped, so
+// a peeked-then-disposed generator doesn't leak a stack entry into the next
+// run. Builds a wrapper whose bare halts on blank and whose override also
+// halts immediately — the minimal shape that surfaces the bug.
 describe('halt-stack reset between calls (regression for #196)', () => {
   // Helper: build a fresh scenario per call so each subtest has independent
   // State/Tape/TapeBlock instances (the engine's symbol patterns are
@@ -360,8 +356,7 @@ describe('halt-stack reset between calls (regression for #196)', () => {
   test('runStepByStep peek + return + run produces no extra iterations', async () => {
     const {machine, initialState, tape} = buildWrapperOverWalkToBlank();
 
-    // Caller peeks at iter 1 then disposes the generator without draining —
-    // pre-#196 this left the override on `#stack`.
+    // Caller peeks at iter 1 then disposes the generator without draining.
     const gen = machine.runStepByStep({initialState});
     gen.next();
     gen.return(undefined);
@@ -413,8 +408,8 @@ describe('halt-stack reset between calls (regression for #196)', () => {
     const tapeBlock = TapeBlock.fromTapes([tape]);
     const machine = new TuringMachine({tapeBlock});
     // A wrapper around a single-iter halt-on-anything bare. Each run pushes
-    // the override; if the pre-#196 leak existed, the second run would see
-    // a stale override and one extra iter.
+    // its own override; a leaking machine-scoped stack would see a stale
+    // override on the second run and produce one extra iter.
     const bare = new State({
       [ifOtherSymbol]: {
         command: [{movement: movements.stay}],

--- a/packages/machine/src/classes/TuringMachine.ts
+++ b/packages/machine/src/classes/TuringMachine.ts
@@ -97,14 +97,8 @@ export default class TuringMachine {
      * Async hook fired when `state.debug[when]` matches at the current
      * iteration. The promise is awaited inline, so the consumer can suspend
      * execution by deferring its resolution. Use for pause-capable inspection
-     * (debugger UIs, conditional breakpoints in tests).
-     *
-     * Renamed from `onDebugBreak` in v5.0.0. In v6.0.0 the dispatch order
-     * was changed so that `before` and `after` for the SAME iter fire on the
-     * same yield (per-iter lifecycle: before → step → after); previously the
-     * `after` of iter K fired on iter K+1's tick with a substituted source
-     * view. The `m.debugBreak` payload field keeps its name (it describes the
-     * engine's reason for pausing).
+     * (debugger UIs, conditional breakpoints in tests). Per-iter lifecycle:
+     * `before` and `after` for the same iter fire on the same yield.
      */
     onPause?: (machineState: MachineState) => void | Promise<void>;
     /**
@@ -170,13 +164,10 @@ export default class TuringMachine {
       this.#tapeBlock[lockSymbol].lock(executionSymbol);
 
 
-      // Halt-stack is run-scoped, not machine-scoped (#196). Declaring it
-      // local makes that lifetime explicit and prevents leftover entries
-      // from a previous `runStepByStep` call (e.g. a build-time peek that
-      // never drained the generator) from being popped during a subsequent
-      // halt-bound transition. Before this change `#stack` was an instance
-      // field and accumulated one extra push per call when the same machine
-      // was reused.
+      // Halt-stack is run-scoped, not machine-scoped (#196) — local
+      // declaration prevents leftover entries from a previous
+      // `runStepByStep` call (e.g. a build-time peek that never drained
+      // the generator) from leaking into a subsequent halt-bound transition.
       const stack: State[] = [];
       let state = initialState;
 
@@ -217,19 +208,14 @@ export default class TuringMachine {
           // The halting iter's after-fire just rides along on the iter's
           // own yield — no post-loop drain needed.
           //
-          // #207: `haltState.debug` is now a boolean, and pauses on the
-          // halt-triggering iter's AFTER side (not before). The previous
-          // before-side check (`nextState.debug?.before === true`) was
-          // "early-warning" timing — the user paused before the halt-bound
-          // transition fired, then had to mentally re-derive what would
-          // happen. Now the pause anchors post-step (after the iter's own
-          // after-pause if armed), so consumers see the just-fired halt-
-          // bound transition + diagram cursor still on the triggering state.
+          // #207 spec: `haltState.debug` is a boolean; the pause anchors on
+          // the AFTER side of the halt-triggering iter so consumers see the
+          // just-fired transition with the diagram cursor still on the
+          // triggering state.
           //
-          // `state` here is always non-halt (halt is terminal — the run
-          // loop never iterates with state === haltState), so `state.debug`
-          // is always `DebugConfig` at runtime. The public getter's return
-          // type matches that.
+          // `state` here is always non-halt (halt is terminal — the run loop
+          // never iterates with state === haltState), so `state.debug` is
+          // always `DebugConfig` at runtime.
           const beforeMatch = matchFilter(state.debug?.before, symbol);
           const afterMatch = matchFilter(state.debug?.after, symbol)
             || (nextState === haltState && haltState.debug);

--- a/packages/machine/src/utilities/equivalence.spec.ts
+++ b/packages/machine/src/utilities/equivalence.spec.ts
@@ -115,10 +115,8 @@ describe('equivalentOn', () => {
   });
 
   test('compareSnapshots: null skips mid-run divergence detection on same alphabet', () => {
-    // Audit gap: the `compareSnapshots: null` branch was exercised only in
-    // cross-alphabet tests. This test pins the same-alphabet contract:
-    // when outputs disagree but compareSnapshots is null, firstDivergenceStep
-    // is null (the engine doesn't probe step-by-step).
+    // When outputs disagree but compareSnapshots is null,
+    // firstDivergenceStep is null (no step-by-step probe).
     const report = equivalentOn(
       {state: binaryNumbers.states.plusOne, getTapeBlock: binaryNumbers.getTapeBlock},
       {state: binaryNumbers.states.minusOne, getTapeBlock: binaryNumbers.getTapeBlock},

--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -140,9 +140,8 @@ describe('toMermaid', () => {
   });
 
   test('renders wrapper-to-override solid arrow when overriddenHaltStateId is set', () => {
-    // Under the v7 callable-subtree model, wrapper → override is a regular
-    // solid `-->` (the new convention reserves bold/dotted for `call`/`return`/
-    // `halt`). The retired `-. onHalt .->` keyword no longer appears.
+    // Wrapper → override is a regular solid `-->` arrow; bold/dotted styles
+    // are reserved for `call` / `return` / `halt`.
     const out = toMermaid({
       initialId: 1,
       alphabets: [[' ', '0']],

--- a/packages/machine/src/utilities/graph.ts
+++ b/packages/machine/src/utilities/graph.ts
@@ -6,10 +6,9 @@ export type GraphTransition = {
   pattern: string;
   command: GraphCommand[];
   nextStateId: number;
-  // Stable, deterministic per-edge identifier. Format: `${fromNodeId}-${patternIx}`
-  // where `patternIx` is the transition's position in the source state's symbol
-  // map. Let's downstream rendering (machines-demo #10) target a specific edge in
-  // the rendered Mermaid SVG to highlight "the edge that will fire next."
+  // Stable per-edge identifier: `${fromNodeId}.${patternIx}` where patternIx
+  // is the transition's position in the source state's symbol map. Lets
+  // downstream rendering target a specific edge in the Mermaid SVG.
   id: string;
 };
 

--- a/packages/machine/src/utilities/introspection.ts
+++ b/packages/machine/src/utilities/introspection.ts
@@ -101,10 +101,10 @@ export function summarizeGraph(graph: Graph): GraphSummary {
   let hasCycles = false;
 
   const visit = (id: number): void => {
-    // No `if (hasCycles) return` guard at function entry: the recursive call
-    // pattern (outer for-loop checks before calling, inner loop checks after
-    // each recursive call) ensures visit() is never invoked when hasCycles
-    // is already true. Static analysis confirmed the guard was unreachable.
+    // No `if (hasCycles) return` guard at function entry: the call pattern
+    // (outer for-loop checks before calling, inner loop checks after each
+    // recursive call) ensures visit() is never invoked when hasCycles is
+    // already true.
     if (color.get(id) === GREY) {
       hasCycles = true;
       return;

--- a/packages/machine/src/utilities/stateGraph.ts
+++ b/packages/machine/src/utilities/stateGraph.ts
@@ -14,16 +14,11 @@ import {
   parseWriteSymbolLabel,
 } from './graph';
 
-// Graph serialization/reconstruction for State graphs. Extracted from
-// `classes/State.ts` (#180) so the State class stays focused on the runtime
-// machinery (transitions, debug, halt-stack composition). Sibling-module
-// private access to State's internals goes through the `STATE_INTERNAL`
+// Graph serialization/reconstruction + state collection for State graphs.
+// Sibling-module access to State's internals uses the `STATE_INTERNAL`
 // Symbol re-exported from State.ts — see the @internal JSDoc there.
-//
-// Public surface is preserved: `State.toGraph` and `State.fromGraph` static
-// methods continue to exist as thin delegates to the functions in this
-// module. New consumers (e.g. #195's planned `collectStates`) will live
-// here too and share the BFS-walk shape with `toGraph`.
+// `State.toGraph` / `.fromGraph` / `.collectStates` static methods on
+// State are thin delegates to functions in this module.
 
 /**
  * Walks the reachable graph from `initialState` and returns a serializable
@@ -142,13 +137,11 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
           movement: decodeMovement((tc.movement as symbol).description),
         })),
         nextStateId: targetInternal.id,
-        // Transition id format: `${stateId}.${transitionIx}` (#205).
-        // Matches `TuringMachine.runStepByStep`'s `MachineState.
-        // matchedTransition.id` so consumers can do
+        // `${stateId}.${transitionIx}` — matches
+        // `MachineState.matchedTransition.id` so consumers can do
         // `graph.nodes[stateId].transitions.find(t => t.id === id)`.
-        // Was `${stateId}-${ix}` pre-#205 — the `.` separator avoids
-        // the hyphen reading as a minus sign next to negative halt-
-        // marker ids in adjacent contexts.
+        // `.` separator (vs `-`) avoids collision with negative
+        // halt-marker ids.
         id: `${stateInternal.id}.${patternIx}`,
       });
 


### PR DESCRIPTION
## Summary

Audit pass on source comments per the rule \"no historical bullshit in source — that belongs in commits/PRs/CHANGELOG.\" 14 files, -55 lines net.

## Bucket 2 — actively wrong (fix-now)

- **\`packages/machine/src/utilities/graph.ts:9-12\`** — \`GraphTransition.id\` JSDoc said the format was \`\${fromNodeId}-\${patternIx}\`. [#205](https://github.com/mellonis/turing-machine-js/issues/205) changed the separator to \`.\` and this file was the last holdout (the actual emit in \`stateGraph.ts:147\` and \`TuringMachine.ts:211\` both correctly use \`.\`). Misleading for anyone reading the type definition. Also fixed \"Let's\" → \"Lets\" typo while in there.
- **\`packages/machine/src/utilities/graph.spec.ts:145\`** — dropped reference to the retired \`-. onHalt .->\` keyword (retired before v7-alpha.2).

## Bucket 1 — historical bloat (trim/drop)

- **\`TuringMachine.ts\`** — JSDoc on \`onPause\` (rename + dispatch-order history), \`runStepByStep\` halt-stack \"before this change\" tail, multi-paragraph #207 timing migration narrative
- **\`State.ts\`** — 4 spots: #180 extraction framing in import preamble, #138 superseded model in \`#bareState\` JSDoc, \"no longer flows\" framing in validateDebugFilter, #206 \`#getEntry\` refactor history
- **\`utilities/stateGraph.ts\`** — file-header extraction story + \"Was \`\${stateId}-\${ix}\` pre-#205\" tail
- **\`utilities/introspection.ts\`** — dropped \"Static analysis confirmed\" tail
- **\`TuringMachine.debug.spec.ts\`** — ~5 \"v6.0.0 / v6 API did X\" tails across describe blocks (the test names already pin the current shape)
- **\`TuringMachine.spec.ts\`** — 3 \"pre-#196 left the override\" framings (regression test header tightened; #196 anchor preserved)
- **\`library-binary-numbers/src/graphs.spec.ts\`** — dropped per-line \`// alpha.1: 4 (one wohs); +1 wrapper node\` deltas; the current count IS the spec
- **\`State.spec.ts\` / \`Reference.spec.ts\` / \`equivalence.spec.ts\` / \`builder.spec.ts\` / \`Tape.spec.ts\`** — short pre-test commentary trims

## What I kept

- Issue numbers cited as forward-looking spec references (\`(#207)\`, \`(#175)\`, etc.) — these are anchors, not archaeology
- WORKAROUND markers, non-obvious invariants, surprising-behavior callouts, hidden-constraint warnings
- The bottom-of-file note in \`State.ts\` about the ESM live-bindings cycle
- The \`isHaltMarker\` filtering rationale in graphs.spec.ts (current spec)

## Test plan

- [x] \`npm test\` — 506/506 passing
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — clean (existing circular-dep warning unchanged)
- [ ] CI green on PR

## Companion

Sibling PR coming up in \`post-machine-js\` for the same audit findings there.