### PR TITLE
docs(visuals): document renderer clear-highlights contract at end of playback

### DIFF
--- a/packages/visuals/README.md
+++ b/packages/visuals/README.md
@@ -294,6 +294,30 @@ replayBtn.addEventListener('click', () => { player.reset();     applyFrame(); },
 
 `SnippetPlayer` is pure state — no timers, no events. Consumers wire `setInterval` / `requestAnimationFrame` / `IntersectionObserver` and call `forward()` / `back()` / `goTo(idx)`. Two players over the same `Snippet` are independent (frame storage is shared and read-only). Mirrors the engine's `DebugSession` shape — stateful playback driver for live runs vs prerecorded runs.
 
+### Renderer contract: clearing highlights at end of playback
+
+`recordSnippet` captures **one `Frame` per iter** plus a `Frame 0` initial-state snapshot. The last frame is the halt-triggering iter — its `highlight` has `toId === 0` (the engine's `haltState` id) with `strong: 'from'`, meaning "source state strong, edge to halt." This is faithful to what the engine yielded; it is NOT a "settled" frame.
+
+If your renderer applies highlight classes via `applyHighlight` (or any equivalent mutation), it must **clear those classes when playback ends** — otherwise the source state stays painted on the graph after `forward()` stops returning `true`, and the run reads as "frozen mid-transition" instead of "halted." The contract:
+
+```ts
+const id = setInterval(() => {
+  if (!player.forward()) {
+    // Playback reached the last frame on the previous tick. Clear residual
+    // highlight classes so the graph returns to neutral before the renderer
+    // sits idle on it.
+    clearHighlightClasses(ops);
+    clearInterval(id);
+    return;
+  }
+  applyFrame();
+}, 800);
+```
+
+`clearHighlightClasses` is whatever DOM-cleanup helper your renderer already runs before each `applyHighlight` call to drop the previous frame's classes. The recorder leaves this to the renderer on purpose: a recording shouldn't dictate "and now clear" — that's an animation-loop concern, not a recording concern. The same applies to non-auto-play paths (`back()` reaching 0, manual `goTo(idx)` to the final frame, etc.): clear whenever the player has settled on a frame and no further `applyHighlight` call is pending.
+
+Reduced-motion variant: if you skip the timer and jump straight to the final frame as a static snapshot, you can choose to either keep the halt-iter highlight (as a "this is what just happened" affordance) or clear it (the snapshot becomes the post-halt resting state). The recorder doesn't choose for you.
+
 ## Versioning
 
 Engine + builder + libraries bump in **lockstep** via `lerna version`. **Visuals breaks lockstep for additive consumer-package patches** (e.g., `7.0.0-alpha.6.1` added formatter primitives + the token surface without bumping the engine — there were no engine changes to justify ghost releases). Semver-prerelease caret semantics make this safe: peer `^7.0.0-alpha.6` accepts `7.0.0-alpha.6.1+` without consumers having to widen anything. When the next engine alpha needs to ship, all 5 packages bump back to lockstep.


### PR DESCRIPTION
Doc-only follow-up to [machines-demo#108](https://github.com/mellonis/machines-demo/issues/108) / [machines-demo PR #109](https://github.com/mellonis/machines-demo/pull/109).

## Why

The README's "Example: playing a snippet" walked through the auto-play loop but didn't say what the renderer must do once the player stops advancing. machines-demo hit this in production — the residual halt-iter highlight stayed painted on the graph forever after \`forward()\` returned \`false\`, reading as "playback froze before halt" rather than "the machine halted."

That's actually a renderer-loop concern, not a recording concern: \`recordSnippet\` faithfully captures one Frame per iter (the last one IS the halt iter with \`highlight.toId === 0\`); whether to clear the highlight when the animation loop stops is up to the consumer. machines-demo fixed it consumer-side in PR #109. This PR documents the contract upstream so future consumers know the same.

## What

Adds a "Renderer contract: clearing highlights at end of playback" subsection between the \`SnippetPlayer\` pure-state paragraph and the Versioning section. The new prose:

- Names \`recordSnippet\`'s faithful one-frame-per-iter shape: NO synthetic "settled" frame is appended; the last frame is the halt iter with \`highlight.toId === 0\`, \`strong: 'from'\`.
- Tells consumers to clear highlight classes when \`forward()\` stops returning \`true\` (and in any equivalent settled-on-final-frame path — \`back()\` reaching 0, manual \`goTo(idx)\` to final, etc.).
- Notes the recorder leaves the clear step to the renderer on purpose.
- Calls out the reduced-motion variant: keeping or clearing the halt-iter highlight is a consumer choice.

Includes the diff-shaped code snippet showing the \`clearHighlightClasses(ops)\` call inside the \`if (!player.forward()) { ... }\` branch.

## Rejected alternative — append a \`highlight: null\` settled frame to \`recordSnippet\`

Tempting because it would auto-fix any future consumer without them reading docs. But:
- Frame shape lies a bit: \`frames.length\` becomes \`iterCount + 2\` instead of \`iterCount + 1\`, and the extra frame doesn't represent an iter.
- Frame shape encodes consumer behavior — recorder picks "clear on the last tick" for everyone.
- A flag on the halt iter (or just \`highlight.toId === 0\`) already lets consumers detect the halt iter if they need to render differently.

The "faithful recording + documented consumer contract" framing is cleaner.

## No source change

\`recordSnippet.ts\`, \`snippetPlayer.ts\`, and the snippet \`.spec.ts\` files are unchanged. No version bump. CHANGELOG unchanged. Docs-only.

## Verification

- README renders cleanly (no broken Markdown).
- 669/669 tests still pass (unchanged).