### PR TITLE
chore: release 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,7 +3198,7 @@
     },
     "packages/builder": {
       "name": "@turing-machine-js/builder",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -3209,7 +3209,7 @@
     },
     "packages/library-binary-numbers": {
       "name": "@turing-machine-js/library-binary-numbers",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -3220,7 +3220,7 @@
     },
     "packages/library-binary-numbers-bare": {
       "name": "@turing-machine-js/library-binary-numbers-bare",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -3231,7 +3231,7 @@
     },
     "packages/machine": {
       "name": "@turing-machine-js/machine",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -3239,13 +3239,13 @@
     },
     "packages/visuals": {
       "name": "@turing-machine-js/visuals",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0"
+        "@turing-machine-js/machine": "^7.1.0"
       }
     }
   }

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-06
+
+Released in lockstep with `@turing-machine-js/machine` 7.1.0 — the abort feature ([#239](https://github.com/mellonis/turing-machine-js/issues/239)). No source or behavior changes in this package; the existing dependency range `^7.0.0` already accepts the 7.1.0 engine.
+
 ## [7.0.0] - 2026-06-03
 
 Stable v7. Lockstep release with `@turing-machine-js/machine` 7.0.0. See the machine package CHANGELOG for the cumulative v7 trajectory.

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/builder",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "A turing machine builder — declarative state-table construction. Not actively developed by the author; the same state-table pattern is also shown as an inline example in @turing-machine-js/machine's README. Contributions welcome.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers-bare/CHANGELOG.md
+++ b/packages/library-binary-numbers-bare/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-06
+
+Released in lockstep with `@turing-machine-js/machine` 7.1.0 — the abort feature ([#239](https://github.com/mellonis/turing-machine-js/issues/239)). No source or behavior changes in this package; `states.md` was regenerated under the 7.1.0 Mermaid id namespacing (`uN`/`s0`/`s0-F` — mechanical id churn only). The existing dependency range `^7.0.0` already accepts the 7.1.0 engine.
+
 ## [7.0.0] - 2026-06-03
 
 Stable v7. Lockstep release with `@turing-machine-js/machine` 7.0.0. See the machine package CHANGELOG for the cumulative v7 trajectory.

--- a/packages/library-binary-numbers-bare/package.json
+++ b/packages/library-binary-numbers-bare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers-bare",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Single-number binary arithmetic on a 3-symbol alphabet (blank, 0, 1) — same operations as @turing-machine-js/library-binary-numbers but without ^/$ markers. Side-by-side with the marker-based library for learning the trade-off.",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/library-binary-numbers/CHANGELOG.md
+++ b/packages/library-binary-numbers/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-06
+
+Released in lockstep with `@turing-machine-js/machine` 7.1.0 — the abort feature ([#239](https://github.com/mellonis/turing-machine-js/issues/239)). No source or behavior changes in this package; `states.md` was regenerated under the 7.1.0 Mermaid id namespacing (`uN`/`s0`/`s0-F` — mechanical id churn only). The existing dependency range `^7.0.0` already accepts the 7.1.0 engine.
+
 ## [7.0.0] - 2026-06-03
 
 Stable v7. Lockstep release with `@turing-machine-js/machine` 7.0.0. See the machine package CHANGELOG for the cumulative v7 trajectory.

--- a/packages/library-binary-numbers/package.json
+++ b/packages/library-binary-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/library-binary-numbers",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "A standard library for working with binary numbers",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-06
+
+The abort feature ([#239](https://github.com/mellonis/turing-machine-js/issues/239)): a second terminal sentinel for abnormal termination that punches straight through the subroutine call stack, plus the run-outcome surface around it. Opt-in; the in-band error-marker idiom remains fully supported.
+
+### Added
+
+- **`abortState`** — the sentinel family's second member (id `-1`; odd negative ids are reserved for sentinels, assigned in creation order). Never popped by the subroutine halt-stack and never composed: `withOverriddenHaltState` throws whether `abortState` is the bare or the override. A transition targeting it terminates the run from any call depth. `AbortState` typed alias exported; `state.isAbort` / `state.isSentinel` predicates (`isSentinel ≡ id <= 0`).
+- **`RunResult`** — `run()` now returns (and `runStepByStep`'s generator carries as its `return` value) a call-scoped `{ outcome: 'halted' | 'aborted', state, stack, step }`. `stack` is the frozen backtrace of pending continuation states on abort and `[]` for a natural halt; a run stopped externally via the `generator.throw(haltState)` idiom also reports `'halted'`, with the stack as it stood. A plain `for...of` discards the generator's return value — the canonical step-level abort signal remains the final yield's `nextState === abortState`.
+- **`DebugSession` `'abort'` terminal event** — mutually exclusive with `'halt'`; **both** terminals now carry the `RunResult` as the listener argument (`'halt'` previously fired with no arguments — additive). `abortState.debug` is a boolean mirroring `haltState.debug`: `true` arms an after-side pause on the abort-triggering iter, delivered before the terminal event.
+- **`mermaidIdFor(id)` / `parseMermaidId(mermaidId)`** — exported mapping between numeric graph ids and the namespaced Mermaid node ids (see Changed).
+- **`GraphNode.isAbort`** — the abort sentinel emits as one top-level graph node, only when referenced; `fromGraph` / `collectStates` map it back to the singleton. Rendered as `s1(((abort)))` with a dashed-red `classDef abortSentinel`.
+
+### Changed
+
+- **Mermaid node ids are namespaced by prefix** — `uN` for user states (was `sN`), `s0` halt, `s1` abort (`sK` for any future sentinel), `s0-F` for frame `F`'s halt marker (was `cF`). Rendered-id churn only; round-trip via `fromMermaid` is regression-locked semantically (a rebuilt machine actually aborts).
+- **Synthetic halt-marker graph ids moved `-frameId` → `-2 * frameId`** — even negatives are markers, odd negatives are sentinels; the two id spaces can never collide. Consumers that keyed on marker ids must adjust (the companion `@turing-machine-js/visuals` 7.1.0 does).
+- Abort-bound transitions never retarget to frame halt markers — abort has no return chain.
+
 ## [7.0.0] - 2026-06-03
 
 Stable v7. The composition-representation overhaul. See alpha.1 through alpha.8 entries below for the detailed step-by-step trajectory; this entry summarizes the cumulative API changes from v6.4.0.

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/machine",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "A convenient Turing machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/visuals/CHANGELOG.md
+++ b/packages/visuals/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-07-06
+
+Lockstep release with `@turing-machine-js/machine` 7.1.0 (the abort feature, [#239](https://github.com/mellonis/turing-machine-js/issues/239)).
+
+### Added
+
+- **Abort-highlight support** — `GraphHighlight.toId: -1` lights the abort sentinel node (`s1`), never halt; regression-locked.
+
+### Changed
+
+- **`HighlightOps` edge keys are built via the engine's `mermaidIdFor`** — mermaid string ids follow the 7.1.0 namespacing (`uN` user states, `s0` halt, `s1` abort, `s0-F` frame halt markers). Consumers resolving DOM elements from these keys must adopt the new vocabulary.
+- **`bareIdOf` splits negative ids by parity** — even negatives (frame halt markers, `-2·frameId`) still collapse to the haltState class (canonical `0`); odd negatives (engine sentinels — `abortState` at `-1`) are now their own breakpoint class and are never folded into halt's. `equivalentIds(-1)` returns `[-1]`; `applyIndicator` no longer lights the abort node from a halt breakpoint.
+- Peer dep `@turing-machine-js/machine` widened `^7.0.0` → `^7.1.0` (this package imports `mermaidIdFor`, a 7.1.0-only export — the floor is hard).
+
 ## [7.0.0] - 2026-06-03
 
 Stable v7. Lockstep release with `@turing-machine-js/machine` 7.0.0. First stable cut of the visuals companion package. See the machine package CHANGELOG for the cumulative v7 trajectory.

--- a/packages/visuals/package.json
+++ b/packages/visuals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turing-machine-js/visuals",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Pure highlight + graph-indexing logic for @turing-machine-js/machine — no DOM, no renderer.",
   "engines": {
     "npm": ">=7.0.0"
@@ -25,7 +25,7 @@
     "visualization"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0"
+    "@turing-machine-js/machine": "^7.1.0"
   },
   "scripts": {
     "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@turing-machine-js/visuals",


### PR DESCRIPTION
Release cut for **v7.1.0** — the abort feature (#239, merged in #241), executed with the npm-native release scripts from #242 (first release on them).

- `node scripts/release-version.mjs 7.1.0` — all 5 packages + lockfile.
- Visuals peer `@turing-machine-js/machine` raised `^7.0.0` → `^7.1.0` (visuals imports `mermaidIdFor`, a 7.1.0-only export — hard floor), lockfile resynced after the hand edit per the release checklist.
- CHANGELOG entries for all 5 packages.

After merge: `node scripts/release-publish.mjs` (dist-tag inferred → `latest`), then the GH release `v7.1.0` targeting master.

Gates: 711/711 tests, lint clean.