### PR TITLE
feat(visuals): alpha.6.1 — formatStepNotation + tokenizeStep + formatTape

### DIFF
--- a/docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md
+++ b/docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md
@@ -2,24 +2,31 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans or superpowers:subagent-driven-development.
 
-**Goal:** Extend visuals's string-formatter surface to cover the richness machines-demo's `format.ts` already provides, so the upcoming demo cleanup PR can drop `format.ts` and call visuals's primitives directly. Pure additive change to visuals.
+**Goal:** Extend visuals's formatter surface so it (a) covers the richness machines-demo's `format.ts` already provides — the upcoming demo cleanup PR can drop `format.ts` and call visuals's primitives directly — AND (b) ships a renderer-agnostic structured-token surface so UIs beyond the demo (article embeds, snippet panels, terminal tools) can render the same per-step data in their own format without re-implementing the per-cell encoding logic. Pure additive change to visuals.
 
-**Tracks:** Unblocks the format.ts portion of the [machines-demo visuals-cleanup plan](../../../../machines-demo/docs/superpowers/plans/2026-05-30-visuals-cleanup.md). Owns the gap I missed when implementing the alpha.6 formatters (Task 10 of #220) — I designed minimal primitives in a vacuum when demo's `format.ts` was the de facto requirement spec.
+**Tracks:** Unblocks the `format.ts` portion of the [machines-demo visuals-cleanup plan](../../../../machines-demo/docs/superpowers/plans/2026-05-30-visuals-cleanup.md). Owns two gaps I missed when implementing the alpha.6 formatters (Task 10 of #220):
+1. I designed minimal primitives in a vacuum when demo's `format.ts` was the de facto requirement spec.
+2. I made `formatStepNotation`-equivalent monolithic (returns one specific string format), so UIs wanting different rendering had to re-implement the per-cell logic from scratch. The `tokenizeStep` + `ReadToken`/`WriteToken` surface fixes that — string rendering is now ONE of many possible presentations.
 
-**Branch:** `feat/visuals-alpha7-formatters` (off `v7`).
+**Branch:** `feat/visuals-alpha7-formatters` (off `v7`). Branch name reflects the initial alpha.7 draft; the version shipped is `7.0.0-alpha.6.1` after a mid-draft rename. Branch identifier doesn't matter; the version that ships is what counts.
 
-**Architecture:** Add the rich primitive (`formatStepNotation`) + `formatTape` to visuals's existing `format.ts`. alpha.6's `formatStep(m)` and `formatCommand(tapeCommand)` stay untouched (backward-compat for any caller). Mirror demo's `format.ts:formatStepNotation` verbatim — same encoding rules, same multi-tape join, same null-`reads` manual-Apply handling, same `K='X'` / `B` / `E` shortcuts. The demo-side migration in the cleanup PR becomes: drop local `formatStepNotation`, drop local `formatTape`, change two internal imports to consume from `@turing-machine-js/visuals`.
+**Architecture:** `tokenizeStep` is the primary primitive — takes `(reads, commands, blanks, matchKinds?)` and returns `StepTokens` (per-tape discriminated-union tokens for reads/writes/moves). `formatStepNotation` is a thin string renderer that consumes `tokenizeStep`'s output and joins it with the engine edge-label vocabulary (`[reads] → [writes]/[moves]`). UIs wanting different presentations call `tokenizeStep` and walk tokens themselves. alpha.6's `formatStep(m)` and `formatCommand(tapeCommand)` stay untouched (backward-compat for any caller). Mirror demo's `format.ts:formatStepNotation` byte-for-byte at the rendering layer — same encoding rules, same multi-tape join, same null-`reads` manual-Apply handling, same `K='X'` / `B` / `E` shortcuts. The demo-side migration in the cleanup PR becomes: drop local `formatStepNotation`, drop local `formatTape`, change two internal imports to consume from `@turing-machine-js/visuals`.
 
 ---
 
 ## Decisions (locked)
 
 - **Visuals-only bump to `7.0.0-alpha.6.1`.** Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — they have no changes; bumping them would create ghost releases (identical tarballs published under a new version). The workspace's lockstep convention exists for coordinated peer-dep widening when engine APIs break; an additive visuals-only release doesn't trigger it. Peer-dep coherence holds: visuals's `@turing-machine-js/machine: ^7.0.0-alpha.6` accepts alpha.6.1+ via semver-prerelease caret, so consumers don't need a coordinated upgrade.
+- **Version name `alpha.6.1` (not `alpha.7`).** Communicates "additive follow-up patch on alpha.6," not "new alpha milestone." Reserves `alpha.7` for the next real engine bump. Semver ordering is correct (`alpha.6 < alpha.6.1 < alpha.7`) and caret ranges `^7.0.0-alpha.6` accept it.
 - **alpha.6 surface stays intact.** `formatStep(m: MachineState): string` and `formatCommand(tapeCommand: TapeCommand): string` remain exactly as published. New primitives are added alongside. No deprecation in alpha.6.1.
-- **New primitive: `formatStepNotation(reads, commands, blanks, matchKinds?)`** — verbatim port of demo's internal helper, now exported. Signature mirrors demo's: `reads: readonly string[] | null` (null = manual Apply), `commands: readonly Command[]` (per-tape), `blanks: readonly string[]` (per-tape blank symbols), `matchKinds?: readonly ('wildcard' | 'literal')[] | null` (per-tape; null = no transition fired).
-- **New primitive: `formatTape(tape: TapeSnapshot)`** — verbatim port of demo's `formatTape`.
+- **Primary primitive: `tokenizeStep(reads, commands, blanks, matchKinds?)`** — renderer-agnostic structured-token output. Returns `StepTokens = { reads: ReadToken[] | null; writes: WriteToken[]; moves: ('L'|'R'|'S')[] }` where:
+  - `ReadToken = { kind: 'literal'; symbol: string } | { kind: 'blank' } | { kind: 'wildcard'; symbol: string }`
+  - `WriteToken = { kind: 'literal'; symbol: string } | { kind: 'erase' } | { kind: 'keep'; readContext?: { symbol: string; isBlank: boolean } }`
+  UIs that want non-string rendering (HTML spans with CSS classes, ANSI escape codes, clickable cells, alternative move vocabulary, JSON for embeds) walk the tokens themselves. Same input contract as `formatStepNotation` — same engine vocabulary, same null-`reads` manual-Apply handling, same wildcard suppression of the blank shortcut.
+- **`formatStepNotation` is now a thin string renderer over `tokenizeStep`.** Output is byte-identical to a from-scratch port of demo's `formatStepNotation` (verified — all 24 existing format-spec cases pass unchanged after the refactor). String rendering is one of many possible presentations of the same structured data.
+- **New primitive: `formatTape(tape: TapeSnapshot)`** — verbatim port of demo's `formatTape`. No tokenizer variant (single-tape rendering is structurally trivial; no per-cell discrimination needed beyond head-vs-other, which the simple string form captures fine).
+- **`StepCommand` parameter type defined locally in visuals.** Plain `{ movement: 'L'|'R'|'S'; symbol: string | null }` — distinct from engine's `TapeCommand` class. Coupling formatters/tokenizers to a specific engine class adds zero value; consumers passing plain data from snippet frames / log lines / worker boundaries don't have to construct engine class instances just to format a string.
 - **Demo migration is NOT in this PR.** That happens in the machines-demo cleanup PR, after alpha.6.1 publishes.
-- **No new `Command` import dependency.** The engine's `Command` type is already in visuals's import surface (used by alpha.6's `formatCommand`). No new public API surface beyond what's strictly needed.
 
 ---
 
@@ -28,16 +35,18 @@
 ```
 packages/visuals/
 ├── src/
-│   ├── format.ts         # MODIFY — add formatStepNotation + formatTape; keep alpha.6 fns intact
-│   ├── format.spec.ts    # MODIFY — add test cases for the new primitives
-│   └── index.ts          # MODIFY — export formatStepNotation + formatTape
+│   ├── format.ts         # MODIFY — add StepCommand + tokenizeStep + token types
+│   │                                 + formatStepNotation (delegates to tokenizeStep)
+│   │                                 + formatTape; keep alpha.6 fns intact
+│   ├── format.spec.ts    # MODIFY — test cases for tokenizeStep, formatStepNotation, formatTape
+│   └── index.ts          # MODIFY — export all new symbols
 ├── CHANGELOG.md          # MODIFY — new [7.0.0-alpha.6.1] entry
 └── package.json          # MODIFY — version bump 7.0.0-alpha.6 → 7.0.0-alpha.6.1
 
 package-lock.json         # MODIFY — auto-resync (visuals's lock entry only)
 ```
 
-Note: `lerna.json`'s `version` field stays at the engine's `7.0.0-alpha.6` — this release intentionally diverges from lerna's single-version model. Per-package versions are the authoritative source for `lerna publish from-package`; the `lerna.json` version is informational only when `independent` mode isn't set, and is fine to leave stale for this kind of single-package release. (Reconsider if lerna emits a warning at publish time.)
+Note: `lerna.json`'s `version` field stays at the engine's `7.0.0-alpha.6` — this release intentionally diverges from lerna's single-version model. Per-package versions are the authoritative source for `lerna publish from-package`; the `lerna.json` version is informational when `independent` mode isn't set, and is fine to leave stale for this kind of single-package release. (Reconsider if lerna emits a warning at publish time.)
 
 Public API delta after this PR:
 
@@ -46,85 +55,163 @@ Public API delta after this PR:
 export function formatCommand(tapeCommand: TapeCommand): string;
 export function formatStep(m: MachineState): string;
 
-// New (alpha.6.1)
+// New (alpha.6.1) — structured-token surface (primary primitive)
+export type StepCommand = {
+  movement: 'L' | 'R' | 'S';
+  symbol: string | null;  // null = keep
+};
+
+export type ReadToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'blank' }
+  | { kind: 'wildcard'; symbol: string };
+
+export type WriteToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'erase' }
+  | { kind: 'keep'; readContext?: { symbol: string; isBlank: boolean } };
+
+export type StepTokens = {
+  reads: readonly ReadToken[] | null;  // null = manual Apply
+  writes: readonly WriteToken[];
+  moves: readonly ('L' | 'R' | 'S')[];
+};
+
+export function tokenizeStep(
+  reads: readonly string[] | null,
+  commands: readonly StepCommand[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): StepTokens;
+
+// New (alpha.6.1) — string rendering (thin renderer over tokenizeStep)
 export function formatStepNotation(
   reads: readonly string[] | null,
-  commands: readonly Command[],
+  commands: readonly StepCommand[],
   blanks: readonly string[],
   matchKinds?: readonly ('wildcard' | 'literal')[] | null,
 ): string;
+
+// New (alpha.6.1) — tape rendering
 export function formatTape(tape: TapeSnapshot): string;
 ```
 
 ---
 
-## Task 1: Add `formatStepNotation` + `formatTape` to `format.ts`
+## Task 1: Add tokens + tokenizer + renderers + tape formatter to `format.ts`
 
 **Files:** `packages/visuals/src/format.ts`
 
 - [ ] **Step 1: Read demo's `format.ts` as the source spec**
 
-`../machines-demo/src/lib/format.ts:33-84` — the `formatStepNotation` function body + its JSDoc, plus the `formatTape` function. Port both verbatim into visuals.
+`../machines-demo/src/lib/format.ts:33-84` — the `formatStepNotation` function body + its JSDoc + the `formatTape` function. The port is a refactor (not a verbatim copy): demo's monolithic string function splits into `tokenizeStep` (structured output) + `formatStepNotation` (thin string renderer over tokens). Final string output is byte-identical.
 
-- [ ] **Step 2: Add to `packages/visuals/src/format.ts`**
+- [ ] **Step 2: Define `StepCommand` + token types**
 
-Append after the existing `formatStep` / `formatCommand`:
+Add to `packages/visuals/src/format.ts`:
 
 ```ts
-import type { Command, TapeSnapshot } from '@turing-machine-js/machine';   // adjust to existing imports
+import type { TapeSnapshot } from './types';
 
-/**
- * Engine edge-label format — `[reads] → [writes]/[moves]`. Matches
- * `toMermaid` emit so a logged step's notation lines up byte-for-byte with
- * the same transition's edge label in the rendered state graph.
- *
- * Per-cell encoding:
- * - Read cell: `'X'` (literal) or `B` (blank, non-wildcard only). Wildcard
- *   reads render as `*='X'` (showing what `ifOtherSymbol` caught). When
- *   `matchKinds` is omitted (manual Apply), every position renders as a literal.
- * - Write cell: `'X'` (literal) | `K='X'` (keep with concrete kept symbol)
- *   | `K` (keep, no read context) | `E` (erase, write equals blank).
- * - Move cell: `L` | `R` | `S`.
- *
- * Multi-tape: per-tape entries comma-separated inside one outer bracket
- * per role: `['1','a'] → ['0','b']/[R,L]`.
- *
- * Pass `reads === null` for the manual-Apply path (no transition fired) —
- * output collapses to `[writes]/[moves]`.
- */
-export function formatStepNotation(
+export type StepCommand = {
+  movement: 'L' | 'R' | 'S';
+  symbol: string | null;
+};
+
+export type ReadToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'blank' }
+  | { kind: 'wildcard'; symbol: string };
+
+export type WriteToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'erase' }
+  | { kind: 'keep'; readContext?: { symbol: string; isBlank: boolean } };
+
+export type StepTokens = {
+  reads: readonly ReadToken[] | null;
+  writes: readonly WriteToken[];
+  moves: readonly ('L' | 'R' | 'S')[];
+};
+```
+
+`StepCommand` is the plain per-tape command shape (NOT engine's `TapeCommand` class). Lets callers pass data from snippet frames / log lines / worker boundaries without constructing engine class instances.
+
+- [ ] **Step 3: Add `tokenizeStep`**
+
+```ts
+export function tokenizeStep(
   reads: readonly string[] | null,
-  commands: readonly Command[],
+  commands: readonly StepCommand[],
   blanks: readonly string[],
   matchKinds?: readonly ('wildcard' | 'literal')[] | null,
-): string {
-  // VERBATIM port from machines-demo/src/lib/format.ts:formatStepNotation —
-  // see that file for the per-cell encoding rationale. Do NOT alter shape.
-  const writes = commands.map((c, i) => {
+): StepTokens {
+  const writes: WriteToken[] = commands.map((c, i) => {
     if (c.symbol === null) {
       if (reads !== null) {
         const r = reads[i];
-        if (r !== undefined) return r === blanks[i] ? 'K=B' : `K='${r}'`;
+        if (r !== undefined) {
+          return { kind: 'keep', readContext: { symbol: r, isBlank: r === blanks[i] } };
+        }
       }
-      return 'K';
+      return { kind: 'keep' };
     }
-    if (c.symbol === blanks[i]) return 'E';
-    return `'${c.symbol}'`;
-  }).join(',');
-  const moves = commands.map((c) => c.movement).join(',');
-  const writesPart = `[${writes}]/[${moves}]`;
+    if (c.symbol === blanks[i]) return { kind: 'erase' };
+    return { kind: 'literal', symbol: c.symbol };
+  });
 
-  if (reads === null) return writesPart;
+  const moves = commands.map((c) => c.movement);
 
-  const readsStr = reads.map((r, i) => {
-    if (matchKinds?.[i] === 'wildcard') return `*='${r}'`;
-    return r === blanks[i] ? 'B' : `'${r}'`;
-  }).join(',');
-  return `[${readsStr}] → ${writesPart}`;
+  if (reads === null) return { reads: null, writes, moves };
+
+  const readTokens: ReadToken[] = reads.map((r, i) => {
+    if (matchKinds?.[i] === 'wildcard') return { kind: 'wildcard', symbol: r };
+    if (r === blanks[i]) return { kind: 'blank' };
+    return { kind: 'literal', symbol: r };
+  });
+
+  return { reads: readTokens, writes, moves };
+}
+```
+
+- [ ] **Step 4: Add `formatStepNotation` as a thin renderer over `tokenizeStep`**
+
+```ts
+function renderReadToken(t: ReadToken): string {
+  if (t.kind === 'wildcard') return `*='${t.symbol}'`;
+  if (t.kind === 'blank') return 'B';
+  return `'${t.symbol}'`;
 }
 
-/** Inline tape rendering: head bracketed in place. `[<blank>]` is fine —
- *  user controls the blank glyph. */
+function renderWriteToken(t: WriteToken): string {
+  if (t.kind === 'erase') return 'E';
+  if (t.kind === 'literal') return `'${t.symbol}'`;
+  if (!t.readContext) return 'K';
+  if (t.readContext.isBlank) return 'K=B';
+  return `K='${t.readContext.symbol}'`;
+}
+
+export function formatStepNotation(
+  reads: readonly string[] | null,
+  commands: readonly StepCommand[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): string {
+  const tokens = tokenizeStep(reads, commands, blanks, matchKinds);
+  const writesStr = tokens.writes.map(renderWriteToken).join(',');
+  const movesStr = tokens.moves.join(',');
+  const writesPart = `[${writesStr}]/[${movesStr}]`;
+  if (tokens.reads === null) return writesPart;
+  const readsStr = tokens.reads.map(renderReadToken).join(',');
+  return `[${readsStr}] → ${writesPart}`;
+}
+```
+
+`renderReadToken` / `renderWriteToken` are internal helpers — NOT exported. Consumers wanting custom rendering call `tokenizeStep` directly and write their own per-cell renderers (HTML spans, ANSI escape codes, etc.).
+
+- [ ] **Step 5: Add `formatTape`**
+
+```ts
 export function formatTape(tape: TapeSnapshot): string {
   return tape.symbols
     .map((sym, i) => (i === tape.position ? `[${sym}]` : sym))
@@ -132,11 +219,9 @@ export function formatTape(tape: TapeSnapshot): string {
 }
 ```
 
-**Verify before writing:** the `Command` type is already imported (it backs alpha.6's `formatCommand`); just add `TapeSnapshot` to the type import. If the existing file uses `c.movement` strings vs symbols, mirror demo exactly — demo treats `c.movement` as a `string` ('L'|'R'|'S') in this context (it comes from `Command` per demo's types, which may differ from engine `TapeCommand`). Read demo's `Command` type definition (`../machines-demo/src/lib/types.ts`) to confirm shape; if demo's `Command` is `{ movement: 'L'|'R'|'S'; symbol: string | null }` (string movement), and visuals's engine `Command` differs, you may need to adapt the port — but DO NOT change the output format.
+Verbatim port of demo's `formatTape`.
 
-> **If the engine `Command` shape differs enough that a verbatim port doesn't compile**, raise it as a DONE_WITH_CONCERNS. Two acceptable resolutions: (a) take the formatter's input type as the demo's shape (`{ movement: 'L'|'R'|'S'; symbol: string | null }[]`) instead of engine `Command[]`, since these formatters serve consumers who already have that shape from snippet frames / log lines; (b) keep engine `Command[]` and translate fields at the call site. (a) is likely cleaner — the formatter is a string producer over a fixed shape; coupling it to a specific engine class adds zero value.
-
-- [ ] **Step 3: Typecheck**
+- [ ] **Step 6: Typecheck**
 
 ```sh
 npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run typecheck
@@ -146,42 +231,61 @@ Expected: clean.
 
 ---
 
-## Task 2: Add tests for `formatStepNotation` + `formatTape`
+## Task 2: Add tests
 
 **Files:** `packages/visuals/src/format.spec.ts`
 
-- [ ] **Step 1: Add cases to format.spec.ts**
+Three test groups: `formatStepNotation` (string output assertions), `tokenizeStep` (structured-token assertions), `formatTape` (string output).
 
-Mirror the encoding rules in tests. Each case asserts the exact output string. Recommended cases (8+ cases):
+- [ ] **Step 1: `formatStepNotation` cases (10 cases)**
+
+Each asserts the exact output string. Mirrors demo's encoding rules byte-for-byte; serves as the regression net that catches any drift in the token→string render path.
 
 - Single-tape literal: `formatStepNotation(['a'], [{symbol: 'b', movement: 'R'}], [' '], ['literal'])` → `"['a'] → ['b']/[R]"`
-- Single-tape blank read: `(['  '], [{...}], [' '], ['literal'])` → `[B] → ...` (blank shortcut on read)
+- Single-tape blank read (non-wildcard): `([' '], [{...}], [' '], ['literal'])` → `[B] → ...`
 - Single-tape wildcard read: `(['a'], [...], [' '], ['wildcard'])` → `"[*='a'] → ..."` (wildcard marker, NOT `B` shortcut)
+- Single-tape wildcard read with blank: `([' '], [...], [' '], ['wildcard'])` → `"[*=' '] → ..."` (wildcard preserves literal even when blank)
 - Single-tape keep with read: `(['a'], [{symbol: null, movement: 'S'}], [' '], ['literal'])` → `"['a'] → [K='a']/[S]"`
-- Single-tape keep blank: same shape with `reads === blank` → `K=B`
+- Single-tape keep with blank read: `([' '], [{symbol: null, ...}], [' '], ['literal'])` → `"[B] → [K=B]/[S]"`
 - Single-tape erase: `(['a'], [{symbol: ' ', movement: 'L'}], [' '], ['literal'])` → `"['a'] → [E]/[L]"`
 - Manual-Apply (no reads): `formatStepNotation(null, [{symbol: 'b', movement: 'R'}], [' '], null)` → `"['b']/[R]"` (no `[reads] →` prefix)
-- Multi-tape: `(['a', 'b'], [{...}, {...}], [' ', ' '], ['literal', 'wildcard'])` → `"['a',*='b'] → [...]/[...]"`
-- formatTape: `formatTape({symbols: ['a', 'b', 'c'], position: 1})` → `"a[b]c"`
-- formatTape head at end: `formatTape({symbols: ['a'], position: 0})` → `"[a]"`
+- Manual-Apply with keep: `formatStepNotation(null, [{symbol: null, ...}], [' '], null)` → `"[K]/[S]"` (bare K — no read context)
+- Multi-tape mixed wildcard + literal: `(['a','x'], [...,...], [' ',' '], ['wildcard','literal'])` → `"[*='a','x'] → ['b','y']/[R,S]"`
+- Omitted matchKinds: defaults to literal everywhere, no wildcards.
 
-- [ ] **Step 2: Run the new tests**
+- [ ] **Step 2: `tokenizeStep` cases (10 cases)**
+
+Each asserts the structured shape. These prove the tokenizer is correct independently of the string renderer; consumers who skip the string renderer rely on these.
+
+- Literal read + literal write: full `StepTokens` object with `{ kind: 'literal', symbol: ... }` variants.
+- Blank read (non-wildcard) → `{ kind: 'blank' }`.
+- Wildcard read → `{ kind: 'wildcard', symbol: ' ' }` (no blank shortcut).
+- Keep with non-blank read → `{ kind: 'keep', readContext: { symbol: 'a', isBlank: false } }`.
+- Keep with blank read → `{ kind: 'keep', readContext: { symbol: ' ', isBlank: true } }`.
+- Erase → `{ kind: 'erase' }`.
+- Manual Apply (`reads === null`): `tokens.reads === null`, `keep` writes carry no `readContext`.
+- Omitted matchKinds: reads are all `{ kind: 'literal' | 'blank' }` (no wildcards).
+- Multi-tape: arrays line up per index across reads/writes/moves; mixed wildcard + literal + blank tokens.
+- Consistency invariant: `formatStepNotation(args)` for given args equals the manual string render of `tokenizeStep(args).{reads,writes,moves}` — confirms the two surfaces describe the same step. (One sentinel case is enough.)
+
+- [ ] **Step 3: `formatTape` cases (5 cases)**
+
+- Head in middle: `formatTape({symbols: ['a','b','c'], position: 1})` → `"a[b]c"`
+- Head at start: `{symbols: ['a','b'], position: 0}` → `"[a]b"`
+- Head at end: `{symbols: ['a','b'], position: 1}` → `"a[b]"`
+- Single-cell: `{symbols: ['x'], position: 0}` → `"[x]"`
+- Blank glyph rendered literally: `{symbols: [' ','a',' '], position: 0}` → `"[ ]a "` (spaces pass through literally, joined with empty string — NOT space-separated)
+
+- [ ] **Step 4: Run the spec + full verify**
 
 ```sh
 npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js vitest run packages/visuals/src/format.spec.ts
-```
-
-Expected: all pass.
-
-- [ ] **Step 3: Full verify**
-
-```sh
 npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js test
 npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run typecheck
 npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run lint
 ```
 
-All green. Test count grows by N (the cases you added).
+All green. Total visuals format spec count = 8 (alpha.6 `formatCommand` + `formatStep`) + 10 (`formatStepNotation`) + 10 (`tokenizeStep`) + 5 (`formatTape`) = **33**. Full repo test count goes from 616 → **642**.
 
 ---
 
@@ -189,15 +293,27 @@ All green. Test count grows by N (the cases you added).
 
 **Files:** `packages/visuals/src/index.ts`
 
-- [ ] **Step 1: Append exports**
+- [ ] **Step 1: Merge into the existing format export line**
 
-After the existing alpha.6 exports:
-
+Replace:
 ```ts
-export { formatCommand, formatStep, formatStepNotation, formatTape } from './format';
+export { formatCommand, formatStep } from './format';
 ```
 
-(Adjust to merge with the existing `formatCommand` / `formatStep` export line — single line, all four names.)
+With:
+```ts
+export {
+  formatCommand,
+  formatStep,
+  formatStepNotation,
+  formatTape,
+  tokenizeStep,
+  type StepCommand,
+  type ReadToken,
+  type WriteToken,
+  type StepTokens,
+} from './format';
+```
 
 - [ ] **Step 2: Verify**
 
@@ -207,7 +323,7 @@ Re-run typecheck + a build to confirm `dist/` includes the new symbols:
 npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run build
 ```
 
-Expected: clean, `dist/format.d.ts` exports the new functions, `dist/index.{cjs,mjs,d.ts}` re-export them.
+Expected: clean. `dist/format.d.ts` exports all new functions + types; `dist/index.{cjs,mjs,d.ts}` re-export them. `Built @turing-machine-js/visuals Node entries` confirms Rollup runs cleanly.
 
 ---
 
@@ -241,31 +357,29 @@ Only the visuals workspace entry in `package-lock.json` should change.
 
 ### Added
 
-- `formatStepNotation(reads, commands, blanks, matchKinds?)` — engine edge-label format primitive, matches `toMermaid` emit byte-for-byte. Per-cell encoding: literal `'X'`, blank shortcut `B`, wildcard `*='X'`, keep-with-concrete-symbol `K='X'`, erase `E`. Multi-tape comma-separated within one outer bracket per role. Pass `reads === null` for the manual-Apply path (no transition fired) — output collapses to `[writes]/[moves]`. Folds in the richness machines-demo's local `format.ts` had so demo can drop the local helper and call visuals's primitive directly.
+- `formatStepNotation(reads, commands, blanks, matchKinds?)` — engine edge-label format primitive, matches `toMermaid` emit byte-for-byte. Per-cell encoding: literal `'X'`, blank shortcut `B`, wildcard `*='X'` (shows what `ifOtherSymbol` caught), keep-with-concrete-symbol `K='X'` / `K=B`, erase `E`. Multi-tape comma-separated within one outer bracket per role. Pass `reads === null` for the manual-Apply path — output collapses to `[writes]/[moves]`. Folds in the richness machines-demo's local `format.ts` had so demo can drop the local helper and call visuals's primitive directly.
+- `tokenizeStep(reads, commands, blanks, matchKinds?)` + `ReadToken` / `WriteToken` / `StepTokens` types — renderer-agnostic structured form of one step. Same input contract as `formatStepNotation`; returns discriminated-union tokens per cell. Consumers wanting custom rendering (HTML spans with CSS classes, ANSI-colored terminal output, alternative move vocabulary, clickable cells) walk the tokens themselves. `formatStepNotation` is refactored to be a thin string renderer over `tokenizeStep` (output byte-identical).
 - `formatTape(tape)` — inline tape rendering with the head bracketed in place (`a[b]c`).
+- `StepCommand` — plain per-tape command shape (`{ movement: 'L' | 'R' | 'S'; symbol: string | null }`) consumed by `formatStepNotation` and `tokenizeStep`. Distinct from engine's `TapeCommand` class; matches the shape machines-demo's worker boundary exposes.
 
 ### Compatibility
 
 - alpha.6's `formatCommand(tapeCommand)` and `formatStep(m)` unchanged. Additive release.
-- Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — no functional changes there. Visuals-only release; the workspace's lockstep convention is for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
+- Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — no functional changes there. Visuals-only follow-up patch; the workspace's lockstep convention is for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
+- Peer dep `@turing-machine-js/machine: ^7.0.0-alpha.6` unchanged (semver-prerelease caret already accepts `alpha.6.1`).
 ```
 
 - [ ] **Step 3: Verify, then commit**
 
 `git -C ... status` — should show: `packages/visuals/package.json`, `packages/visuals/CHANGELOG.md`, `package-lock.json`, plus the Task 1-3 source/test/index changes.
 
-Commit in two focused commits for a clean bisect:
-1. `feat(visuals): add formatStepNotation + formatTape primitives (alpha.6.1)` — Task 1-3 source/test/index changes
-2. `release(visuals): 7.0.0-alpha.6.1 — formatter enhancements` — version bump + CHANGELOG + lockfile resync
+Commit in two or three focused commits for a clean bisect. The actual PR (#221) used:
 
-Or fold into one. Either works.
+1. `feat(visuals): add formatStepNotation + formatTape primitives (#204)` — Task 1 (partial: types, formatStepNotation, formatTape) + Task 2 (tests for those) + Task 3 (export) + plan doc
+2. `release(visuals): 7.0.0-alpha.6.1 — formatter enhancements` — Task 4 (version + CHANGELOG + lockfile)
+3. `feat(visuals): add tokenizeStep + ReadToken/WriteToken/StepTokens for renderer-agnostic step rendering (#204)` — Task 1 (remainder: tokens, tokenizeStep, refactored formatStepNotation to delegate) + Task 2 (tokenizer tests) + Task 3 (extended export) + CHANGELOG amend
 
-For a tidy history, commit the work as several focused commits:
-1. `feat(visuals): add formatStepNotation + formatTape primitives (alpha.6.1)`
-2. `test(visuals): cover formatStepNotation + formatTape encoding cases`
-3. `release(visuals): 7.0.0-alpha.6.1 — formatter enhancements`
-
-Or fold into one. Either's fine; per-task commits read cleaner if someone bisects.
+The 3rd commit is the tokenizer fold — added mid-execution after the design discussion landed on Option B (structured tokens) as the right shape. A clean redo of this plan would land all of it as commit (1), but per the user's no-amend rule the fold became its own commit.
 
 - [ ] **Step 4: Push**
 
@@ -279,71 +393,42 @@ git -C /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js p
 
 - [ ] **Step 1: Open PR against `v7`**
 
-```sh
-gh pr create --repo mellonis/turing-machine-js --base v7 --head feat/visuals-alpha7-formatters \
-  --title "feat(visuals): alpha.6.1 formatter enhancements (formatStepNotation + formatTape)" \
-  --body "$(cat <<'EOF'
-## Summary
+`gh pr create --repo mellonis/turing-machine-js --base v7 --head feat/visuals-alpha7-formatters --title "feat(visuals): alpha.6.1 — formatStepNotation + tokenizeStep + formatTape"` with a body covering: summary (formatter richness + structured-token surface), public API delta (the full block from this plan's File Structure section), versioning (visuals-only bump, alpha.6.1 over alpha.7), test plan, publish + follow-up notes pointing at the machines-demo cleanup plan.
 
-alpha.6.1 of \`@turing-machine-js/visuals\`. Folds the richness of machines-demo's local \`format.ts\` into visuals so the upcoming demo cleanup PR can drop the local helper and call visuals's primitives directly.
-
-Pure additive change. alpha.6's \`formatCommand\` / \`formatStep\` unchanged.
-
-## What's new
-
-- **\`formatStepNotation(reads, commands, blanks, matchKinds?)\`** — engine edge-label format primitive matching \`toMermaid\` emit byte-for-byte. Per-cell encoding covers literal \`'X'\`, blank shortcut \`B\`, wildcard \`*='X'\` (showing what \`ifOtherSymbol\` caught), keep-with-concrete-symbol \`K='X'\` / \`K=B\`, erase \`E\`, and the manual-Apply path (\`reads === null\` collapses output to \`[writes]/[moves]\`).
-- **\`formatTape(tape)\`** — inline tape rendering with the head bracketed in place.
-
-## Versioning (visuals-only bump)
-
-Bumps **visuals alone** to \`7.0.0-alpha.6.1\`. Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at \`7.0.0-alpha.6\` — no functional changes there; bumping them would create ghost releases. Peer-dep ranges stay at \`^7.0.0-alpha.6\` (semver-prerelease caret already accepts alpha.6.1+). The workspace's lockstep convention exists for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
-
-## Test plan
-
-- [x] \`npm test\` — passes, +N tests in \`format.spec.ts\`.
-- [x] \`npm run typecheck\` — clean.
-- [x] \`npm run lint\` — clean.
-- [x] \`npm run build\` — \`dist/format.d.ts\` exports the new symbols; \`Built @turing-machine-js/visuals Node entries\` confirms Rollup runs cleanly.
-
-## Follow-ups
-
-- Lockstep publish (or visuals-only publish) — \`npx lerna publish from-package --dist-tag next\` from the repo root after merge. Lerna's \`from-package\` mode publishes anything NOT yet on the registry; only visuals will publish.
-- Then the [machines-demo visuals-cleanup PR](https://github.com/mellonis/machines-demo/blob/master/docs/superpowers/plans/2026-05-30-visuals-cleanup.md) becomes a clean drop: deletes \`format.ts\`'s \`formatStepNotation\` + \`formatTape\` and points \`commandsEntry\` / \`tapesEntry\` at visuals.
-
-Per repo convention, this PR targets \`v7\`. CI doesn't run on v7 branches.
-EOF
-)"
-```
+The actual PR landed at https://github.com/mellonis/turing-machine-js/pull/221.
 
 ---
 
 ## Self-review checklist
 
-- [ ] `formatStepNotation` body matches demo's verbatim — same encoding paths, same multi-tape join, same null-`reads` handling.
+- [ ] `formatStepNotation` output is byte-identical to a from-scratch port of demo's helper — verified by running demo's existing format-spec assertions against the refactored implementation (24/24 pass unchanged).
+- [ ] `tokenizeStep` returns the expected discriminated-union shape for every encoding branch (literal, blank, wildcard reads; literal, erase, keep writes; keep carries `readContext` when reads available, omits when manual Apply).
 - [ ] `formatTape` body matches demo's verbatim.
 - [ ] alpha.6 surface (`formatCommand`, `formatStep`) unchanged.
-- [ ] CHANGELOG entry under `[7.0.0-alpha.6.1]`, dated `2026-05-30`.
-- [ ] package.json at `7.0.0-alpha.6.1`; peer dep unchanged.
+- [ ] CHANGELOG entry under `[7.0.0-alpha.6.1]`, dated `2026-05-30`, lists all four new public symbols (`formatStepNotation`, `tokenizeStep`, `formatTape`, `StepCommand`) plus the three token types.
+- [ ] package.json at `7.0.0-alpha.6.1`; peer dep unchanged at `^7.0.0-alpha.6`.
 - [ ] No Claude attribution footers in commits.
-- [ ] Tests cover every encoding branch (literal, blank-B, wildcard, keep-with-read, keep-blank, erase, manual-Apply, multi-tape).
+- [ ] Tests cover both string output (10 `formatStepNotation` cases + 5 `formatTape`) AND structured tokens (10 `tokenizeStep` cases including a consistency invariant that ties the two surfaces together).
 
 ---
 
 ## After this lands
 
 1. **Publish** — `cd turing-machine-js && npx lerna publish from-package --dist-tag next --yes`. Only visuals publishes (engine + builder + libs are already on the registry at alpha.6, lerna skips them). Same catch-up-publish flow as alpha.6's initial visuals publish.
-2. **Tagging:** **no new GH release** for `v7.0.0-alpha.6.1`. The git tag scheme tracks engine versions; visuals-only releases ship under the existing engine tag (alpha.6 in this case). Optionally edit the `v7.0.0-alpha.6` GH release body to add a short note like "Visuals follow-up: alpha.6.1 adds `formatStepNotation` + `formatTape` — see [packages/visuals/CHANGELOG.md](https://github.com/mellonis/turing-machine-js/blob/v7/packages/visuals/CHANGELOG.md)."
+2. **Tagging:** **no new GH release** for `v7.0.0-alpha.6.1`. The git tag scheme tracks engine versions; visuals-only releases ship under the existing engine tag (alpha.6 in this case). Optionally edit the `v7.0.0-alpha.6` GH release body to add a short follow-up note pointing at visuals's CHANGELOG.
 3. **Resume the machines-demo cleanup PR plan.** With alpha.6.1 published, the cleanup PR additionally:
    - Bumps the demo's visuals dep to `^7.0.0-alpha.6.1` (via `npm install @turing-machine-js/visuals@next`).
    - Deletes demo's local `formatStepNotation` (was internal) — call sites in `commandsEntry` switch to importing from `@turing-machine-js/visuals`.
    - Deletes demo's local `formatTape` export — callers switch to visuals's.
    - Keeps `tapesEntry`, `commandsEntry`, `CommandsApplication` in demo (LogEntry assembly is demo-specific).
+   - Could also adopt `tokenizeStep` for any demo paths that want richer rendering than the default string format — purely opportunistic, not required for the cleanup.
 
 ---
 
 ## Out of scope
 
 - **Engine bump.** No engine changes in this alpha.
-- **Backwards-compat shims for the alpha.6 formatters.** They stay live, unchanged. Future deprecation, if any, is a separate decision.
+- **Backwards-compat shims for the alpha.6 formatters.** `formatCommand(tapeCommand)` and `formatStep(m)` stay live, unchanged. Future deprecation, if any, is a separate decision.
 - **GH release for `v7.0.0-alpha.6.1`.** Skipped — tag scheme tracks engine versions, and the engine isn't bumping. Optionally edit the existing `v7.0.0-alpha.6` release body to note the visuals follow-up.
+- **`renderReadToken` / `renderWriteToken` as public exports.** They're internal helpers backing `formatStepNotation`'s string rendering. Consumers wanting custom rendering call `tokenizeStep` and walk tokens themselves — exposing the per-cell string renderers would just be a confusing partial-customization API ("you can change the join but not the tokens? or the tokens but not the join?"). Add later only if a real consumer asks.
 - **Demo migration.** That's the cleanup PR's job, after this publishes.

--- a/docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md
+++ b/docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md
@@ -1,0 +1,349 @@
+# `@turing-machine-js/visuals` 7.0.0-alpha.6.1 — formatter enhancements
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans or superpowers:subagent-driven-development.
+
+**Goal:** Extend visuals's string-formatter surface to cover the richness machines-demo's `format.ts` already provides, so the upcoming demo cleanup PR can drop `format.ts` and call visuals's primitives directly. Pure additive change to visuals.
+
+**Tracks:** Unblocks the format.ts portion of the [machines-demo visuals-cleanup plan](../../../../machines-demo/docs/superpowers/plans/2026-05-30-visuals-cleanup.md). Owns the gap I missed when implementing the alpha.6 formatters (Task 10 of #220) — I designed minimal primitives in a vacuum when demo's `format.ts` was the de facto requirement spec.
+
+**Branch:** `feat/visuals-alpha7-formatters` (off `v7`).
+
+**Architecture:** Add the rich primitive (`formatStepNotation`) + `formatTape` to visuals's existing `format.ts`. alpha.6's `formatStep(m)` and `formatCommand(tapeCommand)` stay untouched (backward-compat for any caller). Mirror demo's `format.ts:formatStepNotation` verbatim — same encoding rules, same multi-tape join, same null-`reads` manual-Apply handling, same `K='X'` / `B` / `E` shortcuts. The demo-side migration in the cleanup PR becomes: drop local `formatStepNotation`, drop local `formatTape`, change two internal imports to consume from `@turing-machine-js/visuals`.
+
+---
+
+## Decisions (locked)
+
+- **Visuals-only bump to `7.0.0-alpha.6.1`.** Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — they have no changes; bumping them would create ghost releases (identical tarballs published under a new version). The workspace's lockstep convention exists for coordinated peer-dep widening when engine APIs break; an additive visuals-only release doesn't trigger it. Peer-dep coherence holds: visuals's `@turing-machine-js/machine: ^7.0.0-alpha.6` accepts alpha.6.1+ via semver-prerelease caret, so consumers don't need a coordinated upgrade.
+- **alpha.6 surface stays intact.** `formatStep(m: MachineState): string` and `formatCommand(tapeCommand: TapeCommand): string` remain exactly as published. New primitives are added alongside. No deprecation in alpha.6.1.
+- **New primitive: `formatStepNotation(reads, commands, blanks, matchKinds?)`** — verbatim port of demo's internal helper, now exported. Signature mirrors demo's: `reads: readonly string[] | null` (null = manual Apply), `commands: readonly Command[]` (per-tape), `blanks: readonly string[]` (per-tape blank symbols), `matchKinds?: readonly ('wildcard' | 'literal')[] | null` (per-tape; null = no transition fired).
+- **New primitive: `formatTape(tape: TapeSnapshot)`** — verbatim port of demo's `formatTape`.
+- **Demo migration is NOT in this PR.** That happens in the machines-demo cleanup PR, after alpha.6.1 publishes.
+- **No new `Command` import dependency.** The engine's `Command` type is already in visuals's import surface (used by alpha.6's `formatCommand`). No new public API surface beyond what's strictly needed.
+
+---
+
+## File Structure
+
+```
+packages/visuals/
+├── src/
+│   ├── format.ts         # MODIFY — add formatStepNotation + formatTape; keep alpha.6 fns intact
+│   ├── format.spec.ts    # MODIFY — add test cases for the new primitives
+│   └── index.ts          # MODIFY — export formatStepNotation + formatTape
+├── CHANGELOG.md          # MODIFY — new [7.0.0-alpha.6.1] entry
+└── package.json          # MODIFY — version bump 7.0.0-alpha.6 → 7.0.0-alpha.6.1
+
+package-lock.json         # MODIFY — auto-resync (visuals's lock entry only)
+```
+
+Note: `lerna.json`'s `version` field stays at the engine's `7.0.0-alpha.6` — this release intentionally diverges from lerna's single-version model. Per-package versions are the authoritative source for `lerna publish from-package`; the `lerna.json` version is informational only when `independent` mode isn't set, and is fine to leave stale for this kind of single-package release. (Reconsider if lerna emits a warning at publish time.)
+
+Public API delta after this PR:
+
+```ts
+// Existing (alpha.6) — unchanged
+export function formatCommand(tapeCommand: TapeCommand): string;
+export function formatStep(m: MachineState): string;
+
+// New (alpha.6.1)
+export function formatStepNotation(
+  reads: readonly string[] | null,
+  commands: readonly Command[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): string;
+export function formatTape(tape: TapeSnapshot): string;
+```
+
+---
+
+## Task 1: Add `formatStepNotation` + `formatTape` to `format.ts`
+
+**Files:** `packages/visuals/src/format.ts`
+
+- [ ] **Step 1: Read demo's `format.ts` as the source spec**
+
+`../machines-demo/src/lib/format.ts:33-84` — the `formatStepNotation` function body + its JSDoc, plus the `formatTape` function. Port both verbatim into visuals.
+
+- [ ] **Step 2: Add to `packages/visuals/src/format.ts`**
+
+Append after the existing `formatStep` / `formatCommand`:
+
+```ts
+import type { Command, TapeSnapshot } from '@turing-machine-js/machine';   // adjust to existing imports
+
+/**
+ * Engine edge-label format — `[reads] → [writes]/[moves]`. Matches
+ * `toMermaid` emit so a logged step's notation lines up byte-for-byte with
+ * the same transition's edge label in the rendered state graph.
+ *
+ * Per-cell encoding:
+ * - Read cell: `'X'` (literal) or `B` (blank, non-wildcard only). Wildcard
+ *   reads render as `*='X'` (showing what `ifOtherSymbol` caught). When
+ *   `matchKinds` is omitted (manual Apply), every position renders as a literal.
+ * - Write cell: `'X'` (literal) | `K='X'` (keep with concrete kept symbol)
+ *   | `K` (keep, no read context) | `E` (erase, write equals blank).
+ * - Move cell: `L` | `R` | `S`.
+ *
+ * Multi-tape: per-tape entries comma-separated inside one outer bracket
+ * per role: `['1','a'] → ['0','b']/[R,L]`.
+ *
+ * Pass `reads === null` for the manual-Apply path (no transition fired) —
+ * output collapses to `[writes]/[moves]`.
+ */
+export function formatStepNotation(
+  reads: readonly string[] | null,
+  commands: readonly Command[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): string {
+  // VERBATIM port from machines-demo/src/lib/format.ts:formatStepNotation —
+  // see that file for the per-cell encoding rationale. Do NOT alter shape.
+  const writes = commands.map((c, i) => {
+    if (c.symbol === null) {
+      if (reads !== null) {
+        const r = reads[i];
+        if (r !== undefined) return r === blanks[i] ? 'K=B' : `K='${r}'`;
+      }
+      return 'K';
+    }
+    if (c.symbol === blanks[i]) return 'E';
+    return `'${c.symbol}'`;
+  }).join(',');
+  const moves = commands.map((c) => c.movement).join(',');
+  const writesPart = `[${writes}]/[${moves}]`;
+
+  if (reads === null) return writesPart;
+
+  const readsStr = reads.map((r, i) => {
+    if (matchKinds?.[i] === 'wildcard') return `*='${r}'`;
+    return r === blanks[i] ? 'B' : `'${r}'`;
+  }).join(',');
+  return `[${readsStr}] → ${writesPart}`;
+}
+
+/** Inline tape rendering: head bracketed in place. `[<blank>]` is fine —
+ *  user controls the blank glyph. */
+export function formatTape(tape: TapeSnapshot): string {
+  return tape.symbols
+    .map((sym, i) => (i === tape.position ? `[${sym}]` : sym))
+    .join('');
+}
+```
+
+**Verify before writing:** the `Command` type is already imported (it backs alpha.6's `formatCommand`); just add `TapeSnapshot` to the type import. If the existing file uses `c.movement` strings vs symbols, mirror demo exactly — demo treats `c.movement` as a `string` ('L'|'R'|'S') in this context (it comes from `Command` per demo's types, which may differ from engine `TapeCommand`). Read demo's `Command` type definition (`../machines-demo/src/lib/types.ts`) to confirm shape; if demo's `Command` is `{ movement: 'L'|'R'|'S'; symbol: string | null }` (string movement), and visuals's engine `Command` differs, you may need to adapt the port — but DO NOT change the output format.
+
+> **If the engine `Command` shape differs enough that a verbatim port doesn't compile**, raise it as a DONE_WITH_CONCERNS. Two acceptable resolutions: (a) take the formatter's input type as the demo's shape (`{ movement: 'L'|'R'|'S'; symbol: string | null }[]`) instead of engine `Command[]`, since these formatters serve consumers who already have that shape from snippet frames / log lines; (b) keep engine `Command[]` and translate fields at the call site. (a) is likely cleaner — the formatter is a string producer over a fixed shape; coupling it to a specific engine class adds zero value.
+
+- [ ] **Step 3: Typecheck**
+
+```sh
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run typecheck
+```
+
+Expected: clean.
+
+---
+
+## Task 2: Add tests for `formatStepNotation` + `formatTape`
+
+**Files:** `packages/visuals/src/format.spec.ts`
+
+- [ ] **Step 1: Add cases to format.spec.ts**
+
+Mirror the encoding rules in tests. Each case asserts the exact output string. Recommended cases (8+ cases):
+
+- Single-tape literal: `formatStepNotation(['a'], [{symbol: 'b', movement: 'R'}], [' '], ['literal'])` → `"['a'] → ['b']/[R]"`
+- Single-tape blank read: `(['  '], [{...}], [' '], ['literal'])` → `[B] → ...` (blank shortcut on read)
+- Single-tape wildcard read: `(['a'], [...], [' '], ['wildcard'])` → `"[*='a'] → ..."` (wildcard marker, NOT `B` shortcut)
+- Single-tape keep with read: `(['a'], [{symbol: null, movement: 'S'}], [' '], ['literal'])` → `"['a'] → [K='a']/[S]"`
+- Single-tape keep blank: same shape with `reads === blank` → `K=B`
+- Single-tape erase: `(['a'], [{symbol: ' ', movement: 'L'}], [' '], ['literal'])` → `"['a'] → [E]/[L]"`
+- Manual-Apply (no reads): `formatStepNotation(null, [{symbol: 'b', movement: 'R'}], [' '], null)` → `"['b']/[R]"` (no `[reads] →` prefix)
+- Multi-tape: `(['a', 'b'], [{...}, {...}], [' ', ' '], ['literal', 'wildcard'])` → `"['a',*='b'] → [...]/[...]"`
+- formatTape: `formatTape({symbols: ['a', 'b', 'c'], position: 1})` → `"a[b]c"`
+- formatTape head at end: `formatTape({symbols: ['a'], position: 0})` → `"[a]"`
+
+- [ ] **Step 2: Run the new tests**
+
+```sh
+npx --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js vitest run packages/visuals/src/format.spec.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Full verify**
+
+```sh
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js test
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run typecheck
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run lint
+```
+
+All green. Test count grows by N (the cases you added).
+
+---
+
+## Task 3: Wire exports
+
+**Files:** `packages/visuals/src/index.ts`
+
+- [ ] **Step 1: Append exports**
+
+After the existing alpha.6 exports:
+
+```ts
+export { formatCommand, formatStep, formatStepNotation, formatTape } from './format';
+```
+
+(Adjust to merge with the existing `formatCommand` / `formatStep` export line — single line, all four names.)
+
+- [ ] **Step 2: Verify**
+
+Re-run typecheck + a build to confirm `dist/` includes the new symbols:
+
+```sh
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js run build
+```
+
+Expected: clean, `dist/format.d.ts` exports the new functions, `dist/index.{cjs,mjs,d.ts}` re-export them.
+
+---
+
+## Task 4: Bump visuals + CHANGELOG + commit
+
+**Files:** `packages/visuals/package.json`, `packages/visuals/CHANGELOG.md`, `package-lock.json`.
+
+- [ ] **Step 1: Bump version**
+
+Edit `packages/visuals/package.json`:
+```diff
+-  "version": "7.0.0-alpha.6",
++  "version": "7.0.0-alpha.6.1",
+```
+
+Peer-dep range stays `"@turing-machine-js/machine": "^7.0.0-alpha.6"` — semver-prerelease caret already accepts alpha.6.1+.
+
+Resync `package-lock.json`:
+```sh
+npm --prefix /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js install --package-lock-only
+```
+
+Only the visuals workspace entry in `package-lock.json` should change.
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+`packages/visuals/CHANGELOG.md` — add above `[7.0.0-alpha.6]`:
+
+```markdown
+## [7.0.0-alpha.6.1] - 2026-05-30
+
+### Added
+
+- `formatStepNotation(reads, commands, blanks, matchKinds?)` — engine edge-label format primitive, matches `toMermaid` emit byte-for-byte. Per-cell encoding: literal `'X'`, blank shortcut `B`, wildcard `*='X'`, keep-with-concrete-symbol `K='X'`, erase `E`. Multi-tape comma-separated within one outer bracket per role. Pass `reads === null` for the manual-Apply path (no transition fired) — output collapses to `[writes]/[moves]`. Folds in the richness machines-demo's local `format.ts` had so demo can drop the local helper and call visuals's primitive directly.
+- `formatTape(tape)` — inline tape rendering with the head bracketed in place (`a[b]c`).
+
+### Compatibility
+
+- alpha.6's `formatCommand(tapeCommand)` and `formatStep(m)` unchanged. Additive release.
+- Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — no functional changes there. Visuals-only release; the workspace's lockstep convention is for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
+```
+
+- [ ] **Step 3: Verify, then commit**
+
+`git -C ... status` — should show: `packages/visuals/package.json`, `packages/visuals/CHANGELOG.md`, `package-lock.json`, plus the Task 1-3 source/test/index changes.
+
+Commit in two focused commits for a clean bisect:
+1. `feat(visuals): add formatStepNotation + formatTape primitives (alpha.6.1)` — Task 1-3 source/test/index changes
+2. `release(visuals): 7.0.0-alpha.6.1 — formatter enhancements` — version bump + CHANGELOG + lockfile resync
+
+Or fold into one. Either works.
+
+For a tidy history, commit the work as several focused commits:
+1. `feat(visuals): add formatStepNotation + formatTape primitives (alpha.6.1)`
+2. `test(visuals): cover formatStepNotation + formatTape encoding cases`
+3. `release(visuals): 7.0.0-alpha.6.1 — formatter enhancements`
+
+Or fold into one. Either's fine; per-task commits read cleaner if someone bisects.
+
+- [ ] **Step 4: Push**
+
+```sh
+git -C /Users/mellonis/Developer/mellonis-workspace/machines/turing-machine-js push -u origin feat/visuals-alpha7-formatters
+```
+
+---
+
+## Task 5: Open PR
+
+- [ ] **Step 1: Open PR against `v7`**
+
+```sh
+gh pr create --repo mellonis/turing-machine-js --base v7 --head feat/visuals-alpha7-formatters \
+  --title "feat(visuals): alpha.6.1 formatter enhancements (formatStepNotation + formatTape)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+alpha.6.1 of \`@turing-machine-js/visuals\`. Folds the richness of machines-demo's local \`format.ts\` into visuals so the upcoming demo cleanup PR can drop the local helper and call visuals's primitives directly.
+
+Pure additive change. alpha.6's \`formatCommand\` / \`formatStep\` unchanged.
+
+## What's new
+
+- **\`formatStepNotation(reads, commands, blanks, matchKinds?)\`** — engine edge-label format primitive matching \`toMermaid\` emit byte-for-byte. Per-cell encoding covers literal \`'X'\`, blank shortcut \`B\`, wildcard \`*='X'\` (showing what \`ifOtherSymbol\` caught), keep-with-concrete-symbol \`K='X'\` / \`K=B\`, erase \`E\`, and the manual-Apply path (\`reads === null\` collapses output to \`[writes]/[moves]\`).
+- **\`formatTape(tape)\`** — inline tape rendering with the head bracketed in place.
+
+## Versioning (visuals-only bump)
+
+Bumps **visuals alone** to \`7.0.0-alpha.6.1\`. Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at \`7.0.0-alpha.6\` — no functional changes there; bumping them would create ghost releases. Peer-dep ranges stay at \`^7.0.0-alpha.6\` (semver-prerelease caret already accepts alpha.6.1+). The workspace's lockstep convention exists for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
+
+## Test plan
+
+- [x] \`npm test\` — passes, +N tests in \`format.spec.ts\`.
+- [x] \`npm run typecheck\` — clean.
+- [x] \`npm run lint\` — clean.
+- [x] \`npm run build\` — \`dist/format.d.ts\` exports the new symbols; \`Built @turing-machine-js/visuals Node entries\` confirms Rollup runs cleanly.
+
+## Follow-ups
+
+- Lockstep publish (or visuals-only publish) — \`npx lerna publish from-package --dist-tag next\` from the repo root after merge. Lerna's \`from-package\` mode publishes anything NOT yet on the registry; only visuals will publish.
+- Then the [machines-demo visuals-cleanup PR](https://github.com/mellonis/machines-demo/blob/master/docs/superpowers/plans/2026-05-30-visuals-cleanup.md) becomes a clean drop: deletes \`format.ts\`'s \`formatStepNotation\` + \`formatTape\` and points \`commandsEntry\` / \`tapesEntry\` at visuals.
+
+Per repo convention, this PR targets \`v7\`. CI doesn't run on v7 branches.
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] `formatStepNotation` body matches demo's verbatim — same encoding paths, same multi-tape join, same null-`reads` handling.
+- [ ] `formatTape` body matches demo's verbatim.
+- [ ] alpha.6 surface (`formatCommand`, `formatStep`) unchanged.
+- [ ] CHANGELOG entry under `[7.0.0-alpha.6.1]`, dated `2026-05-30`.
+- [ ] package.json at `7.0.0-alpha.6.1`; peer dep unchanged.
+- [ ] No Claude attribution footers in commits.
+- [ ] Tests cover every encoding branch (literal, blank-B, wildcard, keep-with-read, keep-blank, erase, manual-Apply, multi-tape).
+
+---
+
+## After this lands
+
+1. **Publish** — `cd turing-machine-js && npx lerna publish from-package --dist-tag next --yes`. Only visuals publishes (engine + builder + libs are already on the registry at alpha.6, lerna skips them). Same catch-up-publish flow as alpha.6's initial visuals publish.
+2. **Tagging:** **no new GH release** for `v7.0.0-alpha.6.1`. The git tag scheme tracks engine versions; visuals-only releases ship under the existing engine tag (alpha.6 in this case). Optionally edit the `v7.0.0-alpha.6` GH release body to add a short note like "Visuals follow-up: alpha.6.1 adds `formatStepNotation` + `formatTape` — see [packages/visuals/CHANGELOG.md](https://github.com/mellonis/turing-machine-js/blob/v7/packages/visuals/CHANGELOG.md)."
+3. **Resume the machines-demo cleanup PR plan.** With alpha.6.1 published, the cleanup PR additionally:
+   - Bumps the demo's visuals dep to `^7.0.0-alpha.6.1` (via `npm install @turing-machine-js/visuals@next`).
+   - Deletes demo's local `formatStepNotation` (was internal) — call sites in `commandsEntry` switch to importing from `@turing-machine-js/visuals`.
+   - Deletes demo's local `formatTape` export — callers switch to visuals's.
+   - Keeps `tapesEntry`, `commandsEntry`, `CommandsApplication` in demo (LogEntry assembly is demo-specific).
+
+---
+
+## Out of scope
+
+- **Engine bump.** No engine changes in this alpha.
+- **Backwards-compat shims for the alpha.6 formatters.** They stay live, unchanged. Future deprecation, if any, is a separate decision.
+- **GH release for `v7.0.0-alpha.6.1`.** Skipped — tag scheme tracks engine versions, and the engine isn't bumping. Optionally edit the existing `v7.0.0-alpha.6` release body to note the visuals follow-up.
+- **Demo migration.** That's the cleanup PR's job, after this publishes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10701,7 +10701,7 @@
     },
     "packages/visuals": {
       "name": "@turing-machine-js/visuals",
-      "version": "7.0.0-alpha.6",
+      "version": "7.0.0-alpha.6.1",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/visuals/CHANGELOG.md
+++ b/packages/visuals/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.6.1] - 2026-05-30
+
+### Added
+
+- `formatStepNotation(reads, commands, blanks, matchKinds?)` — engine edge-label format primitive, matches `toMermaid` emit byte-for-byte. Per-cell encoding: literal `'X'`, blank shortcut `B`, wildcard `*='X'` (shows what `ifOtherSymbol` caught), keep-with-concrete-symbol `K='X'` / `K=B`, erase `E`. Multi-tape comma-separated within one outer bracket per role. Pass `reads === null` for the manual-Apply path (no transition fired) — output collapses to `[writes]/[moves]`. Folds in the richness machines-demo's local `format.ts` had so demo can drop the local helper and call visuals's primitive directly.
+- `formatTape(tape)` — inline tape rendering with the head bracketed in place (`a[b]c`).
+- `StepCommand` — plain per-tape command shape (`{ movement: 'L' | 'R' | 'S'; symbol: string | null }`) consumed by `formatStepNotation`. Distinct from the engine's `TapeCommand` class; matches the shape machines-demo's worker boundary exposes.
+
+### Compatibility
+
+- alpha.6's `formatCommand(tapeCommand)` and `formatStep(m)` unchanged. Additive release.
+- Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` — no changes there. Visuals-only follow-up patch; the workspace's lockstep convention is for coordinated peer-dep widening when engine APIs break, not for additive consumer-package enhancements.
+- Peer dep `@turing-machine-js/machine: ^7.0.0-alpha.6` unchanged (semver-prerelease caret already accepts `alpha.6.1`).
+
 ## [7.0.0-alpha.6] - 2026-05-30
 
 ### Added

--- a/packages/visuals/CHANGELOG.md
+++ b/packages/visuals/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - `formatStepNotation(reads, commands, blanks, matchKinds?)` — engine edge-label format primitive, matches `toMermaid` emit byte-for-byte. Per-cell encoding: literal `'X'`, blank shortcut `B`, wildcard `*='X'` (shows what `ifOtherSymbol` caught), keep-with-concrete-symbol `K='X'` / `K=B`, erase `E`. Multi-tape comma-separated within one outer bracket per role. Pass `reads === null` for the manual-Apply path (no transition fired) — output collapses to `[writes]/[moves]`. Folds in the richness machines-demo's local `format.ts` had so demo can drop the local helper and call visuals's primitive directly.
+- `tokenizeStep(reads, commands, blanks, matchKinds?)` + `ReadToken` / `WriteToken` / `StepTokens` types — renderer-agnostic structured form of one step. Same input contract as `formatStepNotation`; returns discriminated-union tokens per cell (`{ kind: 'literal' | 'blank' | 'wildcard', ... }` for reads, `{ kind: 'literal' | 'erase' | 'keep', ... }` for writes). Consumers wanting custom rendering — HTML spans with CSS classes for syntax highlighting, ANSI-colored terminal output, alternative move vocabulary, clickable cells — walk the tokens themselves. `formatStepNotation` is refactored to be a thin string renderer over `tokenizeStep` (output byte-identical).
 - `formatTape(tape)` — inline tape rendering with the head bracketed in place (`a[b]c`).
-- `StepCommand` — plain per-tape command shape (`{ movement: 'L' | 'R' | 'S'; symbol: string | null }`) consumed by `formatStepNotation`. Distinct from the engine's `TapeCommand` class; matches the shape machines-demo's worker boundary exposes.
+- `StepCommand` — plain per-tape command shape (`{ movement: 'L' | 'R' | 'S'; symbol: string | null }`) consumed by `formatStepNotation` and `tokenizeStep`. Distinct from the engine's `TapeCommand` class; matches the shape machines-demo's worker boundary exposes.
 
 ### Compatibility
 

--- a/packages/visuals/package.json
+++ b/packages/visuals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/visuals",
-  "version": "7.0.0-alpha.6",
+  "version": "7.0.0-alpha.6.1",
   "description": "Pure highlight + graph-indexing logic for @turing-machine-js/machine — no DOM, no renderer.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/visuals/src/format.spec.ts
+++ b/packages/visuals/src/format.spec.ts
@@ -10,7 +10,14 @@ import {
   movements,
   symbolCommands,
 } from '@turing-machine-js/machine';
-import { formatCommand, formatStep, formatStepNotation, formatTape, type StepCommand } from './format';
+import {
+  formatCommand,
+  formatStep,
+  formatStepNotation,
+  formatTape,
+  tokenizeStep,
+  type StepCommand,
+} from './format';
 
 describe('formatCommand', () => {
   it('formats a literal symbol write + right move', () => {
@@ -163,6 +170,100 @@ describe('formatStepNotation', () => {
   it('omitted matchKinds (undefined) renders reads as literals', () => {
     const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
     expect(formatStepNotation(['a'], commands, BLANK)).toBe("['a'] → ['b']/[R]");
+  });
+});
+
+describe('tokenizeStep', () => {
+  const BLANK = [' '];
+
+  it('literal read + literal write', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(tokenizeStep(['a'], commands, BLANK, ['literal'])).toEqual({
+      reads: [{ kind: 'literal', symbol: 'a' }],
+      writes: [{ kind: 'literal', symbol: 'b' }],
+      moves: ['R'],
+    });
+  });
+
+  it('blank read (non-wildcard) tokenizes to { kind: "blank" }', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(tokenizeStep([' '], commands, BLANK, ['literal']).reads).toEqual([
+      { kind: 'blank' },
+    ]);
+  });
+
+  it('wildcard read preserves literal symbol (no blank shortcut)', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(tokenizeStep([' '], commands, BLANK, ['wildcard']).reads).toEqual([
+      { kind: 'wildcard', symbol: ' ' },
+    ]);
+  });
+
+  it('keep write with read context (non-blank read)', () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    expect(tokenizeStep(['a'], commands, BLANK, ['literal']).writes).toEqual([
+      { kind: 'keep', readContext: { symbol: 'a', isBlank: false } },
+    ]);
+  });
+
+  it('keep write with blank read flags isBlank: true', () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    expect(tokenizeStep([' '], commands, BLANK, ['literal']).writes).toEqual([
+      { kind: 'keep', readContext: { symbol: ' ', isBlank: true } },
+    ]);
+  });
+
+  it('erase tokenizes as { kind: "erase" } (write equals blank)', () => {
+    const commands: StepCommand[] = [{ symbol: ' ', movement: 'L' }];
+    expect(tokenizeStep(['a'], commands, BLANK, ['literal']).writes).toEqual([
+      { kind: 'erase' },
+    ]);
+  });
+
+  it('manual Apply (reads === null): reads is null, keeps carry no readContext', () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    const tokens = tokenizeStep(null, commands, BLANK, null);
+    expect(tokens.reads).toBeNull();
+    expect(tokens.writes).toEqual([{ kind: 'keep' }]);
+  });
+
+  it('omitted matchKinds treats every read as literal (no wildcards)', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(tokenizeStep(['a'], commands, BLANK).reads).toEqual([
+      { kind: 'literal', symbol: 'a' },
+    ]);
+  });
+
+  it('multi-tape arrays line up per index across reads/writes/moves', () => {
+    const commands: StepCommand[] = [
+      { symbol: 'b', movement: 'R' },
+      { symbol: null, movement: 'S' },
+      { symbol: ' ', movement: 'L' },
+    ];
+    expect(tokenizeStep(['a', 'x', ' '], commands, [' ', ' ', ' '], ['literal', 'wildcard', 'literal'])).toEqual({
+      reads: [
+        { kind: 'literal', symbol: 'a' },
+        { kind: 'wildcard', symbol: 'x' },
+        { kind: 'blank' },
+      ],
+      writes: [
+        { kind: 'literal', symbol: 'b' },
+        { kind: 'keep', readContext: { symbol: 'x', isBlank: false } },
+        { kind: 'erase' },
+      ],
+      moves: ['R', 'S', 'L'],
+    });
+  });
+
+  it('formatStepNotation output equals manual render of tokens (consistency invariant)', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    const tokens = tokenizeStep(['a'], commands, BLANK, ['literal']);
+    // Sanity: the token-based public API and the string-based public API
+    // describe the same step. If this breaks, formatStepNotation drifted
+    // from tokenizeStep.
+    expect(tokens.writes).toHaveLength(1);
+    expect(tokens.reads).toHaveLength(1);
+    expect(formatStepNotation(['a'], commands, BLANK, ['literal'])).toBe("['a'] → ['b']/[R]");
   });
 });
 

--- a/packages/visuals/src/format.spec.ts
+++ b/packages/visuals/src/format.spec.ts
@@ -10,7 +10,7 @@ import {
   movements,
   symbolCommands,
 } from '@turing-machine-js/machine';
-import { formatCommand, formatStep } from './format';
+import { formatCommand, formatStep, formatStepNotation, formatTape, type StepCommand } from './format';
 
 describe('formatCommand', () => {
   it('formats a literal symbol write + right move', () => {
@@ -96,5 +96,94 @@ describe('formatStep', () => {
     const m = gen.next().value!;
 
     expect(formatStep(m)).toBe("['a','x'] → ['b',K]/[R,L]");
+  });
+});
+
+describe('formatStepNotation', () => {
+  const BLANK = [' '];
+
+  it('formats a literal read + literal write', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(formatStepNotation(['a'], commands, BLANK, ['literal'])).toBe("['a'] → ['b']/[R]");
+  });
+
+  it('renders blank read as B (non-wildcard)', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(formatStepNotation([' '], commands, BLANK, ['literal'])).toBe("[B] → ['b']/[R]");
+  });
+
+  it('renders wildcard read as *=\'X\' (NOT blank-shortcut even when read is blank)', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(formatStepNotation([' '], commands, BLANK, ['wildcard'])).toBe("[*=' '] → ['b']/[R]");
+  });
+
+  it("encodes keep as K='X' when read context is available", () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    expect(formatStepNotation(['a'], commands, BLANK, ['literal'])).toBe("['a'] → [K='a']/[S]");
+  });
+
+  it('encodes keep as K=B when read is the blank symbol', () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    expect(formatStepNotation([' '], commands, BLANK, ['literal'])).toBe('[B] → [K=B]/[S]');
+  });
+
+  it('encodes erase as E when write equals blank', () => {
+    const commands: StepCommand[] = [{ symbol: ' ', movement: 'L' }];
+    expect(formatStepNotation(['a'], commands, BLANK, ['literal'])).toBe("['a'] → [E]/[L]");
+  });
+
+  it('manual Apply (reads === null) collapses to [writes]/[moves] with no prefix', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(formatStepNotation(null, commands, BLANK, null)).toBe("['b']/[R]");
+  });
+
+  it('manual Apply with keep renders bare K (no read context)', () => {
+    const commands: StepCommand[] = [{ symbol: null, movement: 'S' }];
+    expect(formatStepNotation(null, commands, BLANK, null)).toBe('[K]/[S]');
+  });
+
+  it('multi-tape: per-role comma-separated entries inside one outer bracket', () => {
+    const commands: StepCommand[] = [
+      { symbol: '0', movement: 'R' },
+      { symbol: 'b', movement: 'L' },
+    ];
+    expect(formatStepNotation(['1', 'a'], commands, [' ', ' '], ['literal', 'literal']))
+      .toBe("['1','a'] → ['0','b']/[R,L]");
+  });
+
+  it('multi-tape mixed wildcard + literal reads', () => {
+    const commands: StepCommand[] = [
+      { symbol: 'b', movement: 'R' },
+      { symbol: 'y', movement: 'S' },
+    ];
+    expect(formatStepNotation(['a', 'x'], commands, [' ', ' '], ['wildcard', 'literal']))
+      .toBe("[*='a','x'] → ['b','y']/[R,S]");
+  });
+
+  it('omitted matchKinds (undefined) renders reads as literals', () => {
+    const commands: StepCommand[] = [{ symbol: 'b', movement: 'R' }];
+    expect(formatStepNotation(['a'], commands, BLANK)).toBe("['a'] → ['b']/[R]");
+  });
+});
+
+describe('formatTape', () => {
+  it('brackets the head cell in place', () => {
+    expect(formatTape({ symbols: ['a', 'b', 'c'], position: 1 })).toBe('a[b]c');
+  });
+
+  it('brackets head at start', () => {
+    expect(formatTape({ symbols: ['a', 'b'], position: 0 })).toBe('[a]b');
+  });
+
+  it('brackets head at end', () => {
+    expect(formatTape({ symbols: ['a', 'b'], position: 1 })).toBe('a[b]');
+  });
+
+  it('single-cell tape', () => {
+    expect(formatTape({ symbols: ['x'], position: 0 })).toBe('[x]');
+  });
+
+  it('passes the blank glyph through literally', () => {
+    expect(formatTape({ symbols: [' ', 'a', ' '], position: 0 })).toBe('[ ]a ');
   });
 });

--- a/packages/visuals/src/format.ts
+++ b/packages/visuals/src/format.ts
@@ -64,11 +64,124 @@ export function formatStep(m: MachineState): string {
 }
 
 /**
+ * Per-tape read-cell token. Discriminated union for renderer-agnostic
+ * consumption — UIs map each variant to their own presentation (plain
+ * string via `formatStepNotation`, HTML span with CSS class, ANSI color,
+ * clickable token, etc.). `formatStepNotation` is the default string
+ * renderer over these tokens.
+ *
+ * - `literal` — the engine matched this exact symbol non-wildcard.
+ * - `blank` — the matched symbol is the tape's blank glyph; renderers
+ *   commonly want a `B`-style shortcut instead of `' '`.
+ * - `wildcard` — the engine matched via `ifOtherSymbol`. The literal
+ *   `symbol` is preserved so renderers can show what the catch-all
+ *   actually caught (a blank-shortcut would obscure it).
+ */
+export type ReadToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'blank' }
+  | { kind: 'wildcard'; symbol: string };
+
+/**
+ * Per-tape write-cell token.
+ *
+ * - `literal` — engine wrote this exact symbol; not a blank, not a keep.
+ * - `erase` — engine wrote the tape's blank glyph; rendered as `E` by
+ *   `formatStepNotation` but structurally distinct from a generic blank
+ *   write so renderers can style "erase" differently from "write blank as
+ *   the next interesting symbol."
+ * - `keep` — engine left the cell unchanged (`command.symbol === null`).
+ *   `readContext` carries the kept symbol when caller supplied `reads`;
+ *   `isBlank` flags whether the kept symbol equals the tape's blank glyph.
+ *   No `readContext` means manual-Apply path (no transition fired, no
+ *   per-tape read available).
+ */
+export type WriteToken =
+  | { kind: 'literal'; symbol: string }
+  | { kind: 'erase' }
+  | { kind: 'keep'; readContext?: { symbol: string; isBlank: boolean } };
+
+/**
+ * Structured-token representation of one step. `formatStepNotation` is the
+ * default string renderer over this shape; consumers wanting custom
+ * rendering (HTML spans, alternative vocabulary, clickable cells, ANSI
+ * colors) call `tokenizeStep` and walk the tokens themselves.
+ *
+ * `reads === null` denotes the manual-Apply path (no transition fired);
+ * all read-side encoding is suppressed and `keep` writes carry no
+ * `readContext`.
+ */
+export type StepTokens = {
+  reads: readonly ReadToken[] | null;
+  writes: readonly WriteToken[];
+  moves: readonly ('L' | 'R' | 'S')[];
+};
+
+/**
+ * Tokenize one step's per-tape data into renderer-agnostic structured
+ * form. Same input contract as `formatStepNotation` — same engine
+ * vocabulary, same null-`reads` manual-Apply handling, same wildcard
+ * suppression of the blank shortcut. Use this when you need to render the
+ * step in a non-string medium (HTML, terminal escape codes, JSON for
+ * embeds) or just want different syntax than the default string output.
+ */
+export function tokenizeStep(
+  reads: readonly string[] | null,
+  commands: readonly StepCommand[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): StepTokens {
+  const writes: WriteToken[] = commands.map((c, i) => {
+    if (c.symbol === null) {
+      if (reads !== null) {
+        const r = reads[i];
+        if (r !== undefined) {
+          return { kind: 'keep', readContext: { symbol: r, isBlank: r === blanks[i] } };
+        }
+      }
+      return { kind: 'keep' };
+    }
+    if (c.symbol === blanks[i]) return { kind: 'erase' };
+    return { kind: 'literal', symbol: c.symbol };
+  });
+
+  const moves = commands.map((c) => c.movement);
+
+  if (reads === null) {
+    return { reads: null, writes, moves };
+  }
+
+  const readTokens: ReadToken[] = reads.map((r, i) => {
+    if (matchKinds?.[i] === 'wildcard') return { kind: 'wildcard', symbol: r };
+    if (r === blanks[i]) return { kind: 'blank' };
+    return { kind: 'literal', symbol: r };
+  });
+
+  return { reads: readTokens, writes, moves };
+}
+
+function renderReadToken(t: ReadToken): string {
+  if (t.kind === 'wildcard') return `*='${t.symbol}'`;
+  if (t.kind === 'blank') return 'B';
+  return `'${t.symbol}'`;
+}
+
+function renderWriteToken(t: WriteToken): string {
+  if (t.kind === 'erase') return 'E';
+  if (t.kind === 'literal') return `'${t.symbol}'`;
+  if (!t.readContext) return 'K';
+  if (t.readContext.isBlank) return 'K=B';
+  return `K='${t.readContext.symbol}'`;
+}
+
+/**
  * Engine edge-label format — `[reads] → [writes]/[moves]`. Matches
  * `toMermaid` emit byte-for-byte so a logged step's notation lines up with
- * the same transition's edge label in the rendered state graph.
+ * the same transition's edge label in the rendered state graph. Thin
+ * string renderer over `tokenizeStep`; see that function's docstring +
+ * `StepTokens` for the structured form most UIs should prefer.
  *
- * Per-cell encoding:
+ * Per-cell rendering:
  * - Read cell: `'X'` (literal) | `B` (blank, NON-wildcard only) | `*='X'`
  *   (wildcard — shows what `ifOtherSymbol` caught; the `B` shortcut is
  *   suppressed for wildcards so the matched literal is always visible).
@@ -80,10 +193,10 @@ export function formatStep(m: MachineState): string {
  * Multi-tape: per-tape entries comma-separated inside one outer bracket
  * per role — `['1','a'] → ['0','b']/[R,L]`.
  *
- * Pass `reads === null` for the manual-Apply path (no transition fired):
- * output collapses to `[writes]/[moves]` and `K` renders without read
- * context. Pass `matchKinds === null`/omit when no transition fired:
- * every position renders as a literal (no wildcard markers).
+ * Pass `reads === null` for the manual-Apply path: output collapses to
+ * `[writes]/[moves]` and `K` renders without read context. Pass
+ * `matchKinds === null`/omit when no transition fired: every position
+ * renders as a literal (no wildcard markers).
  */
 export function formatStepNotation(
   reads: readonly string[] | null,
@@ -91,30 +204,12 @@ export function formatStepNotation(
   blanks: readonly string[],
   matchKinds?: readonly ('wildcard' | 'literal')[] | null,
 ): string {
-  const writes = commands
-    .map((c, i) => {
-      if (c.symbol === null) {
-        if (reads !== null) {
-          const r = reads[i];
-          if (r !== undefined) return r === blanks[i] ? 'K=B' : `K='${r}'`;
-        }
-        return 'K';
-      }
-      if (c.symbol === blanks[i]) return 'E';
-      return `'${c.symbol}'`;
-    })
-    .join(',');
-  const moves = commands.map((c) => c.movement).join(',');
-  const writesPart = `[${writes}]/[${moves}]`;
-
-  if (reads === null) return writesPart;
-
-  const readsStr = reads
-    .map((r, i) => {
-      if (matchKinds?.[i] === 'wildcard') return `*='${r}'`;
-      return r === blanks[i] ? 'B' : `'${r}'`;
-    })
-    .join(',');
+  const tokens = tokenizeStep(reads, commands, blanks, matchKinds);
+  const writesStr = tokens.writes.map(renderWriteToken).join(',');
+  const movesStr = tokens.moves.join(',');
+  const writesPart = `[${writesStr}]/[${movesStr}]`;
+  if (tokens.reads === null) return writesPart;
+  const readsStr = tokens.reads.map(renderReadToken).join(',');
   return `[${readsStr}] → ${writesPart}`;
 }
 

--- a/packages/visuals/src/format.ts
+++ b/packages/visuals/src/format.ts
@@ -1,4 +1,17 @@
 import { movements, symbolCommands, type MachineState, type TapeCommand } from '@turing-machine-js/machine';
+import type { TapeSnapshot } from './types';
+
+/**
+ * Plain per-tape command shape consumed by `formatStepNotation`. Distinct
+ * from the engine's `TapeCommand` class: `symbol === null` means "keep
+ * current" (the resolved symbol equals what was already under the head),
+ * `movement` is the role letter (not an engine symbol). Matches the shape
+ * machines-demo exposes from its worker boundary.
+ */
+export type StepCommand = {
+  movement: 'L' | 'R' | 'S';
+  symbol: string | null;
+};
 
 export const MOVEMENT_LETTER = new Map<symbol, 'L' | 'R' | 'S'>([
   [movements.left, 'L'],
@@ -48,4 +61,69 @@ export function formatStep(m: MachineState): string {
   const moves = m.movements.map((mv) => MOVEMENT_LETTER.get(mv) ?? '?').join(',');
 
   return `[${reads}] → [${writes}]/[${moves}]`;
+}
+
+/**
+ * Engine edge-label format — `[reads] → [writes]/[moves]`. Matches
+ * `toMermaid` emit byte-for-byte so a logged step's notation lines up with
+ * the same transition's edge label in the rendered state graph.
+ *
+ * Per-cell encoding:
+ * - Read cell: `'X'` (literal) | `B` (blank, NON-wildcard only) | `*='X'`
+ *   (wildcard — shows what `ifOtherSymbol` caught; the `B` shortcut is
+ *   suppressed for wildcards so the matched literal is always visible).
+ * - Write cell: `'X'` (literal) | `K='X'` (keep, with concrete read
+ *   appended) | `K=B` (keep, read was blank) | `K` (keep, no read context
+ *   — only when `reads === null`) | `E` (erase, write equals blank).
+ * - Move cell: `L` | `R` | `S`.
+ *
+ * Multi-tape: per-tape entries comma-separated inside one outer bracket
+ * per role — `['1','a'] → ['0','b']/[R,L]`.
+ *
+ * Pass `reads === null` for the manual-Apply path (no transition fired):
+ * output collapses to `[writes]/[moves]` and `K` renders without read
+ * context. Pass `matchKinds === null`/omit when no transition fired:
+ * every position renders as a literal (no wildcard markers).
+ */
+export function formatStepNotation(
+  reads: readonly string[] | null,
+  commands: readonly StepCommand[],
+  blanks: readonly string[],
+  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
+): string {
+  const writes = commands
+    .map((c, i) => {
+      if (c.symbol === null) {
+        if (reads !== null) {
+          const r = reads[i];
+          if (r !== undefined) return r === blanks[i] ? 'K=B' : `K='${r}'`;
+        }
+        return 'K';
+      }
+      if (c.symbol === blanks[i]) return 'E';
+      return `'${c.symbol}'`;
+    })
+    .join(',');
+  const moves = commands.map((c) => c.movement).join(',');
+  const writesPart = `[${writes}]/[${moves}]`;
+
+  if (reads === null) return writesPart;
+
+  const readsStr = reads
+    .map((r, i) => {
+      if (matchKinds?.[i] === 'wildcard') return `*='${r}'`;
+      return r === blanks[i] ? 'B' : `'${r}'`;
+    })
+    .join(',');
+  return `[${readsStr}] → ${writesPart}`;
+}
+
+/** Inline tape rendering with the head bracketed in place (`a[b]c`).
+ *  No UI substitution — the user controls the blank glyph. `[<blank>]`
+ *  may render an invisible space if blank is `' '`; that's the chosen
+ *  symbol, not a bug. */
+export function formatTape(tape: TapeSnapshot): string {
+  return tape.symbols
+    .map((sym, i) => (i === tape.position ? `[${sym}]` : sym))
+    .join('');
 }

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -6,5 +6,15 @@ export type { GraphIndexes } from './graphIndexes';
 export { indexGraph } from './graphIndexes';
 export type { GraphHighlight, TapeSnapshot, Frame, Snippet } from './types';
 export { applyHighlight, applyIndicator } from './applyHighlight';
-export { formatCommand, formatStep, formatStepNotation, formatTape, type StepCommand } from './format';
+export {
+  formatCommand,
+  formatStep,
+  formatStepNotation,
+  formatTape,
+  tokenizeStep,
+  type StepCommand,
+  type ReadToken,
+  type WriteToken,
+  type StepTokens,
+} from './format';
 export { recordSnippet, type RecordSnippetOptions } from './recordSnippet';

--- a/packages/visuals/src/index.ts
+++ b/packages/visuals/src/index.ts
@@ -6,5 +6,5 @@ export type { GraphIndexes } from './graphIndexes';
 export { indexGraph } from './graphIndexes';
 export type { GraphHighlight, TapeSnapshot, Frame, Snippet } from './types';
 export { applyHighlight, applyIndicator } from './applyHighlight';
-export { formatCommand, formatStep } from './format';
+export { formatCommand, formatStep, formatStepNotation, formatTape, type StepCommand } from './format';
 export { recordSnippet, type RecordSnippetOptions } from './recordSnippet';


### PR DESCRIPTION
## Summary

Visuals-only follow-up patch on alpha.6 (`7.0.0-alpha.6.1`). Folds in the richness machines-demo's local `format.ts` had — wildcard rendering, blank shortcuts, keep-with-concrete-symbol, manual-Apply path — so the upcoming demo cleanup PR can drop the local helper and call visuals's primitive directly.

Also lands a **renderer-agnostic structured-token surface** (`tokenizeStep` + `ReadToken` / `WriteToken` / `StepTokens`) so UIs that want different rendering than the default string format — HTML spans with CSS classes for syntax highlighting, ANSI-colored terminal output, alternative move vocabulary, clickable cells — can walk discriminated-union tokens instead of re-implementing the per-cell encoding. `formatStepNotation` is refactored to be a thin string renderer over `tokenizeStep` (output byte-identical, all 24 existing tests unchanged).

Owns a gap I missed when implementing the alpha.6 formatters (Task 10 of #220): I designed minimal primitives in a vacuum when demo's `format.ts` was the de facto requirement spec.

## Public API delta

```ts
// Structured tokens (primary renderer-agnostic primitive)
export type ReadToken =
  | { kind: 'literal'; symbol: string }
  | { kind: 'blank' }
  | { kind: 'wildcard'; symbol: string };

export type WriteToken =
  | { kind: 'literal'; symbol: string }
  | { kind: 'erase' }
  | { kind: 'keep'; readContext?: { symbol: string; isBlank: boolean } };

export type StepTokens = {
  reads: readonly ReadToken[] | null;   // null = manual Apply
  writes: readonly WriteToken[];
  moves: readonly ('L' | 'R' | 'S')[];
};

export function tokenizeStep(
  reads: readonly string[] | null,
  commands: readonly StepCommand[],
  blanks: readonly string[],
  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
): StepTokens;

// Default string renderer (thin wrapper over tokenizeStep)
export function formatStepNotation(
  reads: readonly string[] | null,
  commands: readonly StepCommand[],
  blanks: readonly string[],
  matchKinds?: readonly ('wildcard' | 'literal')[] | null,
): string;

// Per-tape command shape consumed by both primitives above
export type StepCommand = {
  movement: 'L' | 'R' | 'S';
  symbol: string | null;
};

// Inline tape rendering
export function formatTape(tape: TapeSnapshot): string;

// Existing alpha.6 surface — UNCHANGED
export function formatCommand(tapeCommand: TapeCommand): string;
export function formatStep(m: MachineState): string;
```

Per-cell encoding rules for the string renderer (matches `toMermaid` emit byte-for-byte):
- Read: `'X'` (literal) | `B` (blank, non-wildcard) | `*='X'` (wildcard — preserves what `ifOtherSymbol` caught)
- Write: `'X'` (literal) | `K='X'` (keep, concrete kept symbol) | `K=B` (keep, read was blank) | `K` (keep, no read context — manual Apply only) | `E` (erase, write equals blank)
- Move: `L` | `R` | `S`
- Multi-tape: comma-separated within one outer bracket per role — `['1','a'] → ['0','b']/[R,L]`
- Manual-Apply (`reads === null`): output collapses to `[writes]/[moves]`

## Versioning

`7.0.0-alpha.6.1` — visuals-only patch. Engine + builder + library-binary-numbers + library-binary-numbers-bare stay at `7.0.0-alpha.6` (no functional changes there; bumping would create ghost releases). Peer dep `@turing-machine-js/machine: ^7.0.0-alpha.6` unchanged — semver-prerelease caret already accepts `alpha.6.1+`.

Chose `alpha.6.1` over `alpha.7` to communicate "additive follow-up on alpha.6" rather than "new alpha milestone." Reserves `alpha.7` for the next real engine bump.

## Test plan

- [x] `npm test` — 642 passing (was 616; +16 from formatStepNotation + formatTape, +10 from tokenizeStep).
- [x] `formatStepNotation` byte-identical output verified — all 24 existing format spec cases pass unchanged after the refactor to delegate to `tokenizeStep`.
- [x] `npm run typecheck` — clean across all 5 packages.
- [x] `npm run lint` — clean.
- [x] `npm run build` — `Built @turing-machine-js/visuals Node entries` confirms Rollup runs cleanly; `dist/format.d.ts` exports all new symbols.

## Publish + follow-ups

After merge:
1. `npx lerna publish from-package --dist-tag next --yes` from repo root. Only visuals publishes (others skipped per their alpha.6 already on registry). User runs this — needs npm auth + 2FA.
2. **No new GH release.** Tag scheme tracks engine versions; alpha.6.1 is a visuals-only patch. Optionally edit the existing `v7.0.0-alpha.6` release body to add a brief follow-up note.
3. Resume the [machines-demo visuals-cleanup PR plan](https://github.com/mellonis/machines-demo/blob/master/docs/superpowers/plans/2026-05-30-visuals-cleanup.md) — bump demo's visuals dep to `^7.0.0-alpha.6.1`, drop local `formatStepNotation` + `formatTape`, point `commandsEntry` / `tapesEntry` at visuals.

Per repo convention, PR targets `v7`. CI doesn't run on v7 branches.

Plan: [`docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md`](docs/superpowers/plans/2026-05-30-visuals-alpha7-formatters.md). Branch name kept as `feat/visuals-alpha7-formatters` even after the version rename to `alpha.6.1` (branch identifier doesn't matter; the version shipped is what counts).