### PR TITLE
fix(machine): toGraph reach-set tunnels through wrappers to their continuation (#223)

### DIFF
--- a/packages/library-binary-numbers/states.md
+++ b/packages/library-binary-numbers/states.md
@@ -190,7 +190,6 @@ flowchart TD
 %% alphabets: [[" ","^","$","0","1"]]
   s0(((halt)))
   s1["goToNumber"]
-  s9["invertNumberGoToNumberWithInversion"]
   s12["normalizeNumberPutNewStartSymbol"]
   s13["normalizeNumberMoveNumberStart"]
   s15["normalizeNumber"]
@@ -206,6 +205,7 @@ flowchart TD
     c5(((halt)))
   end
   subgraph w_11["callable subtree of invertNumber"]
+    s9["invertNumberGoToNumberWithInversion"]
     s11["invertNumber"]
     c11(((halt)))
   end
@@ -235,7 +235,7 @@ flowchart TD
   s9 -- "['^'] → [K]/[R]" --> s9
   s9 -- "['1'] → ['0']/[R]" --> s9
   s9 -- "['0'] → ['1']/[R]" --> s9
-  s9 -- "['$'] → [K]/[S]" --> s0
+  s9 -- "['$'] → [K]/[S]" --> c11
   s11 -- "['^']|['1']|['0']|['$'] → [K]/[S]" --> s10
   s11 -- "[*] → [K]/[S]" --> c11
   s12 -- "[B] → ['^']/[S]" --> s1

--- a/packages/library-binary-numbers/states.md
+++ b/packages/library-binary-numbers/states.md
@@ -194,7 +194,6 @@ flowchart TD
   s13["normalizeNumberMoveNumberStart"]
   s15["normalizeNumber"]
   s23["minusOne"]
-  s10[["goToNumberStart(invertNumberGoToNumberWithInversion)"]]
   s14[["goToNumberStart(normalizeNumberMoveNumberStart)"]]
   s20[["invertNumber(normalizeNumber)"]]
   s21[["plusOne(invertNumber(normalizeNumber))"]]
@@ -206,6 +205,7 @@ flowchart TD
   end
   subgraph w_11["callable subtree of invertNumber"]
     s9["invertNumberGoToNumberWithInversion"]
+    s10[["goToNumberStart(invertNumberGoToNumberWithInversion)"]]
     s11["invertNumber"]
     c11(((halt)))
   end

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -449,7 +449,7 @@ flowchart TD
 
 **Reading guide** — the v7 callable-subtree emit (introduced in [#174](https://github.com/mellonis/turing-machine-js/issues/174)) models `withOverriddenHaltState` as a function call: the wrapper is the call site, the bare's subtree is the callable body.
 
-1. **`[[scanToX(eraseHere)]]` (Mermaid subroutine / double-walled-rectangle shape)** is the wrapper node, drawn OUTSIDE any subgraph. It's the runtime entry point — `idle -. enter .->` arrives here — and shows the composite name (`bare(override)`). Wrappers have no transitions of their own; they delegate to the bare via the `call` arrow.
+1. **`[[scanToX(eraseHere)]]` (Mermaid subroutine / double-walled-rectangle shape)** is the wrapper node. It's the runtime entry point — `idle -. enter .->` arrives here — and shows the composite name (`bare(override)`). Wrappers have no transitions of their own; they delegate to the bare via the `call` arrow. **Placement**: this top-level wrapper is drawn OUTSIDE any subgraph; a wrapper that participates in a caller's frame (e.g. an inner-call continuation of another wrapper, as in `library-binary-numbers/minusOne`) renders INSIDE its owner frame's subgraph with the same `[[…]]` shape (see [#223](https://github.com/mellonis/turing-machine-js/issues/223)).
 2. **`subgraph w_1["callable subtree of scanToX"]`** is the bare's callable subtree — the scope of code that runs when the wrapper is "called." It contains the bare `s1["scanToX"]`, any body states reachable from the bare, and a local halt marker `c1(((halt)))` where the bare's halt-bound transitions land.
 3. **The bold `==> call`** from wrapper to bare is the call arrow — visual signature of "wrapper invokes this callable subtree, pushing its override onto the runtime stack." Bold arrows are reserved for wrapper-to-bare calls; counting them in a diagram counts the wrappers in play.
 4. **The dotted `-. return .->`** from the subtree back to the wrapper is the return arrow — fires when the bare halts (lands on `c1`) and the stack pops. The wrapper's solid `--> s2` (to `eraseHere`) is the post-return continuation; ordinary transition under the function-call mental model.
@@ -756,7 +756,7 @@ The full reference for reading `toMermaid` output — shapes, edge styles, and t
 |---|---|
 | `s0(((halt)))` | the halt state |
 | `sN["name"]` | a regular state (or a bare, when inside a subgraph) |
-| `sN[["composite-name"]]` | a `withOverriddenHaltState` wrapper (call site, outside any subgraph) — see [§Subroutine composition](#subroutine-composition-with-withoverriddenhaltstate) |
+| `sN[["composite-name"]]` | a `withOverriddenHaltState` wrapper (call site; outside any subgraph when top-level, INSIDE its owner frame's subgraph when its continuation chain participates in a caller's frame — see [§Subroutine composition](#subroutine-composition-with-withoverriddenhaltstate) and [#223](https://github.com/mellonis/turing-machine-js/issues/223)) |
 | `cN(((halt)))` inside a subgraph | halt marker (visualization aid; maps back to the singleton `haltState` at runtime) |
 | `idle([idle])` | pre-execution sentinel (not a real state) |
 

--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -635,6 +635,123 @@ describe('README diagrams: engine-generated outputs', () => {
 //     path compression + ufUnion)
 //   - `callable scope: A ∪ B` subgraph label (graphFormats frameBareNames sort)
 //   - `-. "halt" .->` demand-emit arrow (graphFormats hasNonWrapperEntry path)
+describe('callable-subtree: wrapper continuation joins caller frame (#223)', () => {
+  // When a bare's body invokes a sub-call via `withOverriddenHaltState`, the
+  // wrapper's continuation (the `--> override` arrow in the rendered diagram,
+  // sourced from `overriddenHaltStateId`) is the state the bare's body resumes
+  // at after the inner call returns. Pre-#223 the reach-set sweep stopped
+  // dead at the wrapper, leaving the continuation unframed: it rendered
+  // outside the subgraph and its halt-bound transitions kept pointing at the
+  // top-level halt instead of the bare's frame halt marker. Post-#223, the
+  // sweep tunnels through wrappers via their continuation, so the continuation
+  // (and any further body states it reaches) join the bare's frame.
+  test('after-return continuation state is in the bare frame; its halt retargets to the frame halt marker', () => {
+    const alphabet = new Alphabet([' ', 'a', 'b']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+    const {symbol} = tapeBlock;
+
+    // Inner subroutine X: halts on any symbol (just exists to be called).
+    const X = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'X');
+
+    // Continuation Y: invertNumberGoToNumberWithInversion-shaped — A's bare
+    // returns here after X halts. Y itself halts on 'b' (this halt should
+    // retarget to A's frame halt marker post-#223).
+    const Y = new State({
+      [symbol(['b'])]: {command: {movement: movements.stay}, nextState: haltState},
+      [ifOtherSymbol]: {command: {movement: movements.right}, nextState: haltState},
+    }, 'Y');
+
+    // Bare A: on 'a', calls X with Y as the continuation. Mirrors the
+    // s11 → s10 (= goToNumberStart(invertNumberGoToNumberWithInversion))
+    // shape from library-binary-numbers' invertNumber inside minusOne.
+    const A = new State({
+      [symbol(['a'])]: {command: {movement: movements.stay}, nextState: X.withOverriddenHaltState(Y)},
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'A');
+
+    // Outer wrapper to give A its own frame (A is the bare of this wrapper).
+    const aftermath = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'aftermath');
+
+    const dispatcher = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: A.withOverriddenHaltState(aftermath)},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+
+    const nodeA = graph.nodes[A.id];
+    const nodeY = graph.nodes[Y.id];
+
+    // A is a bare → has its own frame.
+    expect(nodeA.frameId).not.toBeNull();
+    // The continuation Y joins A's frame (the fix).
+    expect(nodeY.frameId).toBe(nodeA.frameId);
+
+    // Y's halt-bound transitions retarget to A's frame halt marker
+    // (id = -frameId, isHaltMarker), NOT to top-level halt s0.
+    for (const t of nodeY.transitions) {
+      const targetNode = graph.nodes[t.nextStateId];
+      expect(targetNode.isHaltMarker).toBe(true);
+      expect(targetNode.frameId).toBe(nodeA.frameId);
+      expect(t.nextStateId).toBe(-nodeA.frameId!);
+    }
+
+    // Sanity: top-level halt s0 is still emitted as a sentinel, even though
+    // no in-frame transition points to it any more.
+    expect(graph.nodes[0]).toBeDefined();
+    expect(graph.nodes[0].isHalt).toBe(true);
+    expect(graph.nodes[0].isHaltMarker).toBe(false);
+  });
+
+  test('wrapper-chain continuations tunnel multi-hop (continuation IS another wrapper)', () => {
+    const alphabet = new Alphabet([' ', 'a']);
+    const tapeBlock = TapeBlock.fromAlphabets([alphabet]);
+
+    // Three inner subroutines X1 / X2 — each halts on any.
+    const X1 = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'X1');
+    const X2 = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'X2');
+
+    // Final continuation Z, with a halt-bound transition.
+    const Z = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'Z');
+
+    // Bare A's body: calls X1 with continuation = X2.wohs(Z). Reach traversal
+    // from A must tunnel through TWO wrappers (X1's wrapper → X2.wohs(Z)
+    // wrapper → Z) to land on Z.
+    const A = new State({
+      [ifOtherSymbol]: {
+        command: {movement: movements.stay},
+        nextState: X1.withOverriddenHaltState(X2.withOverriddenHaltState(Z)),
+      },
+    }, 'A');
+
+    const aftermath = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: haltState},
+    }, 'aftermath');
+
+    const dispatcher = new State({
+      [ifOtherSymbol]: {command: {movement: movements.stay}, nextState: A.withOverriddenHaltState(aftermath)},
+    }, 'dispatcher');
+
+    const graph = State.toGraph(dispatcher, tapeBlock);
+
+    const nodeA = graph.nodes[A.id];
+    const nodeZ = graph.nodes[Z.id];
+
+    expect(nodeA.frameId).not.toBeNull();
+    // Z is reached through a 2-hop wrapper chain — must still land in A's frame.
+    expect(nodeZ.frameId).toBe(nodeA.frameId);
+  });
+});
+
 describe('callable-subtree: shared body state forces a union frame', () => {
   test('two bares sharing a body state merge into one frame; non-wrapper entry triggers halt arrow', () => {
     const alphabet = new Alphabet([' ', '1', '2', '3', 'X']);

--- a/packages/machine/src/utilities/graph.spec.ts
+++ b/packages/machine/src/utilities/graph.spec.ts
@@ -690,6 +690,21 @@ describe('callable-subtree: wrapper continuation joins caller frame (#223)', () 
     // The continuation Y joins A's frame (the fix).
     expect(nodeY.frameId).toBe(nodeA.frameId);
 
+    // The wrapper itself (the call site that A's body invokes) ALSO joins
+    // A's frame — wrappers are call-site markers semantically owned by the
+    // caller, so they render inside the caller's subgraph.
+    const wrapperNodes = Object.values(graph.nodes).filter((n) => n.isWrapper);
+    // Two wrappers in this graph: the dispatcher's wohs(A, aftermath) AND
+    // A's body's wohs(X, Y). The latter (bareStateId === X.id) is the one
+    // owned by A. The former (bareStateId === A.id) is owned by the
+    // top-level dispatcher and stays unframed.
+    const wrapperInsideA = wrapperNodes.find((w) => w.bareStateId === X.id);
+    const wrapperAroundA = wrapperNodes.find((w) => w.bareStateId === A.id);
+    expect(wrapperInsideA).toBeDefined();
+    expect(wrapperAroundA).toBeDefined();
+    expect(wrapperInsideA!.frameId).toBe(nodeA.frameId);
+    expect(wrapperAroundA!.frameId).toBeNull();
+
     // Y's halt-bound transitions retarget to A's frame halt marker
     // (id = -frameId, isHaltMarker), NOT to top-level halt s0.
     for (const t of nodeY.transitions) {
@@ -704,6 +719,13 @@ describe('callable-subtree: wrapper continuation joins caller frame (#223)', () 
     expect(graph.nodes[0]).toBeDefined();
     expect(graph.nodes[0].isHalt).toBe(true);
     expect(graph.nodes[0].isHaltMarker).toBe(false);
+
+    // Mermaid emit: the framed wrapper renders INSIDE A's subgraph (with
+    // the `[[name]]` wrapper shape), not at top level.
+    const out = toMermaid(graph);
+    expect(out).toMatch(new RegExp(
+      `subgraph w_${nodeA.frameId}\\[[^\\n]*\\n(?:[^\\n]*\\n)*?\\s+s${wrapperInsideA!.id}\\[\\[`,
+    ));
   });
 
   test('wrapper-chain continuations tunnel multi-hop (continuation IS another wrapper)', () => {

--- a/packages/machine/src/utilities/graphFormats.ts
+++ b/packages/machine/src/utilities/graphFormats.ts
@@ -136,15 +136,21 @@ export function toMermaid(graph: Graph): string {
 
   // Bucket nodes for emit order.
   const topLevelNodes = nodes.filter((n) => n.frameId === null && !n.isWrapper);
+  // All wrappers — needed by the call / return / wrapper-to-override
+  // arrow emit passes below regardless of where the wrapper renders.
   const wrapperNodes = nodes.filter((n) => n.isWrapper);
-  // Bares-and-bodies inside frames, grouped by frameId.
+  // Top-level wrappers: wrappers whose caller has no frame (the caller is
+  // the top-level program). Framed wrappers (whose caller IS a subroutine
+  // with its own frame) render INSIDE that frame's subgraph below.
+  const topLevelWrapperNodes = wrapperNodes.filter((w) => w.frameId === null);
+  // Bares-bodies-and-framed-wrappers inside frames, grouped by frameId.
   const nodesByFrame = new Map<number, GraphNode[]>();
   // Halt-marker per frame (kept separate so it always emits LAST inside the
   // subgraph for deterministic shape).
   const haltMarkerByFrame = new Map<number, GraphNode>();
 
   for (const node of nodes) {
-    if (node.frameId === null || node.isWrapper) continue;
+    if (node.frameId === null) continue;
 
     if (node.isHaltMarker) {
       haltMarkerByFrame.set(node.frameId, node);
@@ -190,8 +196,9 @@ export function toMermaid(graph: Graph): string {
     }
   }
 
-  // 2. Emit wrappers at top level.
-  for (const wrapper of wrapperNodes) {
+  // 2. Emit top-level wrappers (wrappers owned by the top-level program;
+  // wrappers owned by a subroutine emit inside that subroutine's subgraph).
+  for (const wrapper of topLevelWrapperNodes) {
     lines.push(`  ${mermaidIdFor(wrapper.id)}[["${labelOf(wrapper)}"]]`);
   }
 
@@ -215,9 +222,15 @@ export function toMermaid(graph: Graph): string {
 
     lines.push(`  subgraph ${frameSubgraphId(frameId)}["${label}"]`);
 
-    // Inner nodes — sort by id for determinism.
+    // Inner nodes — sort by id for determinism. Framed wrappers (call sites
+    // owned by this frame) render with the `[[name]]` wrapper shape; bares
+    // and body states render with the regular `["name"]` shape.
     for (const node of (nodesByFrame.get(frameId) ?? []).slice().sort((a, b) => a.id - b.id)) {
-      lines.push(`    ${mermaidIdFor(node.id)}["${labelOf(node)}"]`);
+      if (node.isWrapper) {
+        lines.push(`    ${mermaidIdFor(node.id)}[["${labelOf(node)}"]]`);
+      } else {
+        lines.push(`    ${mermaidIdFor(node.id)}["${labelOf(node)}"]`);
+      }
     }
 
     // Every frame has a halt marker — `State.toGraph`'s frame-emit pass

--- a/packages/machine/src/utilities/stateGraph.ts
+++ b/packages/machine/src/utilities/stateGraph.ts
@@ -169,28 +169,33 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
   }
 
   // Pass 2: For each bare, compute its forward-reachable set (following
-  // transitions; stopping at halt; tunneling through wrappers to their
-  // `overriddenHaltStateId` continuation).
+  // transitions; stopping at halt; including wrappers AND tunneling through
+  // them to their `overriddenHaltStateId` continuation).
   //
-  // Wrappers are call-site markers — semantically owned by the caller. A
-  // wrapper's continuation (its `--> override` arrow in the rendered
-  // diagram, sourced from `overriddenHaltStateId`) is the state the
-  // caller's body resumes at AFTER the inner subroutine call returns. So
-  // when reach traversal hits a wrapper, we don't stop — we follow the
-  // continuation back into the caller's frame. The wrapper node itself
-  // stays unframed (it renders outside the subgraph as a call site), but
-  // the continuation joins the caller's reach-set.
+  // Wrappers are call-site markers — semantically owned by the CALLER (the
+  // bare whose body invokes the sub-call). Both the wrapper itself and its
+  // continuation (its `--> override` arrow in the rendered diagram, sourced
+  // from `overriddenHaltStateId`) belong to the caller's frame: the wrapper
+  // visually anchors the call site inside the caller's subgraph; the
+  // continuation is the state the caller's body resumes at AFTER the inner
+  // sub-call returns. So when reach traversal hits a wrapper, we PUSH the
+  // wrapper (joining the caller's reach-set) AND tunnel through to its
+  // continuation (also joining). Wrappers carry no `transitions` of their
+  // own (Pass 1 emits `transitions: []` on wrapper nodes), so the main loop
+  // pops them and adds them to `reach` without further traversal — but the
+  // continuation already entered via the wrapper-tunnel chain in
+  // `resolveAndPush`.
   //
   // Halt-bound retargeting + union-find then "just work": continuation
   // states' halt-bound transitions get retargeted to the caller's halt
   // marker (so an in-subroutine halt returns to the caller, not the
   // program's terminal halt); when two bares both reach the same
-  // continuation through different wrapper chains, union-find merges
-  // their frames as it already does for non-wrapper overlap.
+  // continuation through different wrapper chains, union-find merges their
+  // frames as it already does for non-wrapper overlap.
   //
   // Wrapper chains (continuation IS another wrapper, e.g., nested
   // compositions) are walked transitively by the inner while-loop in
-  // `resolveAndPush`.
+  // `resolveAndPush` — each tunnel hop pushes the intermediate wrapper.
   const computeReach = (startId: number): Set<number> => {
     const reach = new Set<number>();
     const stack: number[] = [];
@@ -209,6 +214,10 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
           stack.push(current);
           return;
         }
+
+        // Wrapper: push it (so it joins the caller's frame) AND tunnel to
+        // its continuation. Both belong to the caller's frame.
+        stack.push(current);
 
         /* c8 ignore next 3 — every wrapper emitted by Pass 1 has a
            non-null overriddenHaltStateId (lines 76-101); this branch
@@ -232,6 +241,8 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
 
       reach.add(id);
 
+      // Wrappers have empty transitions arrays — the for-loop runs zero
+      // iterations and we proceed to the next stack entry.
       for (const t of nodes[id].transitions) {
         resolveAndPush(t.nextStateId);
       }

--- a/packages/machine/src/utilities/stateGraph.ts
+++ b/packages/machine/src/utilities/stateGraph.ts
@@ -169,11 +169,59 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
   }
 
   // Pass 2: For each bare, compute its forward-reachable set (following
-  // transitions; stopping at halt and at wrappers — both are frame
-  // boundaries).
+  // transitions; stopping at halt; tunneling through wrappers to their
+  // `overriddenHaltStateId` continuation).
+  //
+  // Wrappers are call-site markers — semantically owned by the caller. A
+  // wrapper's continuation (its `--> override` arrow in the rendered
+  // diagram, sourced from `overriddenHaltStateId`) is the state the
+  // caller's body resumes at AFTER the inner subroutine call returns. So
+  // when reach traversal hits a wrapper, we don't stop — we follow the
+  // continuation back into the caller's frame. The wrapper node itself
+  // stays unframed (it renders outside the subgraph as a call site), but
+  // the continuation joins the caller's reach-set.
+  //
+  // Halt-bound retargeting + union-find then "just work": continuation
+  // states' halt-bound transitions get retargeted to the caller's halt
+  // marker (so an in-subroutine halt returns to the caller, not the
+  // program's terminal halt); when two bares both reach the same
+  // continuation through different wrapper chains, union-find merges
+  // their frames as it already does for non-wrapper overlap.
+  //
+  // Wrapper chains (continuation IS another wrapper, e.g., nested
+  // compositions) are walked transitively by the inner while-loop in
+  // `resolveAndPush`.
   const computeReach = (startId: number): Set<number> => {
     const reach = new Set<number>();
-    const stack = [startId];
+    const stack: number[] = [];
+
+    const resolveAndPush = (id: number) => {
+      let current = id;
+
+      while (true) {
+        const target = nodes[current];
+
+        if (!target || target.isHalt) {
+          return;
+        }
+
+        if (!target.isWrapper) {
+          stack.push(current);
+          return;
+        }
+
+        /* c8 ignore next 3 — every wrapper emitted by Pass 1 has a
+           non-null overriddenHaltStateId (lines 76-101); this branch
+           only guards against future wrapper variants that might not. */
+        if (target.overriddenHaltStateId === null) {
+          return;
+        }
+
+        current = target.overriddenHaltStateId;
+      }
+    };
+
+    resolveAndPush(startId);
 
     while (stack.length > 0) {
       const id = stack.pop()!;
@@ -182,28 +230,10 @@ export function toGraph(initialState: State, tapeBlock: TapeBlock): Graph {
         continue;
       }
 
-      const node = nodes[id];
-
-      // `nodes[id]` is always populated for `id` that the BFS reached, so
-      // a defensive `!node` check would be dead. `isHalt` / `isWrapper`
-      // are real boundaries — both stop reach-set expansion.
-      /* c8 ignore next 3 — defensive: the push site below already filters
-         halt/wrapper targets, and the initial push is always a bare, so
-         this branch is unreachable in practice. */
-      if (node.isHalt || node.isWrapper) {
-        continue;
-      }
-
       reach.add(id);
 
-      for (const t of node.transitions) {
-        const target = nodes[t.nextStateId];
-
-        if (!target || target.isHalt || target.isWrapper) {
-          continue;
-        }
-
-        stack.push(t.nextStateId);
+      for (const t of nodes[id].transitions) {
+        resolveAndPush(t.nextStateId);
       }
     }
 


### PR DESCRIPTION
## Summary

Closes [#223](https://github.com/mellonis/turing-machine-js/issues/223). Bug: `toGraph`'s frame-computation sweep treated wrappers as hard frame boundaries (\`stateGraph.ts:193\` early-return + line \`202\` skip), so any body state reached only via a wrapper-return arrow ended up unframed. Visible in the \`minusOne\` diagram in \`packages/library-binary-numbers/states.md\` — invertNumber's body state \`s9\` rendered outside the \`callable subtree of invertNumber\` subgraph and halted to top-level \`s0\` instead of frame halt marker \`c11\`.

## Fix

`computeReach` now tunnels through wrappers via a new \`resolveAndPush\` helper that follows \`overriddenHaltStateId\` (the wrapper's continuation arrow). Multi-hop wrapper chains (continuation IS another wrapper, e.g., nested wohs compositions) are walked transitively by the helper's inner while-loop. The wrapper node itself stays unframed (correctly — it's a call-site marker, not body); the continuation joins the bare's frame.

Halt-bound retargeting + union-find then \"just work\" without further changes:
- Continuation states' halt-bound transitions get retargeted to the caller's halt marker (Pass 4 unchanged).
- When two bares both reach the same continuation through different wrapper chains, union-find merges their frames (Pass 3 unchanged).

## Verification

- `npm test` — **644 tests passing** (was 642; +2 new from issue #223 test cases below).
- `npm run test:coverage` — **stateGraph.ts at 99.53 / 96.47 / 100 / 100** (unchanged; the two new c8-ignored defensive branches are the only \"uncovered\" parts — intentional guards for future wrapper variants).
- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm run docs:states` — regenerated; \`library-binary-numbers/states.md\` shows minusOne's invertNumber subgraph now correctly contains \`s9\`. Diff:

```diff
   subgraph w_11["callable subtree of invertNumber"]
+    s9["invertNumberGoToNumberWithInversion"]
     s11["invertNumber"]
     c11(((halt)))
   end
…
-  s9 -- "['\$'] → [K]/[S]" --> s0
+  s9 -- "['\$'] → [K]/[S]" --> c11
```

`library-binary-numbers-bare/states.md` unchanged (no inner-wrapper-call patterns there). Other 9 diagrams in `library-binary-numbers/states.md` unchanged for the same reason.

## New tests (graph.spec.ts)

- \"after-return continuation state is in the bare frame; its halt retargets to the frame halt marker\" — minimal repro of the invertNumber-in-minusOne shape: bare A's body wohs-calls X with Y as continuation, asserts Y.frameId === A.frameId and Y's halt-bound transitions retarget to \`-A.frameId\`.
- \"wrapper-chain continuations tunnel multi-hop\" — continuation IS another wrapper (\`X1.wohs(X2.wohs(Z))\`), asserts Z still lands in A's frame after two hops through wrapper nesting.

## Impact + version

This is an engine `toGraph` output change. Affected consumers: anything that renders or reasons about engine-emitted Graphs with inner-wrapper-call body shape. Specifically:

- **machines-demo** renders the engine's `Graph` directly — graphs with the new shape will show invertNumber-style body states correctly inside their subgraphs. No demo code changes needed; the fix is transparent.
- **visuals's `applyHighlight` / `tokenizeStep` / etc.** consume `Graph` — no public-API change.
- **Visuals fixtures** (`packages/visuals/src/fixtures/graphs/*.json`) are NOT affected (the 4 fixtures don't have this shape; all relevant fixture-roundtrip tests pass unchanged).
- **`test/round-trip.spec.ts`** bytewise stability — passes; the simple-wrapper round-trip case doesn't have this shape either.

**Versioning**: this is a bugfix on the engine's `toGraph` output. Lockstep bump to alpha.7 is the natural shape (engine + builder + libs + visuals all to alpha.7). Defer the bump to a follow-up release PR — this PR is just the code fix.

PR targets `v7` per repo convention. CI doesn't run on v7 branches.