### PR TITLE
feat(visuals): extract @turing-machine-js/visuals + recordSnippet (#204)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-visuals-package-extract.md
+++ b/docs/superpowers/plans/2026-05-30-visuals-package-extract.md
@@ -2,7 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Extract machines-demo's pure highlight/graph-indexing modules + rules doc into a new lockstep-published package `@turing-machine-js/visuals`. NO new functionality in this PR — pure code-move + scaffold. `recordSnippet` + Snippet/Frame schema lands as a follow-up plan (issue step 3).
+**Goal:** Extract machines-demo's pure highlight/graph-indexing modules + rules doc into a new lockstep-published package `@turing-machine-js/visuals`, AND ship the initial `recordSnippet` + `Snippet`/`Frame` schema so v1 publishes with a complete API.
+
+**Scope split:** Originally drafted as extraction-only (issue step 1) with `recordSnippet` as a follow-up PR (step 3). **Revised mid-implementation to fold step 3 in** — so the first published alpha carries the complete v1 API ready to feed the landing-page work (#79). Step 2 (machines-demo cleanup) remains a separate follow-up in the machines-demo repo. See Tasks 10–13 below.
 
 **Architecture:** New `packages/visuals/` workspace, peer dep on `@turing-machine-js/machine` (`Graph` type only — no runtime dependency). Pure TypeScript, no DOM, no Svelte. Modules are line-for-line moves: `TuringGraph` local alias becomes `import { Graph } from '@turing-machine-js/machine'`; everything else unchanged. The rules doc moves under `packages/visuals/docs/`. machines-demo's local copies + the doc-source are deleted in a follow-up demo PR (issue step 2, **not** this PR — keeps the extract PR self-contained and reviewable against engine tests only).
 
@@ -18,7 +20,12 @@
 
 - **Package name: `@turing-machine-js/visuals`.** Issue #204 lists this as an open question between `visuals` / `highlight` / `graph-visuals`. Going with `visuals` — broadest, room for `recordSnippet` + future visual primitives without renaming.
 - **No DOM applier sub-export in v1.** The package stays purely renderer-agnostic. A future `@turing-machine-js/visuals/dom` sub-path can be added non-breakingly when there's a concrete consumer asking for one. Out of scope here.
-- **Snippet schema versioning policy (deferred to PR B).** This PR does NOT introduce the schema; recording the policy now keeps PR B short: additive fields don't bump `version`; breaking shape changes bump the integer. Will be documented in PR B's README addition.
+- **Snippet schema versioning policy.** Additive fields don't bump `version`; breaking shape changes bump the integer. Documented in the README addition that ships with Task 13.
+- **`Frame` shape (locked).** Per-iter capture: `{ step: number; tape: TapeSnapshot[]; highlight: GraphHighlight | null; log?: string }`. `step` is 0-indexed iter (frame 0 = initial state, before any transition). `tape` is per-tape array (single-tape: length 1). `highlight` is the GraphHighlight to render for this frame (null = no active highlight). `log` is optional pre-formatted text; consumers can render it as a caption / status line. Users wanting a different shape pass `log` callback for the string only — Frame's structural fields stay fixed (consumers' renderers depend on the shape).
+- **`Snippet` shape (locked, no `engine` field per #204 comment).** `{ version: 1; name?: string; graph: Graph; alphabets: string[][]; frames: Frame[] }`. `frames.length === stepsApplied + 1` — frame 0 is the initial state. `alphabets` is per-tape (single-tape: length 1).
+- **`recordSnippet` signature (locked).** `recordSnippet({ machine, initialState, graph, alphabets, name?, maxSteps?, log? }): Snippet`. Caller supplies pre-built `machine`, `initialState`, pre-computed `graph` (via `State.toGraph`), and `alphabets`. Caller chooses which engine (turing-machine-js or post-machine-js) — recorder is engine-agnostic, just runs `machine.runStepByStep({ initialState, stepsLimit: maxSteps })` and captures per iter. `log` callback (optional) receives `(machineState, prevMachineState | null)` and returns the line text. Default frame has `log: undefined`.
+- **Default formatter primitives.** Ship `formatCommand(command)` + `formatStep(machineState, prev?)` as composable helpers, exported alongside `recordSnippet`. Format mirrors the engine's edge-label notation (`[reads] → [writes]/[moves]`) so a logged step lines up with the rendered graph's edge. Users compose their own `log` callback by combining these or write their own from scratch.
+- **`TapeSnapshot` type moves into visuals.** `{ symbols: string[]; position: number }` — pure data, renderer-agnostic, lives in `packages/visuals/src/types.ts` alongside `GraphHighlight`. Demo's local copy stays during this PR (cleaned up in the step-2 follow-up).
 - **`graphHighlightDerivation.ts` does NOT extract.** Its `ExecutionMode` union mirrors machines-demo's MachineView state machine (`'DEMO' | 'MANUAL' | 'RUNNING_AUTO' | …`) — demo orchestration, not engine semantics. Stays in machines-demo and imports `bareIdOf` from the published package post-extract.
 - **`Snippet.engine` field is dropped (per #204 comment 2026-05-29).** Pinned here so PR B inherits the constraint. Engine identity lives at the caller bucket level (`{ turing: Snippet[], post: Snippet[] }`), not on the artifact.
 - **No content rewrites during the move.** Rules doc moves verbatim — any rewording is a separate edit later. Keeps this PR's diff a clean move.
@@ -31,26 +38,29 @@
 ```
 packages/visuals/
 ├── package.json              # NEW — peer dep on @turing-machine-js/machine
-├── tsconfig.json             # NEW — project references, extends repo conventions
+├── tsconfig.json             # NEW — IDE/typecheck config (mirrors machine's)
+├── tsconfig.build.json       # NEW — composite-build config (mirrors machine's)
 ├── README.md                 # NEW — what this package is, public API summary
 ├── src/
-│   ├── index.ts              # NEW — re-exports public surface
-│   ├── highlightOps.ts       # MOVED from machines-demo/src/lib/highlightOps.ts
-│   ├── graphUtils.ts         # MOVED from machines-demo/src/lib/graphUtils.ts
-│   ├── graphIndexes.ts       # MOVED from machines-demo/src/lib/graphIndexes.ts
-│   └── applyHighlight.ts     # MOVED from machines-demo/src/lib/applyHighlight.ts
-├── tests/
-│   ├── graphUtils.spec.ts    # MOVED — renamed .test.ts → .spec.ts to match repo convention
-│   ├── graphIndexes.spec.ts  # (no source test in demo; trivial test added if extraction warrants)
-│   ├── applyHighlight.spec.ts # MOVED + renamed
-│   ├── graphFixtures.spec.ts # MOVED + renamed
-│   └── fixtures/             # MOVED — fixture JSONs (graphs/*.json) used by graphFixtures
+│   ├── index.ts                  # NEW — re-exports public surface
+│   ├── highlightOps.ts           # MOVED from machines-demo/src/lib/highlightOps.ts
+│   ├── graphUtils.ts             # MOVED from machines-demo/src/lib/graphUtils.ts
+│   ├── graphUtils.spec.ts        # MOVED + .test.ts → .spec.ts (colocated next to source per repo convention)
+│   ├── graphIndexes.ts           # MOVED from machines-demo/src/lib/graphIndexes.ts
+│   ├── applyHighlight.ts         # MOVED from machines-demo/src/lib/applyHighlight.ts
+│   ├── applyHighlight.spec.ts    # MOVED + colocated
+│   ├── graphFixtures.spec.ts     # MOVED + colocated
+│   └── fixtures/                 # MOVED — fixture JSONs (graphs/*.json) used by graphFixtures.spec.ts
 └── docs/
     └── graph-highlight-and-breakpoints.md  # MOVED from machines-demo/docs/
 
-tsconfig.build.json           # MODIFY — add reference to packages/visuals
-package.json                  # MODIFY — extend "typecheck" script to include packages/visuals
+tsconfig.build.json           # MODIFY — references packages/visuals/tsconfig.build.json (per repo convention — all entries reference the build variant)
+package.json                  # MODIFY — extend "typecheck" script to include packages/visuals/tsconfig.json
 ```
+
+**Convention notes (verified against `packages/machine`):**
+- **Dual tsconfig** per package: `tsconfig.json` (extends root, `rootDir: ".."`, includes `paths` alias map) for IDE / standalone typecheck; `tsconfig.build.json` (extends local `./tsconfig.json`, `rootDir: "src"`, `composite: true`, `exclude: ["**/*.spec.ts", "dist"]`) for the project-references build.
+- **Tests colocated** as `*.spec.ts` next to source under `src/` (per CLAUDE.md). No top-level `tests/` dir. Fixtures live wherever the colocated spec needs them — under `src/fixtures/` if the test reads from it.
 
 Public API exported from `packages/visuals/src/index.ts`:
 

--- a/docs/superpowers/plans/2026-05-30-visuals-package-extract.md
+++ b/docs/superpowers/plans/2026-05-30-visuals-package-extract.md
@@ -1,0 +1,578 @@
+# `@turing-machine-js/visuals` package extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract machines-demo's pure highlight/graph-indexing modules + rules doc into a new lockstep-published package `@turing-machine-js/visuals`. NO new functionality in this PR — pure code-move + scaffold. `recordSnippet` + Snippet/Frame schema lands as a follow-up plan (issue step 3).
+
+**Architecture:** New `packages/visuals/` workspace, peer dep on `@turing-machine-js/machine` (`Graph` type only — no runtime dependency). Pure TypeScript, no DOM, no Svelte. Modules are line-for-line moves: `TuringGraph` local alias becomes `import { Graph } from '@turing-machine-js/machine'`; everything else unchanged. The rules doc moves under `packages/visuals/docs/`. machines-demo's local copies + the doc-source are deleted in a follow-up demo PR (issue step 2, **not** this PR — keeps the extract PR self-contained and reviewable against engine tests only).
+
+**Tech Stack:** TypeScript (project references), Vitest, npm workspaces, Lerna. Standard repo commands (`npm test`, `npm run lint`, `npm run typecheck`, `npm run build`) automatically pick up the new workspace.
+
+**Branch:** `feat/204-visuals-extract` (off `v7`). Issue: [mellonis/turing-machine-js#204](https://github.com/mellonis/turing-machine-js/issues/204).
+
+**Coverage floor (must hold):** 100% statements / 100% branches / 100% functions / 100% lines. The extracted modules are pure logic with no I/O; demo's existing test suites already hit 100% on these files. Drop is unexpected and indicates an extraction error.
+
+---
+
+## Decisions (locked in this plan)
+
+- **Package name: `@turing-machine-js/visuals`.** Issue #204 lists this as an open question between `visuals` / `highlight` / `graph-visuals`. Going with `visuals` — broadest, room for `recordSnippet` + future visual primitives without renaming.
+- **No DOM applier sub-export in v1.** The package stays purely renderer-agnostic. A future `@turing-machine-js/visuals/dom` sub-path can be added non-breakingly when there's a concrete consumer asking for one. Out of scope here.
+- **Snippet schema versioning policy (deferred to PR B).** This PR does NOT introduce the schema; recording the policy now keeps PR B short: additive fields don't bump `version`; breaking shape changes bump the integer. Will be documented in PR B's README addition.
+- **`graphHighlightDerivation.ts` does NOT extract.** Its `ExecutionMode` union mirrors machines-demo's MachineView state machine (`'DEMO' | 'MANUAL' | 'RUNNING_AUTO' | …`) — demo orchestration, not engine semantics. Stays in machines-demo and imports `bareIdOf` from the published package post-extract.
+- **`Snippet.engine` field is dropped (per #204 comment 2026-05-29).** Pinned here so PR B inherits the constraint. Engine identity lives at the caller bucket level (`{ turing: Snippet[], post: Snippet[] }`), not on the artifact.
+- **No content rewrites during the move.** Rules doc moves verbatim — any rewording is a separate edit later. Keeps this PR's diff a clean move.
+- **machines-demo cleanup (issue step 2) is a separate follow-up PR**, in the machines-demo repo, after this lands and lockstep-publishes with the next engine v7 alpha. This PR does NOT touch machines-demo.
+
+---
+
+## File Structure
+
+```
+packages/visuals/
+├── package.json              # NEW — peer dep on @turing-machine-js/machine
+├── tsconfig.json             # NEW — project references, extends repo conventions
+├── README.md                 # NEW — what this package is, public API summary
+├── src/
+│   ├── index.ts              # NEW — re-exports public surface
+│   ├── highlightOps.ts       # MOVED from machines-demo/src/lib/highlightOps.ts
+│   ├── graphUtils.ts         # MOVED from machines-demo/src/lib/graphUtils.ts
+│   ├── graphIndexes.ts       # MOVED from machines-demo/src/lib/graphIndexes.ts
+│   └── applyHighlight.ts     # MOVED from machines-demo/src/lib/applyHighlight.ts
+├── tests/
+│   ├── graphUtils.spec.ts    # MOVED — renamed .test.ts → .spec.ts to match repo convention
+│   ├── graphIndexes.spec.ts  # (no source test in demo; trivial test added if extraction warrants)
+│   ├── applyHighlight.spec.ts # MOVED + renamed
+│   ├── graphFixtures.spec.ts # MOVED + renamed
+│   └── fixtures/             # MOVED — fixture JSONs (graphs/*.json) used by graphFixtures
+└── docs/
+    └── graph-highlight-and-breakpoints.md  # MOVED from machines-demo/docs/
+
+tsconfig.build.json           # MODIFY — add reference to packages/visuals
+package.json                  # MODIFY — extend "typecheck" script to include packages/visuals
+```
+
+Public API exported from `packages/visuals/src/index.ts`:
+
+```ts
+// Types
+export type {
+  NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp,
+} from './highlightOps';
+export type { GraphIndexes } from './graphIndexes';
+
+// Functions
+export { recordingOps } from './highlightOps';
+export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';
+export { indexGraph } from './graphIndexes';
+export { applyHighlight, applyIndicator } from './applyHighlight';
+```
+
+Note: machines-demo's local `TuringGraph` alias resolves to `Graph` from `@turing-machine-js/machine`. The move replaces every `import { …, type TuringGraph } from './types.ts'` with `import { type Graph } from '@turing-machine-js/machine'` and renames the type at use-sites. `TuringGraph` is NOT re-exported from visuals — callers import `Graph` directly from `@turing-machine-js/machine`.
+
+---
+
+## Task 1: Scaffold `packages/visuals/`
+
+**Files:**
+- Create: `packages/visuals/package.json`
+- Create: `packages/visuals/tsconfig.json`
+- Create: `packages/visuals/README.md`
+- Create: `packages/visuals/src/index.ts`
+- Modify: `tsconfig.build.json`
+- Modify: `package.json` (root — extend `typecheck` script)
+
+- [ ] **Step 1: Write `packages/visuals/package.json`**
+
+```json
+{
+  "name": "@turing-machine-js/visuals",
+  "version": "7.0.0-alpha.6",
+  "description": "Pure highlight + graph-indexing logic for @turing-machine-js/machine — no DOM, no renderer.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "src", "docs", "README.md", "CHANGELOG.md", "LICENSE"],
+  "scripts": {
+    "prepublishOnly": "npm run --workspaces=false -w @turing-machine-js/visuals build"
+  },
+  "peerDependencies": {
+    "@turing-machine-js/machine": "^7.0.0-alpha.6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+> **Verify before committing:** version field matches the current engine alpha tag. Cross-check `packages/machine/package.json`'s version. Lerna's `version` command keeps these in lockstep on the next bump.
+
+- [ ] **Step 2: Write `packages/visuals/tsconfig.json`**
+
+Mirror `packages/machine/tsconfig.json`'s structure. Read it first, then create:
+
+```json
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "strict": true
+  },
+  "references": [
+    { "path": "../machine" }
+  ],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}
+```
+
+> Adjust to match `packages/machine/tsconfig.json` exactly if it differs — repo convention overrides the example above.
+
+- [ ] **Step 3: Write `packages/visuals/README.md`**
+
+```markdown
+# @turing-machine-js/visuals
+
+Pure highlight + graph-indexing logic for [`@turing-machine-js/machine`](../machine). No DOM, no Svelte, no Mermaid — consumers bring their own renderer and DOM applier.
+
+## Scope
+
+Types and pure functions for:
+- Indexing an engine `Graph` for wrapper/bare lookup (`indexGraph`, `bareIdOf`, `highlightExpand`).
+- Applying highlight + indicator operations against a renderer-agnostic `HighlightOps` interface (`applyHighlight`, `applyIndicator`).
+
+See [`docs/graph-highlight-and-breakpoints.md`](./docs/graph-highlight-and-breakpoints.md) for the full set of rules these functions satisfy.
+
+## Versioning
+
+Lockstep with `@turing-machine-js/machine`.
+
+## Install
+
+\`\`\`sh
+npm install @turing-machine-js/visuals @turing-machine-js/machine
+\`\`\`
+```
+
+- [ ] **Step 4: Write `packages/visuals/src/index.ts` (empty for now)**
+
+```ts
+// Public API — populated as modules are moved in Tasks 2–5.
+export {};
+```
+
+- [ ] **Step 5: Modify `tsconfig.build.json` — add reference**
+
+Read the file first; then append `{ "path": "packages/visuals" }` to its `references` array.
+
+- [ ] **Step 6: Modify root `package.json` — extend `typecheck` script**
+
+Read the current value:
+```
+"typecheck": "tsc --noEmit -p packages/machine/tsconfig.json && tsc --noEmit -p packages/builder/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers-bare/tsconfig.json"
+```
+
+Add `&& tsc --noEmit -p packages/visuals/tsconfig.json` at the end.
+
+- [ ] **Step 7: Verify scaffolding compiles**
+
+Run: `npm install && npm run typecheck && npm run build`
+Expected: green. No new tests yet; existing engine tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```sh
+git add packages/visuals tsconfig.build.json package.json package-lock.json
+git commit -m "feat(visuals): scaffold @turing-machine-js/visuals package (#204)"
+```
+
+---
+
+## Task 2: Move `highlightOps.ts`
+
+**Files:**
+- Read: `../machines-demo/src/lib/highlightOps.ts` (source — outside this repo; copy contents, do NOT modify the source from this repo)
+- Create: `packages/visuals/src/highlightOps.ts`
+- Modify: `packages/visuals/src/index.ts`
+
+- [ ] **Step 1: Read source**
+
+Read `../machines-demo/src/lib/highlightOps.ts` in full. It has no external imports beyond TypeScript stdlib types — a pure types + recordingOps module. Direct move.
+
+- [ ] **Step 2: Create the file at the new location**
+
+Write `packages/visuals/src/highlightOps.ts` with the source contents verbatim. No import changes needed (it has none).
+
+- [ ] **Step 3: Add to public exports**
+
+In `packages/visuals/src/index.ts`:
+```ts
+export type { NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp } from './highlightOps';
+export { recordingOps } from './highlightOps';
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/visuals/src
+git commit -m "feat(visuals): move highlightOps from machines-demo (#204)"
+```
+
+---
+
+## Task 3: Move `graphUtils.ts` + test
+
+**Files:**
+- Read: `../machines-demo/src/lib/graphUtils.ts`, `../machines-demo/src/lib/graphUtils.test.ts`
+- Create: `packages/visuals/src/graphUtils.ts`
+- Create: `packages/visuals/tests/graphUtils.spec.ts`
+- Modify: `packages/visuals/src/index.ts`
+
+- [ ] **Step 1: Read source files**
+
+Read both `graphUtils.ts` and `graphUtils.test.ts` from machines-demo. Note imports:
+- Source imports `type TuringGraph` from local `./types.ts` (demo-local alias).
+- Test imports the source + may import test fixtures.
+
+- [ ] **Step 2: Create `packages/visuals/src/graphUtils.ts`**
+
+Copy source contents. Replace the line:
+```ts
+import type { TuringGraph } from './types.ts';
+```
+with:
+```ts
+import type { Graph } from '@turing-machine-js/machine';
+```
+Then rename `TuringGraph` → `Graph` at every use-site in this file.
+
+- [ ] **Step 3: Create `packages/visuals/tests/graphUtils.spec.ts`**
+
+Copy test contents. Update import paths:
+- `from '../src/lib/graphUtils.ts'` → `from '../src/graphUtils'`
+- Any `TuringGraph` → `Graph` from `@turing-machine-js/machine`
+
+If the test references fixtures, defer their move to Task 5 (graphFixtures) — for now, gate any fixture-dependent test on the file existing or comment it out with a `// TODO Task 5: restore after fixtures move` marker. If no fixture deps, the test is self-contained.
+
+- [ ] **Step 4: Add to public exports**
+
+In `packages/visuals/src/index.ts`, append:
+```ts
+export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';
+```
+
+- [ ] **Step 5: Run the moved test**
+
+Run: `npx vitest run packages/visuals/tests/graphUtils.spec.ts`
+Expected: same passing count as the original in machines-demo (or skipped count for fixture-deferred tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add packages/visuals
+git commit -m "feat(visuals): move graphUtils + test (#204)"
+```
+
+---
+
+## Task 4: Move `graphIndexes.ts` (+ test if present)
+
+**Files:**
+- Read: `../machines-demo/src/lib/graphIndexes.ts`
+- Create: `packages/visuals/src/graphIndexes.ts`
+- Modify: `packages/visuals/src/index.ts`
+
+- [ ] **Step 1: Read source**
+
+Read `graphIndexes.ts`. Note the imports — likely `TuringGraph` from local types.
+
+- [ ] **Step 2: Create `packages/visuals/src/graphIndexes.ts`**
+
+Copy contents, replace `TuringGraph` import with `import type { Graph } from '@turing-machine-js/machine'`, rename use-sites.
+
+- [ ] **Step 3: Add to public exports**
+
+```ts
+export type { GraphIndexes } from './graphIndexes';
+export { indexGraph } from './graphIndexes';
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `npm run typecheck`
+Expected: green.
+
+> **Note:** machines-demo does NOT ship a standalone `graphIndexes.test.ts` (only an `applyHighlight.test.ts` and `graphUtils.test.ts`). `indexGraph` is exercised transitively by the applyHighlight tests in Task 6. No dedicated test added in this PR — extraction parity is preserved.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/visuals
+git commit -m "feat(visuals): move graphIndexes (#204)"
+```
+
+---
+
+## Task 5: Move `graphFixtures.test.ts` + fixture JSONs
+
+**Files:**
+- Read: `../machines-demo/src/lib/graphFixtures.test.ts` + any `tests/fixtures/graphs/*.json` referenced
+- Create: `packages/visuals/tests/graphFixtures.spec.ts`
+- Create: `packages/visuals/tests/fixtures/graphs/*.json` (one file per fixture)
+
+- [ ] **Step 1: Read test + identify fixture files**
+
+Read `graphFixtures.test.ts`. Find every `import` or `readFileSync` / `JSON.parse` of a fixture path. List them.
+
+- [ ] **Step 2: Copy each fixture JSON file verbatim**
+
+For each fixture path discovered in Step 1, copy the file from machines-demo to `packages/visuals/tests/fixtures/graphs/<name>.json`. Do not modify the JSON — these are engine-emit snapshots and must roundtrip byte-for-byte.
+
+- [ ] **Step 3: Create the test file**
+
+Copy `graphFixtures.test.ts` contents to `packages/visuals/tests/graphFixtures.spec.ts`. Update:
+- Source import paths (`from '../lib/...'` → `from '../src/...'`).
+- Fixture path strings (`./fixtures/graphs/...` should already resolve from the new test location since fixtures are colocated under `tests/fixtures/`).
+- Any `import * as turing from '@turing-machine-js/machine'` already correct.
+- Type rename: `TuringGraph` → `Graph`.
+
+- [ ] **Step 4: Run the fixture test**
+
+Run: `npx vitest run packages/visuals/tests/graphFixtures.spec.ts`
+Expected: same passing count as in machines-demo. Fixture roundtrip MUST pass — failure here indicates engine-emit drift OR an extraction-time corruption of the JSON.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add packages/visuals/tests
+git commit -m "feat(visuals): move graphFixtures test + fixture JSONs (#204)"
+```
+
+---
+
+## Task 6: Move `applyHighlight.ts` + test
+
+**Files:**
+- Read: `../machines-demo/src/lib/applyHighlight.ts`, `../machines-demo/src/lib/applyHighlight.test.ts`
+- Create: `packages/visuals/src/applyHighlight.ts`
+- Create: `packages/visuals/tests/applyHighlight.spec.ts`
+- Modify: `packages/visuals/src/index.ts`
+
+- [ ] **Step 1: Read source files**
+
+Read both. Note all imports — likely:
+- `import type { TuringGraph } from './types.ts'`
+- `import { ... } from './graphUtils.ts'`
+- `import { ... } from './graphIndexes.ts'`
+- `import { ... } from './highlightOps.ts'`
+
+- [ ] **Step 2: Create `packages/visuals/src/applyHighlight.ts`**
+
+Copy source. Replace:
+- `TuringGraph` import → `import type { Graph } from '@turing-machine-js/machine'` + rename uses.
+- Local imports from `./graphUtils.ts` / `./graphIndexes.ts` / `./highlightOps.ts` → drop the `.ts` extension only if needed for the package's resolution (match the convention used in Tasks 2–4).
+
+- [ ] **Step 3: Create `packages/visuals/tests/applyHighlight.spec.ts`**
+
+Copy test. Update import paths to point at `../src/...`. Rename `TuringGraph` → `Graph`.
+
+- [ ] **Step 4: Add to public exports**
+
+```ts
+export { applyHighlight, applyIndicator } from './applyHighlight';
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `npx vitest run packages/visuals/tests/applyHighlight.spec.ts`
+Expected: all original tests pass at new location. Same count as in machines-demo.
+
+- [ ] **Step 6: Restore any fixture-deferred tests from Task 3**
+
+If Task 3 commented out fixture-dependent graphUtils tests, uncomment them now and verify they pass. Fixtures are in place since Task 5.
+
+- [ ] **Step 7: Full test + typecheck + lint**
+
+Run: `npm test && npm run typecheck && npm run lint`
+Expected: green across all four packages (machine, builder, library-binary-numbers, library-binary-numbers-bare) + the new visuals.
+
+- [ ] **Step 8: Commit**
+
+```sh
+git add packages/visuals
+git commit -m "feat(visuals): move applyHighlight + applyIndicator + test (#204)"
+```
+
+---
+
+## Task 7: Move the rules doc
+
+**Files:**
+- Read: `../machines-demo/docs/graph-highlight-and-breakpoints.md`
+- Create: `packages/visuals/docs/graph-highlight-and-breakpoints.md`
+
+- [ ] **Step 1: Read the source doc**
+
+Read `../machines-demo/docs/graph-highlight-and-breakpoints.md` fully (~272 lines).
+
+- [ ] **Step 2: Copy verbatim**
+
+Create `packages/visuals/docs/graph-highlight-and-breakpoints.md` with identical contents. NO rewrites, NO scope changes, NO reformatting. If any in-doc cross-link points to a machines-demo path (e.g., `../src/components/MachineGraph.svelte`), leave it intact — fixing those links is part of the follow-up machines-demo cleanup PR (issue step 2). A `git mv`-shaped change preserves blame across the move (run `git log --follow` on the new path to verify).
+
+- [ ] **Step 3: Verify the README link resolves**
+
+The `packages/visuals/README.md` from Task 1 links to `./docs/graph-highlight-and-breakpoints.md` — confirm the file is at that path.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add packages/visuals/docs
+git commit -m "docs(visuals): move highlight + breakpoints rules doc (#204)"
+```
+
+---
+
+## Task 8: Coverage verify + CHANGELOG
+
+**Files:**
+- Create: `packages/visuals/CHANGELOG.md`
+
+- [ ] **Step 1: Run coverage**
+
+Run: `npm run test:coverage`
+Expected: visuals package at **100% / 100% / 100% / 100%**. If any file is below 100%, identify the missing branch — likely a defensive `null` check from the demo's original code. Either:
+- Add a missing test case if the branch is reachable.
+- Document the unreachable branch in the file (one-line comment) and verify reviewers accept it.
+
+> **Do NOT lower the floor.** A drop below 100% means extraction-time scope mismatch; investigate before committing.
+
+- [ ] **Step 2: Write `packages/visuals/CHANGELOG.md`**
+
+Per repo convention, every release-bound package needs a CHANGELOG entry up front:
+
+```markdown
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Initial extraction from machines-demo: `Highlight`/`HighlightOps`/`GraphIndexes` types, `indexGraph`, `applyHighlight`, `applyIndicator`, `bareIdOf`, `highlightExpand`, `equivalentIds`, `recordingOps`. Rules doc moved into `docs/graph-highlight-and-breakpoints.md`. Closes mellonis/turing-machine-js#204 (extraction step; recordSnippet follows in a separate PR).
+```
+
+> The `[Unreleased]` heading converts to `[X.Y.Z] - YYYY-MM-DD` during the release-PR pass (per workspace `CLAUDE.md` "CHANGELOG.md is part of every v-bump PR" rule). Not bumped in this PR — version bump is part of the next engine alpha release PR that includes visuals.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add packages/visuals/CHANGELOG.md
+git commit -m "docs(visuals): add CHANGELOG with extraction entry (#204)"
+```
+
+---
+
+## Task 9: Open PR
+
+- [ ] **Step 1: Push the branch**
+
+```sh
+git push -u origin feat/204-visuals-extract
+```
+
+- [ ] **Step 2: Open the PR against `v7`**
+
+```sh
+gh pr create \
+  --repo mellonis/turing-machine-js \
+  --base v7 \
+  --head feat/204-visuals-extract \
+  --title "feat(visuals): extract @turing-machine-js/visuals (#204, step 1)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Extracts pure highlight + graph-indexing modules from machines-demo into a new lockstep-published package `@turing-machine-js/visuals`. Step 1 of [#204](https://github.com/mellonis/turing-machine-js/issues/204) — extraction only. \`recordSnippet\` + Snippet/Frame schema lands in a follow-up PR (step 3). machines-demo consumption (step 2) lands in machines-demo as a separate PR after this publishes.
+
+What's in:
+
+- New \`packages/visuals/\` workspace (peer dep on \`@turing-machine-js/machine\`, no runtime dep, no DOM).
+- Moves: \`highlightOps\`, \`graphUtils\`, \`graphIndexes\`, \`applyHighlight\` + their tests.
+- Rules doc moves to \`packages/visuals/docs/graph-highlight-and-breakpoints.md\` verbatim.
+- Public API exported from \`packages/visuals/src/index.ts\`.
+
+What's NOT in (deliberate):
+
+- \`graphHighlightDerivation.ts\` stays in machines-demo — its \`ExecutionMode\` union is demo-coupled, not engine semantics.
+- \`recordSnippet\`, \`Snippet\`, \`Frame\` types — follow-up PR.
+- machines-demo cleanup — separate PR in machines-demo.
+
+Decisions locked in [\`docs/superpowers/plans/2026-05-30-visuals-package-extract.md\`](docs/superpowers/plans/2026-05-30-visuals-package-extract.md): package name = \`visuals\`; no DOM applier sub-export in v1; \`Snippet.engine\` field dropped (per #204 comment 2026-05-29).
+
+## Test plan
+
+- [x] \`npm test\` — all packages including new visuals.
+- [x] \`npm run typecheck\` — clean across all 5 packages.
+- [x] \`npm run lint\` — clean.
+- [x] \`npm run test:coverage\` — visuals at 100% / 100% / 100% / 100%.
+- [x] \`npm run build\` — clean.
+- [x] Fixture roundtrip test passes — engine emit shape unchanged.
+
+Note: v7-branch PRs do not run CI per repo convention; checks run on the eventual v7 → master integration PR.
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR URL returned**
+
+Capture the PR URL and report back. Done.
+
+---
+
+## Self-review checklist
+
+Before opening the PR, walk this list one more time:
+
+- [ ] Every moved file's `TuringGraph` references replaced with `Graph` from `@turing-machine-js/machine`.
+- [ ] No source files still reference `./types.ts` (machines-demo-local).
+- [ ] `packages/visuals/src/index.ts` exports the full public surface (5 types, 7 functions).
+- [ ] No machines-demo source files were modified — this PR is engine-side only.
+- [ ] Coverage at 100/100/100/100 for the visuals package.
+- [ ] CHANGELOG entry under `[Unreleased]` exists and references the issue.
+- [ ] All `Task N` commits have clear, scope-prefixed messages (`feat(visuals):` or `docs(visuals):`).
+- [ ] No commit includes `🤖 Generated with Claude Code` or any Claude attribution footer (per global CLAUDE.md).
+- [ ] No `--no-verify` or signature-skip flags used.
+
+---
+
+## What happens after this lands
+
+1. **Lockstep publish** with the next engine v7 alpha (bump `7.0.0-alpha.6` → `7.0.0-alpha.7`, etc.) via `lerna publish from-package --dist-tag next`. Same release PR that bumps engine packages bumps visuals.
+2. **Follow-up plan** for `recordSnippet` + Snippet/Frame schema (issue #204 step 3). Will be saved at `docs/superpowers/plans/<date>-visuals-recordsnippet.md`.
+3. **Follow-up PR in machines-demo** (issue #204 step 2) — drop the local copies of the moved modules + rules doc; depend on `@turing-machine-js/visuals` from npm `next`.
+4. **Tiny edit to merged machines-demo spec** (`docs/superpowers/specs/2026-05-27-landing-page-design.md`) — remove the stray `engine` field reference from the snippet-schema decision now that the upstream schema dropped it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2781,6 +2781,10 @@
       "resolved": "packages/machine",
       "link": true
     },
+    "node_modules/@turing-machine-js/visuals": {
+      "resolved": "packages/visuals",
+      "link": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -10693,6 +10697,17 @@
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
+      }
+    },
+    "packages/visuals": {
+      "name": "@turing-machine-js/visuals",
+      "version": "7.0.0-alpha.6",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@turing-machine-js/machine": "^7.0.0-alpha.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "docs:states": "node ./scripts/build-states-md.mjs",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit -p packages/machine/tsconfig.json && tsc --noEmit -p packages/builder/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers-bare/tsconfig.json"
+    "typecheck": "tsc --noEmit -p packages/machine/tsconfig.json && tsc --noEmit -p packages/builder/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers/tsconfig.json && tsc --noEmit -p packages/library-binary-numbers-bare/tsconfig.json && tsc --noEmit -p packages/visuals/tsconfig.json"
   },
   "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "workspaces": [

--- a/packages/visuals/CHANGELOG.md
+++ b/packages/visuals/CHANGELOG.md
@@ -8,4 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Initial extraction from machines-demo: `HighlightOps` / `IndicatorOps` / `RecordedOp` / `NodeKey` / `HighlightClass` / `GraphIndexes` / `GraphHighlight` types, `indexGraph`, `applyHighlight`, `applyIndicator`, `bareIdOf`, `highlightExpand`, `equivalentIds`, `recordingOps`. Rules doc moved into `docs/graph-highlight-and-breakpoints.md`. Closes [#204](https://github.com/mellonis/turing-machine-js/issues/204) (extraction step; recordSnippet follows in a separate PR).
+- Initial extraction from machines-demo (highlight + graph-indexing surface):
+  - Types: `HighlightOps`, `IndicatorOps`, `RecordedOp`, `NodeKey`, `HighlightClass`, `GraphIndexes`, `GraphHighlight`, `TapeSnapshot`.
+  - Functions: `indexGraph`, `applyHighlight`, `applyIndicator`, `bareIdOf`, `highlightExpand`, `equivalentIds`, `recordingOps`.
+  - Rules doc at `docs/graph-highlight-and-breakpoints.md`.
+- Initial `recordSnippet` surface (folded in from step 3 of #204 — first published alpha ships with a complete v1 API ready to feed downstream consumers):
+  - Types: `Snippet` (`{ version: 1, name?, graph, alphabets, frames }`), `Frame` (`{ step, tape, commands?, highlight, log? }`), `RecordSnippetOptions`.
+  - `Frame.commands` carries per-tape `{ movement, read, write }` — both sides of the cell, so players can step forward and backward without recomputing from neighbouring frames.
+  - `recordSnippet({ machine, initialState, graph, alphabets, name?, maxSteps?, log? }) => Snippet` runs `machine.runStepByStep` and captures one frame per iter plus a frame-0 initial-state snapshot.
+  - Composable formatter primitives: `formatCommand(tapeCommand)` + `formatStep(machineState)` — match the engine's edge-label notation (`[reads] → [writes]/[moves]`) so logged steps line up with rendered graph edges.
+
+Closes [#204](https://github.com/mellonis/turing-machine-js/issues/204).

--- a/packages/visuals/CHANGELOG.md
+++ b/packages/visuals/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial extraction from machines-demo: `HighlightOps` / `IndicatorOps` / `RecordedOp` / `NodeKey` / `HighlightClass` / `GraphIndexes` / `GraphHighlight` types, `indexGraph`, `applyHighlight`, `applyIndicator`, `bareIdOf`, `highlightExpand`, `equivalentIds`, `recordingOps`. Rules doc moved into `docs/graph-highlight-and-breakpoints.md`. Closes [#204](https://github.com/mellonis/turing-machine-js/issues/204) (extraction step; recordSnippet follows in a separate PR).

--- a/packages/visuals/README.md
+++ b/packages/visuals/README.md
@@ -1,0 +1,21 @@
+# @turing-machine-js/visuals
+
+Pure highlight + graph-indexing logic for [`@turing-machine-js/machine`](../machine). No DOM, no Svelte, no Mermaid — consumers bring their own renderer and DOM applier.
+
+## Scope
+
+Types and pure functions for:
+- Indexing an engine `Graph` for wrapper/bare lookup (`indexGraph`, `bareIdOf`, `highlightExpand`).
+- Applying highlight + indicator operations against a renderer-agnostic `HighlightOps` interface (`applyHighlight`, `applyIndicator`).
+
+See [`docs/graph-highlight-and-breakpoints.md`](./docs/graph-highlight-and-breakpoints.md) for the full set of rules these functions satisfy.
+
+## Versioning
+
+Lockstep with `@turing-machine-js/machine`.
+
+## Install
+
+```sh
+npm install @turing-machine-js/visuals @turing-machine-js/machine
+```

--- a/packages/visuals/docs/graph-highlight-and-breakpoints.md
+++ b/packages/visuals/docs/graph-highlight-and-breakpoints.md
@@ -1,0 +1,272 @@
+# Graph highlight and breakpoint rules
+
+> Canonical reference for every CSS class the demo applies to the rendered state-graph SVG, when each class fires, and how the breakpoint engine-side / UI-side state stays consistent. Companion to [`execution-model.md`](./execution-model.md) (modes + transitions) and [`machine-graph-palette.md`](./machine-graph-palette.md) (color tokens). Source files: `src/components/MachineGraph.svelte` (the apply-highlight + cache-build + indicator effects), `src/components/MachineView.svelte` (derives `graphHighlight`, owns the `breakpoints` set), `src/lib/machineWorker.ts` (`onPauseFn` + `toggleBreakpoint`), `src/lib/graphUtils.ts` (canonicalization helpers).
+
+## 1. Node-id conventions
+
+The engine's `Graph.nodes` keys are positive integer ids assigned at graph-build time. The demo also recognizes three synthetic ids:
+
+| Id range | Kind | Where it comes from | Click target? |
+|---|---|---|---|
+| `> 0` | Regular state, wrapper, or bare | `State.toGraph` walks reachable States | yes |
+| `0` | Halt singleton (`haltState`) | Engine sentinel, process-wide | no — global, not per-machine |
+| `< 0` | Halt marker (`isHaltMarker: true`, id = `-frameId`) | `toGraph` rewrites in-frame halts so they land inside the subgraph cluster instead of the global singleton | no — collapses to `haltState` at runtime |
+| `'idle'` | Synthetic entry sentinel | `toGraph` always emits a stadium-shape `idle` node with `idle -. enter .-> sN` | no |
+
+Click handlers are attached only to nodes whose key is `typeof === 'number' && > 0` — see `MachineGraph.svelte`'s cache-build `$effect`.
+
+## 2. Wrapper / bare equivalence
+
+A `State.withOverriddenHaltState(continuation)` produces a *wrapper* State that shares its `#debugRef` cell with the bare engine-side (`State.ts:391`: `state.#debugRef = bare.#debugRef`). Setting `wrapper.debug.before = true` and `bare.debug.before = true` mutate the SAME cell.
+
+The demo collapses this into a single breakpoint *equivalence class*:
+
+- The **canonical id** for a class is the bare's id. `bareIdOf(id, graph)` returns the bare id for a wrapper, self otherwise.
+- The `breakpoints: SvelteMap<number, { before: boolean; after: boolean }>` (in `MachineView`) holds canonical bare ids → per-kind state. Entries with both kinds off are pruned. `breakpointIndicatorSet` is the `$derived` set of "any kind set" canonical ids, passed to the indicator effect.
+- The **indicator effect** (in `MachineGraph`) renders the `mg-breakpoint` mark on every class member (bare + every wrapper sharing that bare via `bareStateId`): for each cached node, it normalizes the node's id via `bareIdOf` and checks the indicator set. The set is kind-agnostic — the future per-kind dots (Layer N) will use the Map directly.
+- The **highlight effect** uses an **asymmetric** expansion via `highlightExpand`:
+
+  | Source side | Returns | Why |
+  |---|---|---|
+  | Wrapper | `[wrapper, bare]` | wrapper-entry pause is the visually joined pair — light up both |
+  | Bare | `[bare]` only | when the engine is genuinely on the bare (loop iter), the wrapper isn't active |
+  | Regular state | `[self]` | no class membership |
+
+This means right-clicking a wrapper or a bare opens the menu over the same engine breakpoint class, both nodes show the indicator, but the strong-highlight only "leaks" wrapper → bare, never bare → wrappers.
+
+**Halt class.** The halt singleton (`id 0`) and every halt marker (`id < 0`, one per frame; see §1) form an additional equivalence class — they all collapse to the engine-wide `haltState` at runtime. `bareIdOf` maps any negative id to `0`; `equivalentIds(0, g)` returns `[0, ...all halt markers]`. The breakpoint Map stores canonical `0`; the indicator therefore lights up the singleton AND every halt marker simultaneously. `MachineView`'s `onToggleBreakpoint` also normalizes negative ids to `0` before forwarding to the worker, so the worker (which only has `id 0` in `collectStates`) sees a single canonical toggle regardless of which halt-class node the user right-clicked.
+
+**Class membership in the menu.** The context menu (§12) shows a "Shared with: …" info line listing other class members' names — so the user can see at a glance that flipping the BP also flips the sibling. For the halt class it instead shows "Global — affects all halts in the runtime", since `haltState` is a process-wide singleton rather than a per-graph state. Singleton classes (regular states, no wrappers / no sharing) omit the info line.
+
+## 3. CSS classes applied to SVG elements
+
+All classes are added imperatively by the apply-highlight or indicator `$effect`s in `MachineGraph.svelte`. Styling lives in the same component's `<style>` block; tokens in `app.css`.
+
+| Class | Target | When | Cleared by |
+|---|---|---|---|
+| `mg-breakpoint` | `g.node` | Set on every member of an equivalence class whose canonical id is in `breakpoints` | Indicator effect re-runs on `breakpoints` change |
+| `mg-highlight-from` | `g.node` (+ `'idle'` sentinel) | Source side of the just-fired or about-to-fire transition | Cleared at the top of every apply-highlight run |
+| `mg-highlight-to` | `g.node` | Destination side of same | Same |
+| `mg-highlight-strong` | `g.node` | The "focal" node of the highlight triple (set on the side matching `h.strong`, plus any class member via `highlightExpand` if source is wrapper) | Same |
+| `mg-highlight-edge` | `path` + `g.label` of edge | The edge connecting from→to in graph data-id space (`L_${from}_${to}_*`); also wrapper→bare "call" edge when `toEqIds` expanded the pair | Same |
+| `mg-frame-active` | `g.cluster` of a callable-subtree subgraph | The strong node (via canonical id) lives inside the frame — or the destination return chain detected a post-pop arrival from that frame | Same |
+| `mg-hl-arrow-shape` | inside cloned `<marker>` | Materialized once per render at cache-build time; switched in via `marker-end` swap on highlighted paths (browsers without `context-stroke`) | Marker swap reverts via `data-mg-orig-marker-end` on clear |
+
+## 4. `graphHighlight` shape (the input to the effect)
+
+Derived in `MachineView.svelte` from `(executionMode, currentStateId, nextStateId, prevStateId, pauseBefore, graph)`:
+
+```ts
+type GraphHighlight = {
+  fromId: number | 'idle';   // source-side node
+  toId: number | null;       // destination-side node; null = no destination
+  strong: 'from' | 'to' | null;
+  paused: boolean;           // true → eligible for pulse + revisit logic
+};
+```
+
+| Mode | `fromId` | `toId` | `strong` | `paused` |
+|---|---|---|---|---|
+| `RUNNING_AUTO` | `currentStateId` | `nextStateId` | `'from'` | `false` |
+| `RUNNING_PAUSED`, `pauseBefore = true` (debug.before fired) | `prevStateId ?? 'idle'` | `currentStateId` | `'to'` | `true` |
+| `RUNNING_PAUSED`, `pauseBefore = false` (Step / pause-after / click-pause) | `currentStateId` | `nextStateId` | `'from'` | `true` |
+| Anything else | `null` (no highlight) |
+
+`currentStateId` / `nextStateId` come from the worker's `paused` / `idle` / `stepped` responses (worker uses `m.state.id` for current, `nextStateIdFromYield` for next).
+
+## 5. Halt-target retargeting
+
+`toGraph` rewrites halt-bound transitions of in-frame states so they land on the **frame's halt marker** (id `= -frameId`), not the real `haltState` (id `0`). The engine's runtime, however, reports `nextState.id === 0` for any halt. The apply-highlight effect bridges:
+
+```
+if toId === 0 AND fromId is in some frame F → toId := -F
+```
+
+This makes the visible edge (`L_sX_cF_*`) the one that lights up. If `fromId` isn't in any frame (e.g. `writeMarker → halt` in the callable-subtree example), `toId` stays `0` and falls into the halt-singleton branch (§7).
+
+## 6. Source return chain (engine just halted into a frame)
+
+Fires when `toId < 0` (an in-frame halt marker). The engine will pop the stack and resume at the wrapper's override. To visualize the post-pop trajectory **before** the next iter relocates the strong node:
+
+- Highlight the return arrow `L_w_${F}_s${wrapperId}` (dotted).
+- Mark each wrapper of frame F with `mg-highlight-to`.
+- Highlight each wrapper's call-target-replacement edge `L_s${wrapperId}_s${overrideId}` and the override node.
+
+When multiple wrappers share the bare, the demo highlights all of them — the engine's runtime choice depends on stack state, which the demo doesn't track.
+
+## 7. Destination return chain (engine just resumed at an override-target)
+
+Mirror of §6, fires when `toId > 0` AND `fromId` is in some frame F AND any wrapper of F has `overriddenHaltStateId === toId`. The engine *just popped* and is paused/running at the override. The straight `bare → override` edge doesn't exist in the graph — light up the actual visible path:
+
+- bare (`fromId`, gets `mg-highlight-from` from the standard pass)
+- bare → halt-marker edge `L_s${fromId}_c${F}`
+- halt-marker `c${F}` with `mg-highlight-to`
+- return arrow `L_w_${F}_s${wrapperId}` (dotted)
+- wrapper with `mg-highlight-to`
+- wrapper → override edge `L_s${wrapperId}_s${toId}`
+- override (= `toId`, gets `mg-highlight-to` + strong from standard pass)
+- frame F's cluster gets `mg-frame-active` (strong node lives outside the frame, so the frame-highlight pass otherwise wouldn't fire)
+
+## 8. Halt singleton (`toId === 0` with no retarget)
+
+If §5's retarget didn't fire (because `fromId` isn't in a frame), `toId` stays `0`. The halt-singleton node is then highlighted via a direct lookup `nodeCache.get(0)` instead of the normal `highlightExpand` path (which skips `id <= 0`). Without this branch the leading edge would light up while the singleton stays grey — visually orphaned.
+
+## 9. Frame-active rule
+
+`mg-frame-active` lights the cluster border of a callable-subtree subgraph. Fires when **either**:
+
+- the strong node's canonical id (`bareIdOf(strongId)`) lives inside the frame (`nodeFrameMap.get`), OR
+- the destination return chain (§7) detected a post-pop arrival from that frame.
+
+The first case handles "we're executing inside the subroutine"; the second handles "we just left the subroutine but the return-chain is still visualized."
+
+## 10. Wrapper-entry call-edge highlight
+
+When the to-side expansion via `highlightExpand` produced `[wrapper, bare]` (length 2), the connector between them is the wrapper→bare **call edge** `L_s${wrapperId}_s${bareId}`. The standard `highlightEdgeByDataId(fromKey, toKey)` call uses `toKey = s${wrapper}` so it wouldn't pick up this edge. An explicit follow-up call highlights it so the joined visual pair has a visible connector.
+
+## 11. Pause-revisit pulse
+
+A short opacity pulse fires on the strong element when the current paused event lands on the same state as the **immediately previous** paused event. Implementation:
+
+- `lastPausedStrongId: number | 'idle' | null` stored at module scope.
+- After applying highlight, if `h.paused && strongId === lastPausedStrongId`, call `strongEl.animate(...)`.
+- If `h.paused`, write `strongId` to `lastPausedStrongId`.
+
+**Important: use the raw `strongId`, NOT the canonical bare-id.** Wrapper-pause and bare-pause are visually distinct events even though they share `#debugRef`; pausing at the wrapper then continuing into the bare must NOT pulse (the engine moved between two different nodes). The frame-highlight pass uses the canonical for its lookup, but the pulse comparison uses the raw id.
+
+Idle events (`h.paused === false`) never update `lastPausedStrongId`, so an `idle` that happens to report the same state doesn't poison the next paused-event comparison.
+
+## 12. Right-click handling + listener lifecycle
+
+The cache-build `$effect` walks the rendered SVG and attaches a `contextmenu` listener to every `g.node` whose key is a number (positive state, halt singleton `0`, or negative halt marker — only the synthetic `'idle'` string sentinel is skipped). Left-click stays native (text selection, focus, scroll-tap) — only right-click opens the BP menu, matching IDE convention. Halt nodes participate so the user can set / clear the global haltState breakpoint from any halt-class node (see §2's halt-class paragraph); the per-kind menu items dispatch through `MachineView.onToggleBreakpoint`, which canonicalizes negative ids → `0` before the runner sees them. Because mermaid's `lastSource` cache can skip a re-render when the source is byte-identical (so the SAME DOM persists across builds), the effect must NOT just re-attach — that stacks listeners and a single right-click would trigger N menu opens.
+
+Pattern:
+
+1. Module-scope `clickListenersController: AbortController | null = null`.
+2. At the top of each cache-build pass: `clickListenersController?.abort()` (removes ALL listeners attached with that signal), then `new AbortController()`.
+3. Pass `{ signal }` to every `addEventListener`.
+4. Component unmount aborts in `onMount`'s cleanup.
+
+The right-click handler `preventDefault`s the native context menu, then sets `menuStateId`, `menuX`, `menuY` to render a custom menu at the cursor.
+
+### Menu state + lifecycle
+
+The menu is two `<button role="menuitem">` items inside a `<div role="menu">`, positioned `fixed` at clamped viewport coordinates. Items show `☑`/`☐` based on the current `before` / `after` bits in `breakpointKinds.get(bareIdOf(stateId))`. Picking an item calls `runner.toggleBreakpoint(stateId, kind)` and closes the menu. The worker echoes `breakpointToggled` with the same `kind`, which updates the `breakpoints` Map via `runner.onBreakpointToggled`.
+
+Closing happens via:
+- Picking a menu item (fires `onclick`, then `closeMenu`).
+- ESC keydown (global handler installed while menu open).
+- Outside `mousedown` (global handler; `mousedown` not `click` so item picks land first).
+
+A separate `AbortController` (`menuOutsideController`) gates the global handlers so they detach cleanly when the menu closes or the component unmounts.
+
+### Edge-clamped positioning
+
+After the menu mounts, a `$effect` measures `menuEl.getBoundingClientRect()` and shifts the position so the menu fits in the viewport (8px margin from each edge). The raw `menuX/menuY` are the right-click coordinates; the clamped `menuClampedX/menuClampedY` are what feed the inline `left`/`top` style. Re-runs when the raw coords change (subsequent right-click on a different node).
+
+## 13. Breakpoint replay across builds
+
+Building a new worker creates fresh State instances — any `debug.before`/`debug.after` set on the previous instances is gone. The `breakpoints` Map in `MachineView` is **user intent**, not run state, and survives:
+
+```ts
+async function reloadWorker(source = code) {
+  // ... await runner.build(source) ...
+  // Prune ids that don't exist in the new graph (user edited code).
+  for (const id of [...breakpoints.keys()]) {
+    if (!res.graph.nodes[id]) breakpoints.delete(id);
+  }
+  // Replay surviving kinds via toggleBreakpoint. Fresh States have no
+  // debug set, so each toggle flips off→on. One call per stored kind per
+  // class — the canonical-id keying prevents double-flips of the shared
+  // #debugRef.
+  for (const [id, kinds] of breakpoints) {
+    if (kinds.before) runner.toggleBreakpoint(id, 'before');
+    if (kinds.after) runner.toggleBreakpoint(id, 'after');
+  }
+}
+```
+
+On build **failure** the Map IS cleared — there's no graph to prune against.
+
+The runner's echo `onBreakpointToggled` normalizes the echoed `stateId` via `bareIdOf(graph)` and updates only the matching `kind` bit, so the Map always holds canonical ids regardless of which class member the user actually right-clicked.
+
+## 13a. After-fire + Step: synthetic-pause suppression
+
+The engine's `onIter` fires at end-of-iter — functionally the same execution point as an `onPause(after, K)` fire (both happen after the iter's transition has executed and `onStep` has run). When a user clicks Step from inside an after-fire BP pause, the worker's `onIterFn` would otherwise dispatch a SECOND synthetic pause at the same effective point, producing a duplicate log entry.
+
+Suppression: `onPauseFn` sets `dispatchedAfterThisIter = true` whenever the engine pause is after-side (`m.pause?.side === 'after'`). `onIterFn` reads the flag (and resets it) at iter boundary; when set AND `stepRequested` is true, it skips the synthetic dispatch **but keeps `stepRequested`** so the NEXT iter's `onIter` pauses naturally. Net effect: Step from an after-fire BP advances one iter (the right semantic for "next pause point"), instead of bouncing twice at the same point.
+
+`before`-fires don't set the flag — they fire mid-iter, distinct from end-of-iter, so the synthetic at end-of-iter is a genuinely different pause point and isn't suppressed.
+
+## 14. Worker-side wrapper handling (`onPauseFn`)
+
+The engine fires `onPause` on BOTH the wrapper entry (iter K) and the immediately following bare entry (iter K+1) when the shared `#debugRef.before === true`. The worker pauses at the wrapper (the user-facing call site) and suppresses ONE following bare entry via `pendingJoinedBareId: number | null`:
+
+```
+1. onPause(wrapper):  if node.isWrapper && node.bareStateId !== null:
+                        pendingJoinedBareId := bareStateId; dispatchPause
+2. onPause(bare):     if state.id === pendingJoinedBareId:
+                        clear flag; skip dispatch
+3. onPause(bare K+2): pendingJoinedBareId === null; dispatch normally
+```
+
+Subsequent bare→bare loop iters pause normally — that's a real iteration, not a joined entry.
+
+Also: when pausing at a wrapper, the worker swaps the dispatched `state` field to the bare's `name` (looked up via `currentGraph.nodes[bareStateId].name`). The log reads `paused at state walkToBlank ...` instead of `paused at state walkToBlank(writeMarker) ...` — the composite is engine implementation.
+
+`currentGraph` is the engine-v7 `Graph` snapshot captured at build time and retained worker-side specifically so `onPauseFn` can ask `isWrapper?` and look up names. Cleared in `reset()`.
+
+## 15. Post-machine differences
+
+`@post-machine-js/machine` installs an `Object.defineProperty` lockdown on every non-halt PostMachine-constructed State's `debug` property that funnels DIRECT writes through Post's registry (`pm.setBreakpoint` for un-shared, throw for shared). `haltState` is NOT locked — direct `turing.haltState.debug = boolean` writes go straight to the engine setter (post dropped the module-load halt lockdown alongside engine #207). Post wraps `run`'s `onPause` to filter via that registry — pauses fire only when the registered breakpoint matches.
+
+**Direct mutation of the engine's `DebugConfig` (e.g. `state.debug.before = true`) bypasses Post's lockdown** because the getter passes through; Post's wrapper then filters the engine's onPause out entirely. The worker's `toggleBreakpoint` therefore uses the SETTER form, reading both kinds and writing the merged shape so toggling one doesn't lose the other:
+
+```ts
+const debug = entry.state.debug;
+const currentBefore = debug.before === true;
+const currentAfter = debug.after === true;
+const newBefore = req.kind === 'before' ? !currentBefore : currentBefore;
+const newAfter = req.kind === 'after' ? !currentAfter : currentAfter;
+entry.state.debug = null;  // clear first — see below
+if (newBefore || newAfter) {
+  entry.state.debug = {
+    ...(newBefore ? { before: true } : {}),
+    ...(newAfter ? { after: true } : {}),
+  };
+}
+```
+
+The intermediate `state.debug = null` is **required for Post**: Post's lockdown's setter PUSHES onto the `#breakpoints` array rather than replacing, so without the clear, repeated toggles accumulate stale entries. Turing's setter just creates a fresh DebugConfig either way — the null assignment is a no-op for Turing but essential for Post.
+
+- Turing: setter creates/clears the engine's `DebugConfig` normally.
+- Post: setter is intercepted, routed to `pm.setBreakpoint(path, filter)` or `pm.clearBreakpoint(path)` — registry updated, lockdown's internal write via `withLockdownEscape` then updates the engine ref.
+
+Branchless form works for both engines.
+
+## 16. Quick rules summary
+
+A condensed cheat-sheet for the apply-highlight effect's decisions:
+
+```
+expand from-side via highlightExpand(fromId)            # asymmetric: wrapper → [wrapper, bare]
+expand to-side via highlightExpand(toId) if toId > 0    # bare stays alone
+
+mark fromEqIds as highlight-from (+ strong if h.strong === 'from')
+mark toEqIds as highlight-to    (+ strong if h.strong === 'to')
+
+mark halt-marker  (toId < 0) directly with highlight-to (+ strong if matching)
+mark halt-singleton (toId === 0) directly with highlight-to (+ strong if matching)
+
+highlight edge L_{fromKey}_{toKey}
+if toEqIds had wrapper+bare: also highlight L_s{wrapper}_s{bare}  (call edge)
+
+if toId < 0:    source return chain    (halt-marker entry → wrappers → overrides)
+if toId > 0 AND fromFrame matches some wrapper.overrideId:
+                destination return chain  (bare → halt-marker → wrapper → override; frame active)
+
+mark frame active for canonical(strongId)
+
+if h.paused AND strongId === lastPausedStrongId: pulse strongEl
+if h.paused: lastPausedStrongId := strongId           # raw, not canonical
+```

--- a/packages/visuals/package.json
+++ b/packages/visuals/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@turing-machine-js/visuals",
+  "version": "7.0.0-alpha.6",
+  "description": "Pure highlight + graph-indexing logic for @turing-machine-js/machine — no DOM, no renderer.",
+  "engines": {
+    "npm": ">=7.0.0"
+  },
+  "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
+  "homepage": "https://github.com/mellonis/turing-machine-js#readme",
+  "license": "GPL-3.0-or-later",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mellonis/turing-machine-js.git",
+    "directory": "packages/visuals"
+  },
+  "bugs": {
+    "url": "https://github.com/mellonis/turing-machine-js/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A%22pkg%3A+visuals%22+label%3Abug"
+  },
+  "keywords": [
+    "turing",
+    "machine",
+    "visualization"
+  ],
+  "peerDependencies": {
+    "@turing-machine-js/machine": "^7.0.0-alpha.6"
+  },
+  "scripts": {
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/visuals",
+    "prepublishOnly": "npm run build"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    }
+  }
+}

--- a/packages/visuals/src/applyHighlight.spec.ts
+++ b/packages/visuals/src/applyHighlight.spec.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyHighlight, applyIndicator } from './applyHighlight';
+import { indexGraph } from './graphIndexes';
+import { recordingOps, type RecordedOp } from './highlightOps';
+import type { GraphHighlight } from './types';
+import type { Graph } from '@turing-machine-js/machine';
+
+/**
+ * Rule tests for `applyHighlight`. Section numbers mirror
+ * `docs/graph-highlight-and-breakpoints.md` — any rule change must
+ * update both the doc and the matching `describe` block here.
+ *
+ * Fixtures come from `tests/fixtures/graphs/`, which are committed
+ * snapshots of `State.toGraph` output for each bundled example
+ * (regenerable via `REGEN_FIXTURES=1 npm test`). Using real engine output
+ * means these tests also catch any drift between engine emit and
+ * rule expectations.
+ *
+ * Helpful fixture ids for `turing-callable-subtree`:
+ *   bare walkToBlank             = 3   (frameId 3)
+ *   writeMarker (override)       = 4
+ *   wrapper walkToBlank(writeMarker) = 5  (bareStateId 3, overriddenHaltStateId 4)
+ *   halt singleton               = 0
+ *   frame halt marker            = -3  (id = -frameId)
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE_DIR = resolve(__dirname, './fixtures/graphs');
+
+function loadGraph(name: string): Graph {
+  return JSON.parse(readFileSync(resolve(FIXTURE_DIR, `${name}.json`), 'utf-8'));
+}
+
+/** Run `applyHighlight` with a recording ops impl, return the ordered ops list. */
+function run(highlight: GraphHighlight | null, graph: Graph, prev: number | 'idle' | null = null): {
+  ops: RecordedOp[];
+  next: number | 'idle' | null;
+} {
+  const indexes = indexGraph(graph);
+  const { highlight: opsImpl, record } = recordingOps();
+  const { nextPrevStrongId } = applyHighlight(highlight, graph, indexes, prev, opsImpl);
+  return { ops: record, next: nextPrevStrongId };
+}
+
+describe('applyHighlight', () => {
+  describe('null/empty highlight', () => {
+    it('returns no-op with nextPrev=null when highlight is null', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops, next } = run(null, g, 3);
+      expect(ops).toEqual([]);
+      expect(next).toBeNull();
+    });
+  });
+
+  describe('§5 halt-target retargeting', () => {
+    it('rewrites toId=0 to -frameId when fromId is in a frame', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Bare walkToBlank (id 3, frameId 3) halts → engine reports toId=0,
+      // should retarget to -3 (frame halt marker).
+      const { ops } = run({ fromId: 3, toId: 0, strong: 'from', paused: false }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      // halt marker -3 gets highlight-to; halt singleton 0 does not.
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: -3, cls: 'mg-highlight-to' });
+      expect(classOps).not.toContainEqual({ op: 'addNodeClass', id: 0, cls: 'mg-highlight-to' });
+    });
+
+    it('does NOT retarget when fromId is outside any frame', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // writeMarker (id 4) is the wrapper's override-target; sits outside
+      // the frame (frameId: null), so its halt→halt-singleton stays as id 0.
+      const { ops } = run({ fromId: 4, toId: 0, strong: 'from', paused: false }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 0, cls: 'mg-highlight-to' });
+    });
+  });
+
+  describe('§2 + §3 wrapper/bare equivalence (asymmetric)', () => {
+    it('wrapper-strong expands to [wrapper, bare] — both get highlight-to + strong', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Wrapper-entry pause: idle → wrapper(5), pauseBefore strong=to.
+      const { ops } = run({ fromId: 'idle', toId: 5, strong: 'to', paused: true }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-to' });
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-strong' });
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 3, cls: 'mg-highlight-to' });
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 3, cls: 'mg-highlight-strong' });
+    });
+
+    it('bare-strong stays bare only — does NOT light up wrapper', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Bare-loop pause: prev=bare(3), to=bare(3), pauseBefore strong=to.
+      const { ops } = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 3, cls: 'mg-highlight-to' });
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 3, cls: 'mg-highlight-strong' });
+      // Wrapper 5 gets NOTHING from the to-side expansion.
+      expect(classOps).not.toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-to' });
+      expect(classOps).not.toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-strong' });
+    });
+  });
+
+  describe('§6 source return chain (toId < 0)', () => {
+    it('lights up return arrow + wrapper + override edge + override target', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Just-fired halt-bound transition: from=bare(3), to=halt-marker(-3),
+      // strong=from (pause-after-style).
+      const { ops } = run({ fromId: 3, toId: -3, strong: 'from', paused: true }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      const edgeOps = ops.filter((o) => o.op === 'highlightEdge');
+      // Return arrow w_3 → wrapper(5).
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 'w_3', toKey: 's5' });
+      // Wrapper gets highlight-to.
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-to' });
+      // Wrapper → override edge.
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 's5', toKey: 's4' });
+      // Override (writeMarker) gets highlight-to.
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 4, cls: 'mg-highlight-to' });
+    });
+  });
+
+  describe('§7 destination return chain (paused at override after pop)', () => {
+    it('lights the full path bare → halt-marker → return → wrapper → override + frame', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Paused-before writeMarker: prev=bare(3) (last yield was bare's halt),
+      // current=writeMarker(4). strong=to. Bare is in frame 3; wrapper 5's
+      // override is 4 → matches.
+      const { ops } = run({ fromId: 3, toId: 4, strong: 'to', paused: true }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      const edgeOps = ops.filter((o) => o.op === 'highlightEdge');
+      const frameOps = ops.filter((o) => o.op === 'markFrameActive');
+
+      // Halt marker lit.
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: -3, cls: 'mg-highlight-to' });
+      // bare → halt-marker edge.
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 's3', toKey: 'c3' });
+      // Return arrow.
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 'w_3', toKey: 's5' });
+      // Wrapper highlight-to.
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 5, cls: 'mg-highlight-to' });
+      // Wrapper → override edge.
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 's5', toKey: 's4' });
+      // Frame active (override sits outside frame, but the chain fired so
+      // we still mark the frame to show "we came out of THIS subtree").
+      expect(frameOps).toContainEqual({ op: 'markFrameActive', frameId: 3 });
+    });
+
+    it('does NOT fire when fromId is not in any frame', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // From idle → writeMarker(4): no frame on the from side, no chain.
+      const { ops } = run({ fromId: 'idle', toId: 4, strong: 'to', paused: true }, g);
+      const edgeOps = ops.filter((o) => o.op === 'highlightEdge');
+      expect(edgeOps).not.toContainEqual({ op: 'highlightEdge', fromKey: 's3', toKey: 'c3' });
+      expect(edgeOps).not.toContainEqual({ op: 'highlightEdge', fromKey: 'w_3', toKey: 's5' });
+    });
+  });
+
+  describe('§8 halt singleton (toId === 0, no retarget)', () => {
+    it('marks the halt singleton with highlight-to + strong', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // writeMarker (id 4, no frame) → halt singleton (0). strong=from
+      // (pause-after applying writeMarker's command).
+      const { ops } = run({ fromId: 4, toId: 0, strong: 'from', paused: true }, g);
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: 0, cls: 'mg-highlight-to' });
+      // strong is 'from', so halt singleton is not strong.
+      expect(classOps).not.toContainEqual({ op: 'addNodeClass', id: 0, cls: 'mg-highlight-strong' });
+    });
+  });
+
+  describe('§9 frame-active', () => {
+    it('marks the frame when canonical strong is inside it (wrapper case)', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // Wrapper-entry pause: strong=wrapper(5). bareIdOf(5)=3. nodeFrameMap[3]=3.
+      const { ops } = run({ fromId: 'idle', toId: 5, strong: 'to', paused: true }, g);
+      const frameOps = ops.filter((o) => o.op === 'markFrameActive');
+      expect(frameOps).toContainEqual({ op: 'markFrameActive', frameId: 3 });
+    });
+
+    it('marks the frame when bare is strong', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops } = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g);
+      const frameOps = ops.filter((o) => o.op === 'markFrameActive');
+      expect(frameOps).toContainEqual({ op: 'markFrameActive', frameId: 3 });
+    });
+
+    it('does NOT mark a frame when strong is outside any frame', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // writeMarker (4, no frame) is strong.
+      const { ops } = run({ fromId: 4, toId: 0, strong: 'from', paused: true }, g);
+      const frameOps = ops.filter((o) => o.op === 'markFrameActive');
+      expect(frameOps).toEqual([]);
+    });
+  });
+
+  describe('§10 wrapper-entry call edge', () => {
+    it('highlights the wrapper → bare call edge when to-side expanded to both', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops } = run({ fromId: 'idle', toId: 5, strong: 'to', paused: true }, g);
+      const edgeOps = ops.filter((o) => o.op === 'highlightEdge');
+      expect(edgeOps).toContainEqual({ op: 'highlightEdge', fromKey: 's5', toKey: 's3' });
+    });
+
+    it('does NOT highlight a call edge when to-side is bare only', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops } = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g);
+      const edgeOps = ops.filter((o) => o.op === 'highlightEdge');
+      // No s5→s3 call edge (bare doesn't expand to include wrapper).
+      expect(edgeOps).not.toContainEqual({ op: 'highlightEdge', fromKey: 's5', toKey: 's3' });
+    });
+  });
+
+  describe('§11 pause-revisit pulse (raw, not canonical)', () => {
+    it('does NOT pulse on wrapper-pause → bare-pause transition', () => {
+      const g = loadGraph('turing-callable-subtree');
+      // First pause: wrapper-entry. prev=null → no pulse. nextPrev=5 (wrapper).
+      const r1 = run({ fromId: 'idle', toId: 5, strong: 'to', paused: true }, g, null);
+      expect(r1.ops.find((o) => o.op === 'pulse')).toBeUndefined();
+      expect(r1.next).toBe(5);
+      // Second pause: bare loop iter. prev=5 (wrapper), strong=3 (bare).
+      // 5 !== 3 → NO pulse, even though they share #debugRef.
+      const r2 = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g, r1.next);
+      expect(r2.ops.find((o) => o.op === 'pulse')).toBeUndefined();
+      expect(r2.next).toBe(3);
+    });
+
+    it('pulses on same-state revisit (bare → bare)', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const r1 = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g, null);
+      expect(r1.ops.find((o) => o.op === 'pulse')).toBeUndefined();
+      const r2 = run({ fromId: 3, toId: 3, strong: 'to', paused: true }, g, r1.next);
+      expect(r2.ops).toContainEqual({ op: 'pulse', id: 3 });
+    });
+
+    it('does NOT update prev on non-paused (idle / RUNNING_AUTO) events', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const r = run({ fromId: 3, toId: 3, strong: 'from', paused: false }, g, 5);
+      expect(r.next).toBe(5); // unchanged
+    });
+
+    it('resets prev to null on null highlight', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const r = run(null, g, 3);
+      expect(r.next).toBeNull();
+    });
+  });
+
+  describe('scroll-into-view', () => {
+    it('scrolls to the strong node', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops } = run({ fromId: 3, toId: 4, strong: 'to', paused: true }, g);
+      expect(ops).toContainEqual({ op: 'scrollIntoView', id: 4 });
+    });
+
+    it('does not scroll when strong is null (no highlight)', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { ops } = run(null, g);
+      expect(ops.find((o) => o.op === 'scrollIntoView')).toBeUndefined();
+    });
+  });
+
+  describe('applyIndicator (§2 canonical breakpoint + §3 indicator class)', () => {
+    it('marks every member of the equivalence class when canonical id is in set', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { indicator, record } = recordingOps();
+      // BP set has the bare id (3). Both wrapper (5) and bare (3) should turn on.
+      applyIndicator(new Set([3]), g, [3, 4, 5, -3, 0, 'idle'], indicator);
+      const onIds = record
+        .filter((r): r is Extract<RecordedOp, { op: 'setBreakpoint' }> => r.op === 'setBreakpoint' && r.on)
+        .map((r) => r.id);
+      expect(onIds).toContain(3);
+      expect(onIds).toContain(5);
+      // writeMarker (4), halt-marker (-3), halt (0), idle: never on.
+      expect(onIds).not.toContain(4);
+      expect(onIds).not.toContain(-3);
+      expect(onIds).not.toContain(0);
+      expect(onIds).not.toContain('idle');
+    });
+
+    it('clears every node when the set is empty', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { indicator, record } = recordingOps();
+      applyIndicator(new Set(), g, [3, 4, 5, 'idle'], indicator);
+      const onCount = record.filter((r) => r.op === 'setBreakpoint' && r.on).length;
+      expect(onCount).toBe(0);
+      // Every node still gets an explicit off call (idempotent clears).
+      expect(record.length).toBe(4);
+    });
+
+    // machines-demo#37 — halt singleton (id 0) is a valid breakpoint
+    // target (engine-wide haltState). The set stores canonical id 0;
+    // both the halt singleton AND every halt marker (negative ids; one
+    // per frame) collapse to that class via `bareIdOf(-N, g) === 0`.
+    it('marks halt singleton AND every halt marker when 0 is in the set', () => {
+      const g = loadGraph('turing-callable-subtree');
+      const { indicator, record } = recordingOps();
+      applyIndicator(new Set([0]), g, [3, 4, 5, -3, 0, 'idle'], indicator);
+      const onIds = record
+        .filter((r): r is Extract<RecordedOp, { op: 'setBreakpoint' }> => r.op === 'setBreakpoint' && r.on)
+        .map((r) => r.id);
+      expect(onIds).toContain(0); // halt singleton
+      expect(onIds).toContain(-3); // halt marker for frame 3
+      // Regular and wrapper / bare nodes: never on.
+      expect(onIds).not.toContain(3);
+      expect(onIds).not.toContain(4);
+      expect(onIds).not.toContain(5);
+      expect(onIds).not.toContain('idle');
+    });
+  });
+
+  describe('regression: simple machines (no callable subtree)', () => {
+    it('lights from + to + strong + edge for a plain RUNNING_AUTO tick', () => {
+      const g = loadGraph('turing-replace-b');
+      // Pick any two ids that have a transition between them.
+      const nodes = Object.values(g.nodes).filter((n) => !n.isHalt && !n.isHaltMarker);
+      const src = nodes.find((n) => n.transitions.length > 0)!;
+      const transition = src.transitions[0];
+      const dst = transition.nextStateId;
+      const { ops } = run(
+        { fromId: src.id, toId: dst, strong: 'from', paused: false },
+        g,
+      );
+      const classOps = ops.filter((o) => o.op === 'addNodeClass');
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: src.id, cls: 'mg-highlight-from' });
+      expect(classOps).toContainEqual({ op: 'addNodeClass', id: src.id, cls: 'mg-highlight-strong' });
+    });
+  });
+});

--- a/packages/visuals/src/applyHighlight.ts
+++ b/packages/visuals/src/applyHighlight.ts
@@ -1,0 +1,217 @@
+import type { GraphHighlight } from './types';
+import type { Graph } from '@turing-machine-js/machine';
+import type { GraphIndexes } from './graphIndexes';
+import type { HighlightOps, IndicatorOps, NodeKey } from './highlightOps';
+import { bareIdOf, highlightExpand } from './graphUtils';
+
+/**
+ * Pure highlight-rule evaluator. Given the current `highlight` (from
+ * `MachineView`'s `$derived`), the engine `graph`, derived `indexes`,
+ * and the previous strong-id (for pause-revisit pulse detection), emit
+ * a sequence of `ops` calls describing the resulting visual state.
+ *
+ * Strictly additive — the caller is expected to clear previously-applied
+ * highlight classes / edge marks / cluster activations BEFORE invoking
+ * this function. The function never reads back from the consumer.
+ *
+ * Returns the new prev-strong-id to thread into the next call. Pulse
+ * comparison uses the RAW strong id (not canonical), so wrapper-pause
+ * and bare-pause register as different positions and don't pulse each
+ * other. Updates only when `highlight.paused === true`; non-paused
+ * events (idle / RUNNING_AUTO ticks) leave it untouched. Null highlight
+ * resets it to null.
+ *
+ * See `docs/graph-highlight-and-breakpoints.md` for the 16 rules
+ * enumerated.
+ */
+export function applyHighlight(
+  highlight: GraphHighlight | null,
+  graph: Graph | null,
+  indexes: GraphIndexes,
+  prevStrongId: NodeKey | null,
+  ops: HighlightOps,
+): { nextPrevStrongId: NodeKey | null } {
+  if (!highlight || !graph) {
+    return { nextPrevStrongId: null };
+  }
+
+  // §5 Halt-target retargeting: real halt (id 0) reached from an in-frame
+  // state retargets to the frame's halt marker (id = -frameId), so the
+  // visible edge lands inside the cluster.
+  let toId: number | null = highlight.toId;
+  if (toId === 0 && typeof highlight.fromId === 'number') {
+    const fromFrameId = indexes.nodeFrameMap.get(highlight.fromId);
+    if (fromFrameId !== undefined) toId = -fromFrameId;
+  }
+
+  // §2 Equivalence-class expansion (asymmetric, via highlightExpand):
+  //   wrapper → [wrapper, bare]  (joined visual pair for wrapper-entry pause)
+  //   bare    → [bare]           (engine genuinely on the bare; no wrapper sync)
+  // From-side expansion only fires for positive numeric ids; the 'idle'
+  // sentinel is handled directly below. Halt markers / singleton fall
+  // through the direct-lookup branches.
+  const fromEqIds = typeof highlight.fromId === 'number'
+    ? highlightExpand(highlight.fromId, graph)
+    : [];
+  const toEqIds = toId !== null && toId > 0
+    ? highlightExpand(toId, graph)
+    : [];
+
+  // §3 Class application — from side.
+  if (highlight.fromId === 'idle') {
+    ops.addNodeClass('idle', 'mg-highlight-from');
+    if (highlight.strong === 'from') ops.addNodeClass('idle', 'mg-highlight-strong');
+  }
+  for (const id of fromEqIds) {
+    ops.addNodeClass(id, 'mg-highlight-from');
+    if (highlight.strong === 'from') ops.addNodeClass(id, 'mg-highlight-strong');
+  }
+
+  // §3 + §8 Class application — to side. Halt markers (toId < 0) and the
+  // real halt singleton (toId === 0; only possible when §5 didn't retarget)
+  // bypass the equivalence-class expansion via direct lookup.
+  if (toId !== null && toId <= 0) {
+    ops.addNodeClass(toId, 'mg-highlight-to');
+    if (highlight.strong === 'to') ops.addNodeClass(toId, 'mg-highlight-strong');
+  }
+  for (const id of toEqIds) {
+    ops.addNodeClass(id, 'mg-highlight-to');
+    if (highlight.strong === 'to') ops.addNodeClass(id, 'mg-highlight-strong');
+  }
+
+  // Edge highlight: the data-id token form mermaid emits.
+  const fromKey = highlight.fromId === 'idle' ? 'idle' : `s${highlight.fromId}`;
+  const toKey =
+    toId === null ? null
+    : toId < 0 ? `c${-toId}`  // halt marker
+    : `s${toId}`;
+  if (toKey !== null) ops.highlightEdge(fromKey, toKey);
+
+  // §10 Wrapper-entry "call" edge: when to-side expanded to [wrapper, bare],
+  // light up the wrapper→bare connector so the joined pair has a visible link.
+  if (toEqIds.length > 1) {
+    const wrapperId = toEqIds.find((id) => graph.nodes[id]?.isWrapper);
+    const bareId = toEqIds.find((id) => !graph.nodes[id]?.isWrapper);
+    if (wrapperId !== undefined && bareId !== undefined) {
+      ops.highlightEdge(`s${wrapperId}`, `s${bareId}`);
+    }
+  }
+
+  // §6 Source return chain: just-fired transition landed on a frame's
+  // halt marker. Light up the post-pop trajectory before the next iter
+  // moves the strong node.
+  if (toId !== null && toId < 0) {
+    const frameId = -toId;
+    const wrappers = indexes.frameWrappersMap.get(frameId) ?? [];
+    for (const { wrapperId, overrideId } of wrappers) {
+      ops.highlightEdge(`w_${frameId}`, `s${wrapperId}`);
+      ops.addNodeClass(wrapperId, 'mg-highlight-to');
+      if (overrideId !== null) {
+        ops.highlightEdge(`s${wrapperId}`, `s${overrideId}`);
+        ops.addNodeClass(overrideId, 'mg-highlight-to');
+      }
+    }
+  }
+
+  // §7 Destination return chain: paused at a positive toId that's some
+  // wrapper W's override AND fromId is in W's frame — the engine just
+  // popped. The straight bare→override edge doesn't exist in the graph;
+  // light up the actual visible path bare → halt-marker → return →
+  // wrapper → override, plus the frame cluster.
+  if (typeof highlight.fromId === 'number' && toId !== null && toId > 0) {
+    const fromFrameId = indexes.nodeFrameMap.get(highlight.fromId);
+    if (fromFrameId !== undefined) {
+      const wrappers = indexes.frameWrappersMap.get(fromFrameId) ?? [];
+      const matching = wrappers.filter((w) => w.overrideId === toId);
+      if (matching.length > 0) {
+        ops.addNodeClass(-fromFrameId, 'mg-highlight-to');
+        ops.highlightEdge(`s${highlight.fromId}`, `c${fromFrameId}`);
+        for (const { wrapperId } of matching) {
+          ops.highlightEdge(`w_${fromFrameId}`, `s${wrapperId}`);
+          ops.addNodeClass(wrapperId, 'mg-highlight-to');
+          ops.highlightEdge(`s${wrapperId}`, `s${toId}`);
+        }
+        ops.markFrameActive(fromFrameId);
+      }
+    }
+  }
+
+  // §9 Frame-active for the strong node. Wrappers are outside any frame
+  // so canonicalize via bareIdOf so the wrapper-entry pause still lights
+  // up the bare's enclosing cluster.
+  const strongId = highlight.strong === 'from' ? highlight.fromId : highlight.toId;
+  const strongIdCanonical = typeof strongId === 'number'
+    ? bareIdOf(strongId, graph)
+    : strongId;
+  if (typeof strongIdCanonical === 'number') {
+    const frameId = indexes.nodeFrameMap.get(strongIdCanonical);
+    if (frameId !== undefined) ops.markFrameActive(frameId);
+  }
+
+  // §11 Pulse on same-state revisit. Uses RAW strongId — wrapper-pause
+  // and bare-pause are visually distinct positions even though they
+  // share #debugRef; pausing at wrapper then continuing into bare must
+  // not pulse. Idles never pulse and never update prevStrongId.
+  if (
+    highlight.paused
+    && strongId !== null
+    && strongId === prevStrongId
+    && strongId !== undefined
+  ) {
+    ops.pulse(strongId);
+  }
+
+  // Scroll-into-view target: for wrapper-entry pauses, scroll to the
+  // BARE (not the wrapper) so the focus matches the displayed state
+  // name. The worker's `resolveDisplayName` returns the bare's name
+  // for wrapper iters (so the log reads "paused at walkToBlank ..."),
+  // but `toId` is the wrapper's id and `highlightExpand` lights up
+  // both nodes as strong. Without this canonicalization the scroll
+  // lands on the wrapper while the log line and user's mental focus
+  // are on the bare. Halt-related ids (≤ 0) are scrolled to as-is —
+  // `bareIdOf` would collapse them all to the halt singleton, which
+  // is structurally separate from the in-frame halt marker the user
+  // is paused near.
+  if (strongId !== null) {
+    let scrollTarget: NodeKey = strongId;
+    if (typeof strongId === 'number' && strongId > 0) {
+      const node = graph.nodes[strongId];
+      if (node?.isWrapper && node.bareStateId !== null) {
+        scrollTarget = node.bareStateId;
+      }
+    }
+    ops.scrollIntoView(scrollTarget);
+  }
+
+  const nextPrevStrongId = highlight.paused ? strongId : prevStrongId;
+  return { nextPrevStrongId };
+}
+
+/**
+ * Pure breakpoint-indicator rule evaluator. For each cached node key,
+ * emit `ops.setBreakpoint(key, on)` reflecting whether the node's
+ * canonical bare-id is in the `breakpoints` set.
+ *
+ * The 'idle' string sentinel never carries a breakpoint. All numeric
+ * keys are valid BP-class members:
+ *   - positive id   → regular state; canonical via bareIdOf (wrappers
+ *                     collapse to bare)
+ *   - 0             → haltState singleton (engine-wide; canonical = 0)
+ *   - negative id   → halt marker (per-frame visualization sentinel;
+ *                     bareIdOf maps to 0 — same class as the singleton)
+ * Consumers pass their iterable of cached node keys (e.g. `nodeCache.keys()`).
+ */
+export function applyIndicator(
+  breakpoints: ReadonlySet<number>,
+  graph: Graph | null,
+  nodeIds: Iterable<NodeKey>,
+  ops: IndicatorOps,
+): void {
+  for (const key of nodeIds) {
+    const on =
+      typeof key === 'number'
+      && graph !== null
+      && breakpoints.has(bareIdOf(key, graph));
+    ops.setBreakpoint(key, on);
+  }
+}

--- a/packages/visuals/src/fixtures/graphs/post-walk-mark.json
+++ b/packages/visuals/src/fixtures/graphs/post-walk-mark.json
@@ -1,0 +1,108 @@
+{
+  "initialId": 6,
+  "alphabets": [
+    [
+      "␣",
+      "•"
+    ]
+  ],
+  "nodes": {
+    "0": {
+      "id": 0,
+      "name": "id:0",
+      "isHalt": true,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "6": {
+      "id": 6,
+      "name": "10",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "'•'",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": 7,
+          "id": "6.0"
+        },
+        {
+          "pattern": "B",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": 8,
+          "id": "6.1"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": [
+        "main"
+      ]
+    },
+    "7": {
+      "id": 7,
+      "name": "20",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "*",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 6,
+          "id": "7.0"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "8": {
+      "id": 8,
+      "name": "30",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "*",
+          "command": [
+            {
+              "symbol": "'•'",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": 0,
+          "id": "8.0"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    }
+  }
+}

--- a/packages/visuals/src/fixtures/graphs/turing-callable-subtree.json
+++ b/packages/visuals/src/fixtures/graphs/turing-callable-subtree.json
@@ -1,0 +1,108 @@
+{
+  "initialId": 5,
+  "alphabets": [
+    [
+      " ",
+      "a",
+      "b",
+      "*"
+    ]
+  ],
+  "nodes": {
+    "0": {
+      "id": 0,
+      "name": "id:0",
+      "isHalt": true,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "3": {
+      "id": 3,
+      "name": "walkToBlank",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": 3,
+      "transitions": [
+        {
+          "pattern": "B",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": -3,
+          "id": "3.0"
+        },
+        {
+          "pattern": "*",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 3,
+          "id": "3.1"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "4": {
+      "id": 4,
+      "name": "writeMarker",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "*",
+          "command": [
+            {
+              "symbol": "'*'",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": 0,
+          "id": "4.0"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "5": {
+      "id": 5,
+      "name": "walkToBlank(writeMarker)",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": true,
+      "bareStateId": 3,
+      "frameId": null,
+      "transitions": [],
+      "overriddenHaltStateId": 4,
+      "tags": []
+    },
+    "-3": {
+      "id": -3,
+      "name": "halt",
+      "isHalt": true,
+      "isHaltMarker": true,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": 3,
+      "transitions": [],
+      "overriddenHaltStateId": null,
+      "tags": []
+    }
+  }
+}

--- a/packages/visuals/src/fixtures/graphs/turing-copy-two-tapes.json
+++ b/packages/visuals/src/fixtures/graphs/turing-copy-two-tapes.json
@@ -1,0 +1,87 @@
+{
+  "initialId": 2,
+  "alphabets": [
+    [
+      "␣",
+      "a",
+      "b"
+    ],
+    [
+      "␣",
+      "a",
+      "b"
+    ]
+  ],
+  "nodes": {
+    "0": {
+      "id": 0,
+      "name": "id:0",
+      "isHalt": true,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "2": {
+      "id": 2,
+      "name": "id:2",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "'a',*",
+          "command": [
+            {
+              "symbol": "'a'",
+              "movement": "R"
+            },
+            {
+              "symbol": "'a'",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 2,
+          "id": "2.0"
+        },
+        {
+          "pattern": "'b',*",
+          "command": [
+            {
+              "symbol": "'b'",
+              "movement": "R"
+            },
+            {
+              "symbol": "'b'",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 2,
+          "id": "2.1"
+        },
+        {
+          "pattern": "B,*",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "S"
+            },
+            {
+              "symbol": "K",
+              "movement": "S"
+            }
+          ],
+          "nextStateId": 0,
+          "id": "2.2"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    }
+  }
+}

--- a/packages/visuals/src/fixtures/graphs/turing-replace-b.json
+++ b/packages/visuals/src/fixtures/graphs/turing-replace-b.json
@@ -1,0 +1,72 @@
+{
+  "initialId": 1,
+  "alphabets": [
+    [
+      "␣",
+      "a",
+      "b",
+      "c",
+      "*"
+    ]
+  ],
+  "nodes": {
+    "0": {
+      "id": 0,
+      "name": "id:0",
+      "isHalt": true,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [],
+      "overriddenHaltStateId": null,
+      "tags": []
+    },
+    "1": {
+      "id": 1,
+      "name": "id:1",
+      "isHalt": false,
+      "isHaltMarker": false,
+      "isWrapper": false,
+      "bareStateId": null,
+      "frameId": null,
+      "transitions": [
+        {
+          "pattern": "'b'",
+          "command": [
+            {
+              "symbol": "'*'",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 1,
+          "id": "1.0"
+        },
+        {
+          "pattern": "B",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "L"
+            }
+          ],
+          "nextStateId": 0,
+          "id": "1.1"
+        },
+        {
+          "pattern": "*",
+          "command": [
+            {
+              "symbol": "K",
+              "movement": "R"
+            }
+          ],
+          "nextStateId": 1,
+          "id": "1.2"
+        }
+      ],
+      "overriddenHaltStateId": null,
+      "tags": []
+    }
+  }
+}

--- a/packages/visuals/src/format.spec.ts
+++ b/packages/visuals/src/format.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Alphabet,
+  Tape,
+  TapeBlock,
+  TapeCommand,
+  TuringMachine,
+  State,
+  haltState,
+  movements,
+  symbolCommands,
+} from '@turing-machine-js/machine';
+import { formatCommand, formatStep } from './format';
+
+describe('formatCommand', () => {
+  it('formats a literal symbol write + right move', () => {
+    const tc = new TapeCommand({ symbol: 'X', movement: movements.right });
+    expect(formatCommand(tc)).toBe("'X'/R");
+  });
+
+  it('formats keep + stay as K/S', () => {
+    const tc = new TapeCommand({ movement: movements.stay });
+    // default symbol is symbolCommands.keep
+    expect(formatCommand(tc)).toBe('K/S');
+  });
+
+  it('formats erase + left as E/L', () => {
+    const tc = new TapeCommand({ symbol: symbolCommands.erase, movement: movements.left });
+    expect(formatCommand(tc)).toBe('E/L');
+  });
+
+  it('formats keep + right as K/R', () => {
+    const tc = new TapeCommand({ symbol: symbolCommands.keep, movement: movements.right });
+    expect(formatCommand(tc)).toBe('K/R');
+  });
+
+  it('formats a literal symbol write + left move', () => {
+    const tc = new TapeCommand({ symbol: 'a', movement: movements.left });
+    expect(formatCommand(tc)).toBe("'a'/L");
+  });
+});
+
+describe('formatStep', () => {
+  it("formats a single-tape iter: 'a' → 'b'/R", () => {
+    const alphabet = new Alphabet([' ', 'a', 'b']);
+    const tape = new Tape({ alphabet, symbols: ['a'] });
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({ tapeBlock });
+    const initialState = new State({
+      [tapeBlock.symbol(['a'])]: {
+        command: [{ symbol: 'b', movement: movements.right }],
+        nextState: haltState,
+      },
+    });
+    const gen = machine.runStepByStep({ initialState });
+    const m = gen.next().value!;
+
+    expect(formatStep(m)).toBe("['a'] → ['b']/[R]");
+  });
+
+  it('encodes keep as K when nextSymbol equals currentSymbol', () => {
+    const alphabet = new Alphabet([' ', 'a', 'b']);
+    const tape = new Tape({ alphabet, symbols: ['a'] });
+    const tapeBlock = TapeBlock.fromTapes([tape]);
+    const machine = new TuringMachine({ tapeBlock });
+    const initialState = new State({
+      [tapeBlock.symbol(['a'])]: {
+        command: [{ symbol: symbolCommands.keep, movement: movements.stay }],
+        nextState: haltState,
+      },
+    });
+    const gen = machine.runStepByStep({ initialState });
+    const m = gen.next().value!;
+
+    // keep → nextSymbols[0] === currentSymbols[0], so write cell is K
+    expect(formatStep(m)).toBe("['a'] → [K]/[S]");
+  });
+
+  it('formats a 2-tape iter with comma-separated entries', () => {
+    const alphabetA = new Alphabet([' ', 'a', 'b']);
+    const alphabetB = new Alphabet([' ', 'x', 'y']);
+    const tape1 = new Tape({ alphabet: alphabetA, symbols: ['a'] });
+    const tape2 = new Tape({ alphabet: alphabetB, symbols: ['x'] });
+    const tapeBlock = TapeBlock.fromTapes([tape1, tape2]);
+    const machine = new TuringMachine({ tapeBlock });
+    const initialState = new State({
+      [tapeBlock.symbol(['a', 'x'])]: {
+        command: [
+          { symbol: 'b', movement: movements.right },
+          { symbol: symbolCommands.keep, movement: movements.left },
+        ],
+        nextState: haltState,
+      },
+    });
+    const gen = machine.runStepByStep({ initialState });
+    const m = gen.next().value!;
+
+    expect(formatStep(m)).toBe("['a','x'] → ['b',K]/[R,L]");
+  });
+});

--- a/packages/visuals/src/format.ts
+++ b/packages/visuals/src/format.ts
@@ -1,0 +1,51 @@
+import { movements, symbolCommands, type MachineState, type TapeCommand } from '@turing-machine-js/machine';
+
+const MOVEMENT_LETTER = new Map<symbol, string>([
+  [movements.left, 'L'],
+  [movements.right, 'R'],
+  [movements.stay, 'S'],
+]);
+
+/**
+ * Render a single tape command in `WRITE/MOVE` form.
+ * - Write: `'X'` (literal symbol) | `K` (keep) | `E` (erase = write blank).
+ * - Move: `L` / `R` / `S` from `movements.*`.
+ *
+ * Matches the engine's edge-label vocabulary so formatted commands line up
+ * with the write/move cells in `toMermaid`-emitted edge labels.
+ */
+export function formatCommand(tapeCommand: TapeCommand): string {
+  let write: string;
+
+  if (tapeCommand.symbol === symbolCommands.keep) {
+    write = 'K';
+  } else if (tapeCommand.symbol === symbolCommands.erase) {
+    write = 'E';
+  } else {
+    write = `'${tapeCommand.symbol as string}'`;
+  }
+
+  const move = MOVEMENT_LETTER.get(tapeCommand.movement) ?? '?';
+
+  return `${write}/${move}`;
+}
+
+/**
+ * Render one step's edge-label notation: `[reads] → [writes]/[moves]`.
+ * Each role is wrapped in a single `[…]`; multi-tape entries are
+ * comma-separated inside the brackets.
+ *
+ * Matches the engine's `toMermaid` emit so logged steps line up with
+ * graph edge labels. Note: `nextSymbols` in `MachineState` is already
+ * resolved (keep → current symbol, erase → blank) — `K` is inferred
+ * by comparing `nextSymbols[i] === currentSymbols[i]`.
+ */
+export function formatStep(m: MachineState): string {
+  const reads = m.currentSymbols.map((s) => `'${s}'`).join(',');
+  const writes = m.nextSymbols
+    .map((s, i) => (s === m.currentSymbols[i] ? 'K' : `'${s}'`))
+    .join(',');
+  const moves = m.movements.map((mv) => MOVEMENT_LETTER.get(mv) ?? '?').join(',');
+
+  return `[${reads}] → [${writes}]/[${moves}]`;
+}

--- a/packages/visuals/src/format.ts
+++ b/packages/visuals/src/format.ts
@@ -1,6 +1,6 @@
 import { movements, symbolCommands, type MachineState, type TapeCommand } from '@turing-machine-js/machine';
 
-const MOVEMENT_LETTER = new Map<symbol, string>([
+export const MOVEMENT_LETTER = new Map<symbol, 'L' | 'R' | 'S'>([
   [movements.left, 'L'],
   [movements.right, 'R'],
   [movements.stay, 'S'],

--- a/packages/visuals/src/graphIndexes.ts
+++ b/packages/visuals/src/graphIndexes.ts
@@ -1,0 +1,84 @@
+import type { Graph } from '@turing-machine-js/machine';
+
+/**
+ * Derived lookups over an engine `Graph` that the highlight + indicator
+ * passes need. Recomputed once per Build; consumed read-only thereafter.
+ *
+ * Pure transformation of `graph` — same input always produces deep-equal
+ * output. See `docs/graph-highlight-and-breakpoints.md` for how each
+ * field is consumed.
+ */
+export type GraphIndexes = {
+  /** `GraphNode.id` → containing callable-subtree frameId. Only nodes
+   *  with `frameId !== null` (i.e. in-frame states) are present. */
+  nodeFrameMap: Map<number, number>;
+
+  /** frameId → list of wrappers calling into that frame, each with the
+   *  wrapper's id and its override-target id. Used by both source and
+   *  destination return-chain passes. */
+  frameWrappersMap: Map<number, Array<{ wrapperId: number; overrideId: number | null }>>;
+
+  /** Cluster label text (as emitted by `toMermaid`) → frameId. The
+   *  rendered SVG's `g.cluster` carries the label inside a
+   *  `<foreignObject>`; consumers match by `label.textContent.trim()` to
+   *  build their own `clusterCache: Map<frameId, SVGElement>`. */
+  frameLabelToId: Map<string, number>;
+};
+
+/**
+ * Walk the engine graph once and build all derived lookups. Cheap;
+ * intended to run on every Build (graph identity changes per build).
+ */
+export function indexGraph(graph: Graph | null): GraphIndexes {
+  const nodeFrameMap = new Map<number, number>();
+  const frameWrappersMap = new Map<
+    number,
+    Array<{ wrapperId: number; overrideId: number | null }>
+  >();
+  const frameLabelToId = new Map<string, number>();
+
+  if (!graph) return { nodeFrameMap, frameWrappersMap, frameLabelToId };
+
+  for (const node of Object.values(graph.nodes)) {
+    if (node.frameId !== null) nodeFrameMap.set(node.id, node.frameId);
+  }
+
+  // For each wrapper, append to its bare's frame entry. Multiple wrappers
+  // can share the same bare with different overrides; we record them all
+  // so the return-chain passes can highlight every candidate.
+  for (const node of Object.values(graph.nodes)) {
+    if (!node.isWrapper || node.bareStateId === null) continue;
+    const bare = graph.nodes[node.bareStateId];
+    if (!bare || bare.frameId === null) continue;
+    const entry = { wrapperId: node.id, overrideId: node.overriddenHaltStateId };
+    const arr = frameWrappersMap.get(bare.frameId);
+    if (arr) arr.push(entry);
+    else frameWrappersMap.set(bare.frameId, [entry]);
+  }
+
+  // Cluster label reconstruction: mirrors the engine's `toMermaid` emit
+  // (`callable subtree of NAME` for single-bare frames, `callable scope:
+  // A ∪ B ∪ …` for union frames; bare names sorted by id). Consumers
+  // need this to map mermaid's rendered cluster (whose own SVG id is the
+  // useless literal `[object Object]`) back to a frameId.
+  const bareIds = new Set<number>();
+  for (const n of Object.values(graph.nodes)) {
+    if (n.isWrapper && n.bareStateId !== null) bareIds.add(n.bareStateId);
+  }
+  const frameToBareNames = new Map<number, string[]>();
+  for (const n of Object.values(graph.nodes).sort((a, b) => a.id - b.id)) {
+    if (n.isWrapper || n.isHaltMarker || n.frameId === null) continue;
+    if (!bareIds.has(n.id)) continue;
+    const arr = frameToBareNames.get(n.frameId) ?? [];
+    arr.push(n.name);
+    frameToBareNames.set(n.frameId, arr);
+  }
+  for (const [frameId, names] of frameToBareNames) {
+    const label = names.length > 1
+      ? `callable scope: ${names.join(' ∪ ')}`
+      : `callable subtree of ${names[0] ?? frameId}`;
+    frameLabelToId.set(label, frameId);
+  }
+
+  return { nodeFrameMap, frameWrappersMap, frameLabelToId };
+}

--- a/packages/visuals/src/graphUtils.spec.ts
+++ b/packages/visuals/src/graphUtils.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { bareIdOf, equivalentIds, highlightExpand } from './graphUtils';
+import type { Graph } from '@turing-machine-js/machine';
+
+/**
+ * Tests for the pure breakpoint / highlight class helpers in
+ * `graphUtils.ts`. These rules feed both the breakpoint indicator
+ * (`applyIndicator`) and the context-menu "Shared with" info line
+ * (`MachineGraph.svelte`); the upstream engine v7 collapses wrapper
+ * states (`State.withOverriddenHaltState`) onto a shared `#debugRef`
+ * with their bare, so the demo collapses them into one breakpoint per
+ * equivalence class.
+ *
+ * Fixture: `turing-callable-subtree` has
+ *   3  → bare `walkToBlank` (frameId 3)
+ *   4  → `writeMarker` (override)
+ *   5  → wrapper `walkToBlank(writeMarker)` (bareStateId 3)
+ *   0  → halt singleton
+ *   -3 → halt marker for frame 3
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadGraph(name: string): Graph {
+  const path = resolve(__dirname, '../../tests/fixtures/graphs', `${name}.json`);
+  return JSON.parse(readFileSync(path, 'utf8')) as Graph;
+}
+
+describe('bareIdOf', () => {
+  const g = loadGraph('turing-callable-subtree');
+
+  it('maps a wrapper id to its bareStateId', () => {
+    expect(bareIdOf(5, g)).toBe(3);
+  });
+
+  it('returns the bare id unchanged for non-wrapper positive ids', () => {
+    expect(bareIdOf(3, g)).toBe(3);
+    expect(bareIdOf(4, g)).toBe(4);
+  });
+
+  it('collapses halt markers (negative ids) to the halt singleton (0)', () => {
+    expect(bareIdOf(-3, g)).toBe(0);
+  });
+
+  it('returns 0 for the halt singleton itself', () => {
+    expect(bareIdOf(0, g)).toBe(0);
+  });
+
+  it('returns the id unchanged when graph is null', () => {
+    expect(bareIdOf(5, null)).toBe(5);
+    expect(bareIdOf(-3, null)).toBe(-3);
+  });
+
+  it('returns the id unchanged when no node entry exists', () => {
+    expect(bareIdOf(999, g)).toBe(999);
+  });
+});
+
+describe('highlightExpand (asymmetric)', () => {
+  const g = loadGraph('turing-callable-subtree');
+
+  it('expands wrapper → [wrapper, bare]', () => {
+    expect(highlightExpand(5, g).sort()).toEqual([3, 5]);
+  });
+
+  it('does NOT expand bare → [bare] only (no wrapper sync from bare side)', () => {
+    expect(highlightExpand(3, g)).toEqual([3]);
+  });
+
+  it('returns [id] for a non-wrapper non-bare id', () => {
+    expect(highlightExpand(4, g)).toEqual([4]);
+  });
+
+  it('returns [id] when graph is null', () => {
+    expect(highlightExpand(5, null)).toEqual([5]);
+  });
+});
+
+describe('equivalentIds (symmetric class lookup)', () => {
+  const g = loadGraph('turing-callable-subtree');
+
+  it('returns [bare, ...wrappers] from a wrapper input', () => {
+    expect(equivalentIds(5, g).sort()).toEqual([3, 5]);
+  });
+
+  it('returns [bare, ...wrappers] from the bare input — symmetric', () => {
+    expect(equivalentIds(3, g).sort()).toEqual([3, 5]);
+  });
+
+  it('returns [singleton] for a stand-alone state', () => {
+    expect(equivalentIds(4, g)).toEqual([4]);
+  });
+
+  it('halt singleton (0) → [0, ...all halt markers]', () => {
+    const ids = equivalentIds(0, g).sort((a, b) => a - b);
+    expect(ids).toEqual([-3, 0]);
+  });
+
+  it('halt marker (-3) → same class as halt singleton (symmetric)', () => {
+    const ids = equivalentIds(-3, g).sort((a, b) => a - b);
+    expect(ids).toEqual([-3, 0]);
+  });
+
+  it('returns [id] when graph is null', () => {
+    expect(equivalentIds(5, null)).toEqual([5]);
+    expect(equivalentIds(0, null)).toEqual([0]);
+  });
+});

--- a/packages/visuals/src/graphUtils.spec.ts
+++ b/packages/visuals/src/graphUtils.spec.ts
@@ -26,7 +26,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 function loadGraph(name: string): Graph {
-  const path = resolve(__dirname, '../../tests/fixtures/graphs', `${name}.json`);
+  const path = resolve(__dirname, './fixtures/graphs', `${name}.json`);
   return JSON.parse(readFileSync(path, 'utf8')) as Graph;
 }
 

--- a/packages/visuals/src/graphUtils.ts
+++ b/packages/visuals/src/graphUtils.ts
@@ -1,0 +1,74 @@
+import type { Graph } from '@turing-machine-js/machine';
+
+/**
+ * Normalize an engine `GraphNode.id` to its canonical representative for
+ * breakpoint-class lookups (machines-demo#37). Wrappers produced by
+ * `State.withOverriddenHaltState` share `#debugRef` with their bare state
+ * engine-side (turing-machine-js v7 `State.ts`: `state.#debugRef =
+ * bare.#debugRef`), so they form a single breakpoint from the user's POV.
+ * This collapses any wrapper id to its bare's id; non-wrapper ids return
+ * self. Used so the demo can store ONE canonical id per equivalence class
+ * in its breakpoint set, and expand to all class members for indicator
+ * rendering — keeping the worker-side toggle count to one per class
+ * (multiple toggles on the shared ref would double-flip).
+ */
+export function bareIdOf(id: number, graph: Graph | null): number {
+  if (!graph) return id;
+  // Halt markers (negative ids, one per frame) are visualization sentinels;
+  // at runtime they all collapse to the haltState singleton (id 0). For
+  // breakpoint purposes they're a single class — setting BP on any
+  // halt-related node sets it on the global haltState.
+  if (id < 0) return 0;
+  const node = graph.nodes[id];
+  if (node && node.isWrapper && node.bareStateId !== null) {
+    return node.bareStateId;
+  }
+  return id;
+}
+
+/**
+ * Asymmetric expansion for the highlight effect (machines-demo#37).
+ * Wrapper → `[wrapper, bare]` (the wrapper-entry pause is visually joined
+ * to its bare, since the user thinks of them as one call site).
+ * Bare → `[bare]` only (when the engine is genuinely on the bare — e.g. a
+ * loop iter — the wrapper is not the "active" state and shouldn't get the
+ * strong highlight).
+ * Non-wrapper / non-bare ids return `[id]`.
+ */
+export function highlightExpand(id: number, graph: Graph | null): number[] {
+  if (!graph) return [id];
+  const node = graph.nodes[id];
+  if (node?.isWrapper && node.bareStateId !== null) {
+    return [id, node.bareStateId];
+  }
+  return [id];
+}
+
+/**
+ * All GraphNode ids in the same breakpoint equivalence class as `id`.
+ * Symmetric — gives consumers the full list of nodes that share an engine
+ * breakpoint, regardless of which class member is the input. Used by the
+ * context-menu's "Shared with" info line so the user can see at a glance
+ * which other nodes flip together.
+ *
+ * Halt class (canonical id 0): the halt singleton + every halt marker in
+ * the graph. Wrapper/bare class: the bare + every wrapper pointing at it.
+ * Singleton classes (regular states, idle sentinel proxies) return just
+ * the input id.
+ */
+export function equivalentIds(id: number, graph: Graph | null): number[] {
+  if (!graph) return [id];
+  const canonical = bareIdOf(id, graph);
+  if (canonical === 0) {
+    const ids: number[] = [0];
+    for (const node of Object.values(graph.nodes)) {
+      if (node.isHaltMarker) ids.push(node.id);
+    }
+    return ids;
+  }
+  const result = new Set<number>([canonical]);
+  for (const node of Object.values(graph.nodes)) {
+    if (node.isWrapper && node.bareStateId === canonical) result.add(node.id);
+  }
+  return [...result];
+}

--- a/packages/visuals/src/highlightOps.ts
+++ b/packages/visuals/src/highlightOps.ts
@@ -1,0 +1,94 @@
+/**
+ * Contract between the pure highlight logic (`applyHighlight`,
+ * `applyIndicator`) and any consumer that actually renders the graph
+ * (Svelte component, vanilla embed, server-side snapshot, etc.).
+ *
+ * The pure functions decide *what* should happen (which node gets a class,
+ * which edge lights up, where to pulse); the consumer's `HighlightOps`
+ * implementation decides *how* (DOM mutation, recording for tests, etc.).
+ *
+ * See `docs/graph-highlight-and-breakpoints.md` for the rules each
+ * implementation must respect.
+ */
+
+export type NodeKey = number | 'idle';
+
+/** Classes the apply-highlight pass may add to a `g.node` element. */
+export type HighlightClass =
+  | 'mg-highlight-from'
+  | 'mg-highlight-to'
+  | 'mg-highlight-strong';
+
+/**
+ * Operations the highlight logic invokes on the rendered graph. Purely
+ * additive — the consumer is expected to clear previous highlight state
+ * (classes, marker swaps) BEFORE invoking `applyHighlight`. The pure
+ * function never reads back from the consumer; it just emits ops.
+ *
+ * Edge keys follow mermaid's data-id token form: `'idle'` for the
+ * synthetic entry sentinel, `'s${id}'` for regular/wrapper/bare states,
+ * `'c${id}'` for halt markers (id = `-frameId`), `'w_${id}'` for callable-
+ * subtree subgraph clusters. Mermaid emits `L_${from}_${to}_${ix}` per
+ * edge; ix-resolution is the consumer's concern (multiple edges between
+ * the same pair are rare; the consumer typically picks the first match).
+ */
+export interface HighlightOps {
+  /** Add a highlight class to the node identified by `id`. */
+  addNodeClass(id: NodeKey, cls: HighlightClass): void;
+
+  /** Highlight the edge whose data-id matches `L_${fromKey}_${toKey}_*`. */
+  highlightEdge(fromKey: string, toKey: string): void;
+
+  /** Mark the callable-subtree cluster for `frameId` as active. */
+  markFrameActive(frameId: number): void;
+
+  /** Fire a one-shot pulse animation on the given node. */
+  pulse(id: NodeKey): void;
+
+  /** Scroll the given node into the visible area of its container. */
+  scrollIntoView(id: NodeKey): void;
+}
+
+/** Operations the indicator (breakpoint dot) pass invokes. */
+export interface IndicatorOps {
+  /** Set or clear the breakpoint indicator on the given node. */
+  setBreakpoint(id: NodeKey, on: boolean): void;
+}
+
+/** A single recorded op — serializable, suitable for snapshot tests. */
+export type RecordedOp =
+  | { op: 'addNodeClass'; id: NodeKey; cls: HighlightClass }
+  | { op: 'highlightEdge'; fromKey: string; toKey: string }
+  | { op: 'markFrameActive'; frameId: number }
+  | { op: 'pulse'; id: NodeKey }
+  | { op: 'scrollIntoView'; id: NodeKey }
+  | { op: 'setBreakpoint'; id: NodeKey; on: boolean };
+
+/**
+ * Build a recording `HighlightOps` + `IndicatorOps` pair plus the shared
+ * `record` array of calls in invocation order. Used by tests to assert
+ * what the pure logic would have done without running a real DOM.
+ *
+ * Snapshot-friendly: the record contains only plain JSON-serializable
+ * values (no DOM nodes, no function refs).
+ */
+export function recordingOps(): {
+  highlight: HighlightOps;
+  indicator: IndicatorOps;
+  record: RecordedOp[];
+} {
+  const record: RecordedOp[] = [];
+  return {
+    record,
+    highlight: {
+      addNodeClass(id, cls) { record.push({ op: 'addNodeClass', id, cls }); },
+      highlightEdge(fromKey, toKey) { record.push({ op: 'highlightEdge', fromKey, toKey }); },
+      markFrameActive(frameId) { record.push({ op: 'markFrameActive', frameId }); },
+      pulse(id) { record.push({ op: 'pulse', id }); },
+      scrollIntoView(id) { record.push({ op: 'scrollIntoView', id }); },
+    },
+    indicator: {
+      setBreakpoint(id, on) { record.push({ op: 'setBreakpoint', id, on }); },
+    },
+  };
+}

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -7,3 +7,4 @@ export { indexGraph } from './graphIndexes';
 export type { GraphHighlight, TapeSnapshot, Frame, Snippet } from './types';
 export { applyHighlight, applyIndicator } from './applyHighlight';
 export { formatCommand, formatStep } from './format';
+export { recordSnippet, type RecordSnippetOptions } from './recordSnippet';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -4,3 +4,5 @@ export { recordingOps } from './highlightOps';
 export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';
 export type { GraphIndexes } from './graphIndexes';
 export { indexGraph } from './graphIndexes';
+export type { GraphHighlight } from './types';
+export { applyHighlight, applyIndicator } from './applyHighlight';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -1,3 +1,4 @@
 // Public API — populated as modules are moved in Tasks 2–8.
 export type { NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp } from './highlightOps';
 export { recordingOps } from './highlightOps';
+export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -1,0 +1,2 @@
+// Public API — populated as modules are moved in Tasks 2–8.
+export {};

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -1,8 +1,9 @@
-// Public API — populated as modules are moved in Tasks 2–8.
+// Public API — extracted modules + Snippet recording surface.
 export type { NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp } from './highlightOps';
 export { recordingOps } from './highlightOps';
 export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';
 export type { GraphIndexes } from './graphIndexes';
 export { indexGraph } from './graphIndexes';
-export type { GraphHighlight } from './types';
+export type { GraphHighlight, TapeSnapshot, Frame, Snippet } from './types';
 export { applyHighlight, applyIndicator } from './applyHighlight';
+export { formatCommand, formatStep } from './format';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -1,2 +1,3 @@
 // Public API — populated as modules are moved in Tasks 2–8.
-export {};
+export type { NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp } from './highlightOps';
+export { recordingOps } from './highlightOps';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -2,3 +2,5 @@
 export type { NodeKey, HighlightClass, HighlightOps, IndicatorOps, RecordedOp } from './highlightOps';
 export { recordingOps } from './highlightOps';
 export { bareIdOf, highlightExpand, equivalentIds } from './graphUtils';
+export type { GraphIndexes } from './graphIndexes';
+export { indexGraph } from './graphIndexes';

--- a/packages/visuals/src/recordSnippet.spec.ts
+++ b/packages/visuals/src/recordSnippet.spec.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Alphabet,
+  State,
+  Tape,
+  TapeBlock,
+  TuringMachine,
+  haltState,
+  ifOtherSymbol,
+  movements,
+  symbolCommands,
+} from '@turing-machine-js/machine';
+import { recordSnippet } from './recordSnippet';
+
+/** Build a machine that converts each 'a' → 'b' (move right) until blank (halt). */
+function buildTwoAMachine() {
+  const alphabet = new Alphabet([' ', 'a', 'b']);
+  const tape = new Tape({ alphabet, symbols: ['a', 'a'] });
+  const tapeBlock = TapeBlock.fromTapes([tape]);
+  const machine = new TuringMachine({ tapeBlock });
+
+  const initialState = new State({
+    [tapeBlock.symbol(['a'])]: {
+      command: [{ symbol: 'b', movement: movements.right }],
+    },
+    [ifOtherSymbol]: {
+      nextState: haltState,
+    },
+  });
+
+  const graph = State.toGraph(initialState, tapeBlock);
+  const alphabets = [alphabet.symbols.filter((s) => s !== alphabet.blankSymbol).concat(alphabet.blankSymbol)];
+
+  return { machine, initialState, graph, alphabets, alphabet };
+}
+
+describe('recordSnippet', () => {
+  describe('frame 0 (initial state)', () => {
+    it('step is 0', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[0].step).toBe(0);
+    });
+
+    it('commands is undefined', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[0].commands).toBeUndefined();
+    });
+
+    it('highlight is null', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[0].highlight).toBeNull();
+    });
+
+    it('tape reflects initial state (position 0, contains "a")', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      const frame0Tape = snippet.frames[0].tape[0];
+      expect(frame0Tape.position).toBe(0);
+      expect(frame0Tape.symbols).toContain('a');
+    });
+  });
+
+  describe('frame count', () => {
+    it('2 "a"s + halt iter = 3 iters → 4 frames (frame 0 + 3)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      // iter 1: read 'a', write 'b', move R
+      // iter 2: read 'a', write 'b', move R
+      // iter 3: read blank, nextState = haltState
+      expect(snippet.frames).toHaveLength(4);
+    });
+  });
+
+  describe('per-iter frame commands', () => {
+    it('frame 1: write "b", move R', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[1].commands).toEqual([{ movement: 'R', symbol: 'b' }]);
+    });
+
+    it('frame 2: write "b", move R', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[2].commands).toEqual([{ movement: 'R', symbol: 'b' }]);
+    });
+
+    it('frame 3 (halt iter): symbol null (keep), movement S (stay)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      // halt-bound transition has default command: keep + stay
+      expect(snippet.frames[3].commands).toEqual([{ movement: 'S', symbol: null }]);
+    });
+  });
+
+  describe('per-iter frame tape (post-command snapshots)', () => {
+    it('frame 1 tape: "b" written at position 0, head at position 1', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      const tape = snippet.frames[1].tape[0];
+      expect(tape.symbols[0]).toBe('b');
+      expect(tape.position).toBe(1);
+    });
+
+    it('frame 2 tape: both cells "b", head at position 2', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      const tape = snippet.frames[2].tape[0];
+      expect(tape.symbols[0]).toBe('b');
+      expect(tape.symbols[1]).toBe('b');
+      expect(tape.position).toBe(2);
+    });
+  });
+
+  describe('snippet metadata', () => {
+    it('version is 1', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.version).toBe(1);
+    });
+
+    it('graph is the passed-in graph (referential equality)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.graph).toBe(graph);
+    });
+
+    it('alphabets is the passed-in alphabets (referential equality)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.alphabets).toBe(alphabets);
+    });
+
+    it('name is set when provided', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets, name: 'test snippet' });
+      expect(snippet.name).toBe('test snippet');
+    });
+
+    it('name is absent when not provided', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect('name' in snippet).toBe(false);
+    });
+  });
+
+  describe('log option', () => {
+    it('attaches log to non-frame-0 frames when log returns a string', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({
+        machine,
+        initialState,
+        graph,
+        alphabets,
+        log: () => 'step line',
+      });
+      // frame 0 has no log
+      expect(snippet.frames[0].log).toBeUndefined();
+      // frames 1-3 all have log
+      for (let i = 1; i < snippet.frames.length; i++) {
+        expect(snippet.frames[i].log).toBe('step line');
+      }
+    });
+
+    it('omits log when log returns undefined', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({
+        machine,
+        initialState,
+        graph,
+        alphabets,
+        log: () => undefined,
+      });
+      for (const frame of snippet.frames) {
+        expect('log' in frame).toBe(false);
+      }
+    });
+
+    it('passes current and previous MachineState to log', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const calls: [unknown, unknown][] = [];
+      recordSnippet({
+        machine,
+        initialState,
+        graph,
+        alphabets,
+        log: (m, prev) => { calls.push([m.step, prev ? prev.step : null]); return undefined; },
+      });
+      // 3 iters → 3 log calls
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toEqual([1, null]);
+      expect(calls[1]).toEqual([2, 1]);
+      expect(calls[2]).toEqual([3, 2]);
+    });
+  });
+
+  describe('maxSteps truncation', () => {
+    it('with maxSteps: 1 → 2 frames (frame 0 + frame 1)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets, maxSteps: 1 });
+      expect(snippet.frames).toHaveLength(2);
+    });
+
+    it('with maxSteps: 1, frame 1 tape reflects the first command applied', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets, maxSteps: 1 });
+      const tape = snippet.frames[1].tape[0];
+      // 'a' was written to 'b', head moved right
+      expect(tape.symbols[0]).toBe('b');
+      expect(tape.position).toBe(1);
+    });
+  });
+
+  describe('highlight', () => {
+    it('non-frame-0 frames have a non-null highlight with strong: "from" and paused: false', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      for (let i = 1; i < snippet.frames.length; i++) {
+        const h = snippet.frames[i].highlight;
+        expect(h).not.toBeNull();
+        expect(h!.strong).toBe('from');
+        expect(h!.paused).toBe(false);
+      }
+    });
+
+    it('halt-iter frame highlight has toId: 0 (haltState)', () => {
+      const { machine, initialState, graph, alphabets } = buildTwoAMachine();
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      const lastFrame = snippet.frames[snippet.frames.length - 1];
+      expect(lastFrame.highlight!.toId).toBe(0);
+    });
+  });
+
+  describe('single-step machine (halts immediately)', () => {
+    it('produces 2 frames when machine halts on step 1', () => {
+      const alphabet = new Alphabet([' ', 'x']);
+      const tape = new Tape({ alphabet, symbols: ['x'] });
+      const tapeBlock = TapeBlock.fromTapes([tape]);
+      const machine = new TuringMachine({ tapeBlock });
+      const initialState = new State({
+        [ifOtherSymbol]: { nextState: haltState },
+      });
+      const graph = State.toGraph(initialState, tapeBlock);
+      const alphabets = [['x', ' ']];
+
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames).toHaveLength(2);
+      expect(snippet.frames[0].commands).toBeUndefined();
+      expect(snippet.frames[1].commands).toBeDefined();
+    });
+  });
+
+  describe('keep command → symbol null', () => {
+    it('a keep+stay command produces symbol: null in commands', () => {
+      const alphabet = new Alphabet([' ', 'a']);
+      const tape = new Tape({ alphabet, symbols: ['a'] });
+      const tapeBlock = TapeBlock.fromTapes([tape]);
+      const machine = new TuringMachine({ tapeBlock });
+      const initialState = new State({
+        [tapeBlock.symbol(['a'])]: {
+          command: [{ symbol: symbolCommands.keep, movement: movements.stay }],
+          nextState: haltState,
+        },
+      });
+      const graph = State.toGraph(initialState, tapeBlock);
+      const alphabets = [['a', ' ']];
+
+      const snippet = recordSnippet({ machine, initialState, graph, alphabets });
+      expect(snippet.frames[1].commands![0]).toEqual({ movement: 'S', symbol: null });
+    });
+  });
+});

--- a/packages/visuals/src/recordSnippet.spec.ts
+++ b/packages/visuals/src/recordSnippet.spec.ts
@@ -75,23 +75,24 @@ describe('recordSnippet', () => {
   });
 
   describe('per-iter frame commands', () => {
-    it('frame 1: write "b", move R', () => {
+    it('frame 1: read "a", write "b", move R', () => {
       const { machine, initialState, graph, alphabets } = buildTwoAMachine();
       const snippet = recordSnippet({ machine, initialState, graph, alphabets });
-      expect(snippet.frames[1].commands).toEqual([{ movement: 'R', symbol: 'b' }]);
+      expect(snippet.frames[1].commands).toEqual([{ movement: 'R', read: 'a', write: 'b' }]);
     });
 
-    it('frame 2: write "b", move R', () => {
+    it('frame 2: read "a", write "b", move R', () => {
       const { machine, initialState, graph, alphabets } = buildTwoAMachine();
       const snippet = recordSnippet({ machine, initialState, graph, alphabets });
-      expect(snippet.frames[2].commands).toEqual([{ movement: 'R', symbol: 'b' }]);
+      expect(snippet.frames[2].commands).toEqual([{ movement: 'R', read: 'a', write: 'b' }]);
     });
 
-    it('frame 3 (halt iter): symbol null (keep), movement S (stay)', () => {
+    it('frame 3 (halt iter): read===write (keep), movement S (stay)', () => {
       const { machine, initialState, graph, alphabets } = buildTwoAMachine();
       const snippet = recordSnippet({ machine, initialState, graph, alphabets });
-      // halt-bound transition has default command: keep + stay
-      expect(snippet.frames[3].commands).toEqual([{ movement: 'S', symbol: null }]);
+      // halt-bound transition has default command: keep + stay; blank cell read+written
+      const blank = snippet.frames[3].commands![0].read;
+      expect(snippet.frames[3].commands).toEqual([{ movement: 'S', read: blank, write: blank }]);
     });
   });
 
@@ -252,8 +253,8 @@ describe('recordSnippet', () => {
     });
   });
 
-  describe('keep command → symbol null', () => {
-    it('a keep+stay command produces symbol: null in commands', () => {
+  describe('keep command → read === write', () => {
+    it('a keep+stay command yields read === write in commands', () => {
       const alphabet = new Alphabet([' ', 'a']);
       const tape = new Tape({ alphabet, symbols: ['a'] });
       const tapeBlock = TapeBlock.fromTapes([tape]);
@@ -268,7 +269,7 @@ describe('recordSnippet', () => {
       const alphabets = [['a', ' ']];
 
       const snippet = recordSnippet({ machine, initialState, graph, alphabets });
-      expect(snippet.frames[1].commands![0]).toEqual({ movement: 'S', symbol: null });
+      expect(snippet.frames[1].commands![0]).toEqual({ movement: 'S', read: 'a', write: 'a' });
     });
   });
 });

--- a/packages/visuals/src/recordSnippet.ts
+++ b/packages/visuals/src/recordSnippet.ts
@@ -1,0 +1,142 @@
+import {
+  haltState,
+  type Graph,
+  type MachineState,
+  type State,
+  type TuringMachine,
+} from '@turing-machine-js/machine';
+import { MOVEMENT_LETTER } from './format';
+import { bareIdOf } from './graphUtils';
+import type { Frame, GraphHighlight, Snippet, TapeSnapshot } from './types';
+
+export type RecordSnippetOptions = {
+  machine: TuringMachine;
+  initialState: State;
+  graph: Graph;
+  alphabets: string[][];
+  name?: string;
+  /**
+   * Maximum number of iteration steps to record. Defaults to 1000.
+   * If the machine hasn't halted after `maxSteps` iters, recording stops
+   * and the snippet contains `maxSteps + 1` frames (frame 0 plus one per iter).
+   */
+  maxSteps?: number;
+  /**
+   * Optional per-frame log formatter. Called with the current and previous
+   * `MachineState`; return a string to attach as `frame.log`, or `undefined`
+   * to omit. Not called for frame 0 (initial state — no transition has fired).
+   */
+  log?: (m: MachineState, prev: MachineState | null) => string | undefined;
+};
+
+const DEFAULT_MAX_STEPS = 1000;
+
+function snapshotTapes(machine: TuringMachine): TapeSnapshot[] {
+  return machine.tapeBlock.tapes.map((t) => ({
+    symbols: [...t.symbols],
+    position: t.position,
+  }));
+}
+
+function deriveCommands(
+  m: MachineState,
+): NonNullable<Frame['commands']> {
+  return m.movements.map((mv, i) => {
+    const movement = MOVEMENT_LETTER.get(mv) ?? 'S';
+    // nextSymbols is already resolved (keep → current symbol, erase → blank).
+    // If it equals the current symbol the command is "keep" → null (no write flash).
+    const written =
+      m.nextSymbols[i] !== m.currentSymbols[i] ? m.nextSymbols[i] : null;
+    return { movement, symbol: written };
+  });
+}
+
+function deriveHighlight(m: MachineState, graph: Graph): GraphHighlight {
+  return {
+    fromId: bareIdOf(m.state.id, graph),
+    toId: m.nextState === haltState ? 0 : m.nextState.id,
+    strong: 'from',
+    paused: false,
+  };
+}
+
+/**
+ * Record a full machine run into a `Snippet` — a self-contained playback
+ * artifact suitable for embeds, articles, or landing-page panels.
+ *
+ * The returned snippet contains one frame per iteration plus a frame-0
+ * initial-state snapshot. Recording stops when the machine halts or when
+ * `maxSteps` iterations have been consumed (default 1000).
+ *
+ * Tape-timing note: `runStepByStep` yields BEFORE applying its command
+ * (the command is applied after the yield resumes). The recorder uses a
+ * one-step-delayed snapshot so each frame's `tape` reflects the
+ * post-command state for that frame's iter.
+ */
+export function recordSnippet(opts: RecordSnippetOptions): Snippet {
+  const {
+    machine,
+    initialState,
+    graph,
+    alphabets,
+    name,
+    maxSteps = DEFAULT_MAX_STEPS,
+    log,
+  } = opts;
+
+  const frames: Frame[] = [
+    { step: 0, tape: snapshotTapes(machine), highlight: null },
+  ];
+
+  // pending holds everything for the frame whose tape snapshot is not yet
+  // available (because applyCommand hasn't fired yet). It is flushed at the
+  // start of the NEXT iter (when the tape reflects the previous command) and
+  // after the loop (when the final command has been applied).
+  let pending: Omit<Frame, 'tape'> | null = null;
+  let prev: MachineState | null = null;
+
+  try {
+    for (const m of machine.runStepByStep({ initialState, stepsLimit: maxSteps })) {
+      // At this point applyCommand for the PREVIOUS iter has already run
+      // (the generator called applyCommand before looping back to yield).
+      // So the current tape state = post-command of the previous iter.
+      if (pending !== null) {
+        frames.push({ ...pending, tape: snapshotTapes(machine) });
+      }
+
+      const commands = deriveCommands(m);
+      const highlight = deriveHighlight(m, graph);
+      const logLine = log ? log(m, prev) : undefined;
+
+      pending = {
+        step: m.step,
+        commands,
+        highlight,
+        ...(logLine !== undefined ? { log: logLine } : {}),
+      };
+
+      prev = m;
+    }
+  } catch (e) {
+    // runStepByStep throws 'Long execution' when stepsLimit is hit.
+    // At that point applyCommand for the last yielded iter has run, so the
+    // tape is in the post-command state we want for the pending frame.
+    if (!(e instanceof Error) || e.message !== 'Long execution') {
+      throw e;
+    }
+  }
+
+  // Flush the last pending frame. After the loop (or after the catch), the
+  // tape reflects the post-command state of the final yielded iter.
+  if (pending !== null) {
+    frames.push({ ...pending, tape: snapshotTapes(machine) });
+  }
+
+  return {
+    version: 1,
+    ...(name !== undefined ? { name } : {}),
+    graph,
+    alphabets,
+    frames,
+  };
+}

--- a/packages/visuals/src/recordSnippet.ts
+++ b/packages/visuals/src/recordSnippet.ts
@@ -41,14 +41,13 @@ function snapshotTapes(machine: TuringMachine): TapeSnapshot[] {
 function deriveCommands(
   m: MachineState,
 ): NonNullable<Frame['commands']> {
-  return m.movements.map((mv, i) => {
-    const movement = MOVEMENT_LETTER.get(mv) ?? 'S';
-    // nextSymbols is already resolved (keep → current symbol, erase → blank).
-    // If it equals the current symbol the command is "keep" → null (no write flash).
-    const written =
-      m.nextSymbols[i] !== m.currentSymbols[i] ? m.nextSymbols[i] : null;
-    return { movement, symbol: written };
-  });
+  return m.movements.map((mv, i) => ({
+    movement: MOVEMENT_LETTER.get(mv) ?? 'S',
+    read: m.currentSymbols[i],
+    // nextSymbols is already resolved (keep → current symbol, erase → blank);
+    // when write === read the command was a keep (UI suppresses the flash).
+    write: m.nextSymbols[i],
+  }));
 }
 
 function deriveHighlight(m: MachineState, graph: Graph): GraphHighlight {

--- a/packages/visuals/src/types.ts
+++ b/packages/visuals/src/types.ts
@@ -48,10 +48,26 @@ export type TapeSnapshot = {
  * `tape` is per-tape (single-tape machines: length 1). `highlight` describes
  * what to render on the state graph at this moment (null when no highlight).
  * `log` is optional pre-formatted text — a caption / status line consumers can render.
+ * `commands` carries the per-tape engine command for the iter that produced this frame.
+ * Undefined on frame 0 (initial state — no transition has fired yet).
+ * `movement` drives the tape slide direction; `symbol === null` means keep (no write —
+ * UI skips the per-cell flash); a non-null `symbol` is the literal that was written to
+ * the just-vacated cell.
  */
 export type Frame = {
   step: number;
   tape: TapeSnapshot[];
+  /**
+   * Per-tape engine command for the iter that produced this frame.
+   * Undefined on frame 0 (initial state — no transition has fired yet).
+   * `movement` drives the tape slide direction; `symbol === null` means
+   * keep (no write — UI skips the per-cell flash); a non-null `symbol`
+   * is the literal that was written to the just-vacated cell.
+   */
+  commands?: {
+    movement: 'L' | 'R' | 'S';
+    symbol: string | null;
+  }[];
   highlight: GraphHighlight | null;
   log?: string;
 };

--- a/packages/visuals/src/types.ts
+++ b/packages/visuals/src/types.ts
@@ -48,25 +48,29 @@ export type TapeSnapshot = {
  * `tape` is per-tape (single-tape machines: length 1). `highlight` describes
  * what to render on the state graph at this moment (null when no highlight).
  * `log` is optional pre-formatted text — a caption / status line consumers can render.
- * `commands` carries the per-tape engine command for the iter that produced this frame.
- * Undefined on frame 0 (initial state — no transition has fired yet).
- * `movement` drives the tape slide direction; `symbol === null` means keep (no write —
- * UI skips the per-cell flash); a non-null `symbol` is the literal that was written to
- * the just-vacated cell.
  */
 export type Frame = {
   step: number;
   tape: TapeSnapshot[];
   /**
-   * Per-tape engine command for the iter that produced this frame.
+   * Per-tape engine command for the iter that produced this frame. Carries
+   * both sides of the cell so players can step bi-directionally without
+   * recomputing from neighbouring frames:
+   *
+   * - `movement` — `'L' | 'R' | 'S'`. Forward step slides the tape this way;
+   *   backward step slides the opposite.
+   * - `read` — symbol on the head's cell BEFORE this iter (what the engine
+   *   matched). Backward step writes this back.
+   * - `write` — symbol on the cell AFTER this iter (=== `read` if no write
+   *   happened). Forward step writes this; UI triggers the per-cell flash
+   *   iff `write !== read`.
+   *
    * Undefined on frame 0 (initial state — no transition has fired yet).
-   * `movement` drives the tape slide direction; `symbol === null` means
-   * keep (no write — UI skips the per-cell flash); a non-null `symbol`
-   * is the literal that was written to the just-vacated cell.
    */
   commands?: {
     movement: 'L' | 'R' | 'S';
-    symbol: string | null;
+    read: string;
+    write: string;
   }[];
   highlight: GraphHighlight | null;
   log?: string;

--- a/packages/visuals/src/types.ts
+++ b/packages/visuals/src/types.ts
@@ -1,0 +1,31 @@
+/**
+ * State-graph highlight descriptor (machines-demo#10). MachineView derives it
+ * from `executionMode` + the latest pause-response data; MachineGraph reads
+ * it to light up the `from → edge → to` triple in the rendered SVG.
+ *
+ * - `fromId: 'idle'` represents the synthetic `idle([idle])` sentinel that
+ *   `toMermaid` emits at the entry point. Used in IDLE mode to mark "where
+ *   execution would start".
+ * - `fromId: number` is an engine `GraphNode.id` — the source state.
+ * - `toId: number | null` is the destination state's id (or `null` at halt).
+ * - `strong` selects which end of the triple gets the bolder/stronger
+ *   accent. Per the (B) rule: `from` strong at `before` pause; `to` strong
+ *   at `after` / iter-end pause / IDLE (destination feels current).
+ */
+export type GraphHighlight = {
+  fromId: number | 'idle';
+  toId: number | null;
+  strong: 'from' | 'to';
+  /**
+   * True when this highlight reflects a paused-event apply (RUNNING_PAUSED),
+   * false for per-iter idle applies (RUNNING_AUTO). MachineGraph uses this
+   * to detect cross-pause same-state revisits — pulsing the strong node when
+   * the current paused apply lands on the same state as the previous paused
+   * apply, even when intermediate idle applies pointed elsewhere
+   * (e.g., stateA breakpoint → continue → run through stateB/C → stateA
+   * breakpoint fires again). The simpler "previous apply's strong matches"
+   * check already covers AUTO self-loops; this flag drives the second pulse
+   * trigger.
+   */
+  paused: boolean;
+};

--- a/packages/visuals/src/types.ts
+++ b/packages/visuals/src/types.ts
@@ -1,3 +1,5 @@
+import type { Graph } from '@turing-machine-js/machine';
+
 /**
  * State-graph highlight descriptor (machines-demo#10). MachineView derives it
  * from `executionMode` + the latest pause-response data; MachineGraph reads
@@ -28,4 +30,47 @@ export type GraphHighlight = {
    * trigger.
    */
   paused: boolean;
+};
+
+/**
+ * Per-tape snapshot: the cells visible/usable plus the head's index into them.
+ * Same shape as machines-demo's TapeSnapshot. Pure data — no library handles.
+ */
+export type TapeSnapshot = {
+  symbols: string[];
+  position: number;
+};
+
+/**
+ * One frame of a recorded snippet — the state of the machine at iter `step`.
+ * Frame 0 = initial state (before any transition); frame N = state after iter N's transition.
+ *
+ * `tape` is per-tape (single-tape machines: length 1). `highlight` describes
+ * what to render on the state graph at this moment (null when no highlight).
+ * `log` is optional pre-formatted text — a caption / status line consumers can render.
+ */
+export type Frame = {
+  step: number;
+  tape: TapeSnapshot[];
+  highlight: GraphHighlight | null;
+  log?: string;
+};
+
+/**
+ * Recorded run of a machine — playback artifact for embeds, articles,
+ * landing-page panels. Engine-agnostic (no `engine` field; identity lives
+ * at the caller bucket level).
+ *
+ * - `version: 1` — schema integer. Additive fields don't bump it;
+ *   shape-breaking changes do.
+ * - `graph` — engine `State.toGraph` output captured at recording time.
+ * - `alphabets` — per-tape alphabet list (single-tape: length 1).
+ * - `frames` — length === `stepsApplied + 1`; frame 0 is the initial state.
+ */
+export type Snippet = {
+  version: 1;
+  name?: string;
+  graph: Graph;
+  alphabets: string[][];
+  frames: Frame[];
 };

--- a/packages/visuals/tsconfig.build.json
+++ b/packages/visuals/tsconfig.build.json
@@ -4,5 +4,8 @@
     "rootDir": "src",
     "composite": true
   },
+  "references": [
+    { "path": "../machine/tsconfig.build.json" }
+  ],
   "exclude": ["**/*.spec.ts", "dist"]
 }

--- a/packages/visuals/tsconfig.build.json
+++ b/packages/visuals/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "composite": true
+  },
+  "exclude": ["**/*.spec.ts", "dist"]
+}

--- a/packages/visuals/tsconfig.json
+++ b/packages/visuals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "dist",
+    "paths": {
+      "@turing-machine-js/*": ["../*/src/index"]
+    }
+  }
+}

--- a/scripts/build-node-entries.mjs
+++ b/scripts/build-node-entries.mjs
@@ -35,6 +35,11 @@ const allPackages = [
     dir: 'packages/library-binary-numbers-bare',
     external: ['@turing-machine-js/machine'],
   },
+  {
+    name: '@turing-machine-js/visuals',
+    dir: 'packages/visuals',
+    external: ['@turing-machine-js/machine'],
+  },
 ];
 
 const packages = requestedPkg

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "packages/machine/tsconfig.build.json"
+    },
+    {
+      "path": "packages/visuals/tsconfig.json"
     }
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,7 @@
       "path": "packages/machine/tsconfig.build.json"
     },
     {
-      "path": "packages/visuals/tsconfig.json"
+      "path": "packages/visuals/tsconfig.build.json"
     }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       '@turing-machine-js/builder': resolve(root, './packages/builder/src'),
       '@turing-machine-js/library-binary-numbers': resolve(root, './packages/library-binary-numbers/src'),
       '@turing-machine-js/library-binary-numbers-bare': resolve(root, './packages/library-binary-numbers-bare/src'),
+      '@turing-machine-js/visuals': resolve(root, './packages/visuals/src'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Lands the full v1 API of a new lockstep-published package `@turing-machine-js/visuals`. Originally framed as "step 1 only" (extraction) per [#204](https://github.com/mellonis/turing-machine-js/issues/204)'s prescribed sequencing; **revised mid-implementation to fold in step 3** (`recordSnippet` + `Snippet`/`Frame` schema) so the first published alpha carries everything downstream consumers need — no v1 → v1.1 two-publish dance to feed the landing-page work ([machines-demo#79](https://github.com/mellonis/machines-demo/issues/79)). Step 2 (machines-demo cleanup) remains a separate follow-up in machines-demo.

## What's in

**Extraction** (from machines-demo):
- Types: `HighlightOps`, `IndicatorOps`, `RecordedOp`, `NodeKey`, `HighlightClass`, `GraphIndexes`, `GraphHighlight`, `TapeSnapshot`.
- Functions: `indexGraph`, `applyHighlight`, `applyIndicator`, `bareIdOf`, `highlightExpand`, `equivalentIds`, `recordingOps`.
- Rules doc verbatim at `packages/visuals/docs/graph-highlight-and-breakpoints.md`.
- 4 fixture JSONs at `packages/visuals/src/fixtures/graphs/` (used by extracted specs).

**New** (`recordSnippet` surface):
- Types: `Snippet` (`{ version: 1, name?, graph, alphabets, frames }`), `Frame` (`{ step, tape, commands?, highlight, log? }`), `RecordSnippetOptions`.
- `Frame.commands` carries per-tape `{ movement, read, write }` — both sides of the cell. Forward step: move per `movement`, flash if `write !== read`. Backward step: move opposite, write `read` back. **Symmetric, no derivation** — light players don't reconstruct deltas from neighbouring frames.
- `recordSnippet({ machine, initialState, graph, alphabets, name?, maxSteps?, log? })` runs `machine.runStepByStep` and captures one frame per iter plus a frame-0 initial-state snapshot.
- Composable formatter primitives `formatCommand(tapeCommand)` + `formatStep(machineState)` matching the engine's `toMermaid` edge-label notation so logged steps line up with the rendered graph.

**Toolchain wiring:** dual tsconfig, root `tsconfig.build.json` reference, `typecheck` script entry, `vitest.config.ts` alias, `scripts/build-node-entries.mjs` Rollup entry, CHANGELOG `[Unreleased]` entry.

## Deliberately NOT in

- **`graphFixtures.test.ts`** — stays in machines-demo (demo-coupled to `examples` + post-machine peer dep; refactoring it visuals-pure is a separate concern).
- **`graphHighlightDerivation.ts`** — stays in machines-demo (its `ExecutionMode` union is demo orchestration, not engine semantics).
- **A default DOM applier sub-export** — renderer-agnostic in v1. Add later non-breakingly when a concrete consumer asks for one.
- **machines-demo cleanup** — drop the local copies + adjust imports; separate PR in machines-demo after this publishes lockstep with the next engine alpha.

## Decisions locked

Documented in [`docs/superpowers/plans/2026-05-30-visuals-package-extract.md`](docs/superpowers/plans/2026-05-30-visuals-package-extract.md):

- **Package name:** `@turing-machine-js/visuals` (vs `highlight` / `graph-visuals`). Broadest.
- **No DOM applier sub-export in v1.**
- **`Snippet.engine` field dropped** (per #204 comment 2026-05-29).
- **`Snippet` schema versioning:** additive fields don't bump `version`; breaking shape changes bump the integer.
- **`Frame.commands` shape: `{ movement, read, write }`** — symmetric for bidirectional playback.
- **`recordSnippet` signature** — caller supplies pre-built machine + pre-computed graph; recorder is engine-agnostic (works for `@turing-machine-js/machine` and `@post-machine-js/machine` callers alike).

## Test plan

- [x] `npm test` — 616 tests passing (added 16 from `graphUtils.spec.ts`, 24 from `applyHighlight.spec.ts`, 8 from `format.spec.ts`, 24 from `recordSnippet.spec.ts`).
- [x] `npm run typecheck` — clean across all 5 packages.
- [x] `npm run lint` — clean.
- [x] `npm run build` — `Built @turing-machine-js/visuals Node entries` produces `dist/index.{js,d.ts,mjs,cjs}` at top level.
- [x] `npm run test:coverage` — repo floors hold (98.93%/94.69%/100%/99.49% vs 97/90/95/97 floor).
- [x] Smoke-tested via `npm link` into machines-demo: `virtual:lib-versions` resolves the visuals version through the symlink.

## Known coverage gaps (follow-up)

- `applyHighlight.ts`: 97.46% statements / 89.13% branches. Uncovered: wrapper-pause canonicalization + wrapper-entry scroll paths (current fixtures don't include wrapper graphs).
- `graphIndexes.ts`: 89.18% statements / 80.64% branches. Uncovered: null-graph early return + edge cases in frame-name reconstruction.
- New code (`format.ts`, `recordSnippet.ts`) at 100% on the test set added in this PR.

Closing these requires new fixtures with `withOverriddenHaltState`-produced wrapper graphs — out of scope for the move.

## Commit history

15 commits on the branch — 3 scaffolding iterations resolving spec/quality review issues, 1 fixture-path fix mid-extraction, 7 per-task feat/docs/changelog commits, plus the recordSnippet fold (types + recorder + read/write schema revision + CHANGELOG expansion). Per the user's "no amend" policy. Consider squash-merge.

Per repo convention, this PR targets `v7` (not `master`). CI doesn't run on v7 branches; checks fire on the eventual v7 → master integration PR.